### PR TITLE
fix: scope gutter highlighters to their editor

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -6,9 +6,10 @@
 2. **CopySelectionContextAction** reads settings (path type + code content toggle)
 3. **Action** extracts editor context (file path, line range, optionally code)
 4. **CopyPasteManager** writes formatted text to clipboard
-5. **CopySelectionNotifier** shows toast notification (BALLOON type)
-6. **CopySelectionStatusBarWidget** updates (currently stub, prints to console)
-7. **CopySelectionSettings** provides path type and code content preferences
+5. **CopySelectionHighlighter** replaces the gutter marker scoped to the active editor
+6. **CopySelectionNotifier** shows toast notification (BALLOON type)
+7. **CopySelectionStatusBarWidget** updates (currently stub, prints to console)
+8. **CopySelectionSettings** provides path type and code content preferences
 
 ## Output Formats
 
@@ -27,6 +28,8 @@ fun example() {
 ## Source File Details
 
 - **CopySelectionBaseAction.kt** (~55 lines): Abstract base. `buildPathString()` (line range formatting), `copyToClipboard()` (CopyPasteManager), `update()` (action enablement). Subclasses implement abstract `getPath()`.
+
+- **CopySelectionHighlighter.kt**: Stores the last gutter highlighter in each `Editor`'s user data and only removes it through that editor's `MarkupModel`.
 
 - **CopySelectionContextAction.kt** (~105 lines): Main unified action. Reads path type + code content from `CopySelectionSettings`. Contains `resolvePath()`, `resolveLineRange()`, `getCodeContent()`, `detectLanguage()` (15 file type mappings). Only action with shortcut: `Ctrl+Alt+C` / `Meta+Alt+C`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ Single flat package: `com.github.hon454.copyselectioncontext/`
 |------|------|
 | `CopySelectionContextAction.kt` | Main unified action (`Ctrl+Alt+C` shortcut) |
 | `CopySelectionBaseAction.kt` | Abstract base with clipboard logic |
+| `CopySelectionHighlighter.kt` | Editor-scoped gutter highlighter lifecycle |
 | `CopyRelativePathAction.kt` | Relative path (context menu only) |
 | `CopyAbsolutePathAction.kt` | Absolute path (context menu only) |
 | `CopyWithCodeContentAction.kt` | Path + markdown code block (context menu only) |

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
@@ -5,9 +5,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.markup.HighlighterLayer
-import com.intellij.openapi.editor.markup.HighlighterTargetArea
-import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.WindowManager
@@ -15,10 +12,6 @@ import com.intellij.openapi.vfs.VirtualFile
 import java.awt.datatransfer.StringSelection
 
 abstract class CopySelectionBaseAction : AnAction() {
-    companion object {
-        private var lastHighlighter: RangeHighlighter? = null
-    }
-
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.getData(CommonDataKeys.PROJECT) ?: return
         val editor = e.getData(CommonDataKeys.EDITOR) ?: return
@@ -48,20 +41,8 @@ abstract class CopySelectionBaseAction : AnAction() {
             CopySelectionAnalytics.getInstance()?.recordCopy(appSettings.outputFormat)
         }
 
-        lastHighlighter?.let { highlighter ->
-            editor.markupModel.removeHighlighter(highlighter)
-        }
-        lastHighlighter = null
-
         val (gutterStartLine, gutterEndLine) = resolveLineNumbers(editor)
-        val startOffset = editor.document.getLineStartOffset(gutterStartLine - 1)
-        val endOffset = editor.document.getLineEndOffset(gutterEndLine - 1)
-        lastHighlighter = editor.markupModel.addRangeHighlighter(
-            startOffset, endOffset,
-            HighlighterLayer.ADDITIONAL_SYNTAX,
-            null,
-            HighlighterTargetArea.LINES_IN_RANGE
-        ).also { it.gutterIconRenderer = CopySelectionGutterIconRenderer() }
+        CopySelectionHighlighter.update(editor, gutterStartLine, gutterEndLine)
 
         val historyService = project.getService(CopyHistoryService::class.java)
         val maxSize = CopySelectionSettings.getInstance().state.copyHistorySize

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionHighlighter.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionHighlighter.kt
@@ -1,0 +1,33 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.markup.HighlighterLayer
+import com.intellij.openapi.editor.markup.HighlighterTargetArea
+import com.intellij.openapi.editor.markup.RangeHighlighter
+import com.intellij.openapi.util.Key
+
+internal object CopySelectionHighlighter {
+    private val lastHighlighterKey = Key.create<RangeHighlighter>(
+        "CopySelectionContext.lastHighlighter"
+    )
+
+    fun update(editor: Editor, startLine: Int, endLine: Int) {
+        val markupModel = editor.markupModel
+        editor.getUserData(lastHighlighterKey)
+            ?.takeIf { it.isValid }
+            ?.let(markupModel::removeHighlighter)
+
+        val document = editor.document
+        val startOffset = document.getLineStartOffset(startLine - 1)
+        val endOffset = document.getLineEndOffset(endLine - 1)
+        val highlighter = markupModel.addRangeHighlighter(
+            startOffset,
+            endOffset,
+            HighlighterLayer.ADDITIONAL_SYNTAX,
+            null,
+            HighlighterTargetArea.LINES_IN_RANGE,
+        ).also { it.gutterIconRenderer = CopySelectionGutterIconRenderer() }
+
+        editor.putUserData(lastHighlighterKey, highlighter)
+    }
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionHighlighterTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionHighlighterTest.kt
@@ -1,0 +1,87 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.markup.HighlighterLayer
+import com.intellij.openapi.editor.markup.HighlighterTargetArea
+import com.intellij.openapi.editor.markup.MarkupModel
+import com.intellij.openapi.editor.markup.RangeHighlighter
+import com.intellij.openapi.util.Key
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+
+class CopySelectionHighlighterTest {
+    @Test
+    fun `highlighters remain scoped to their owning editor`() {
+        val firstHighlighter = mockHighlighter()
+        val secondHighlighter = mockHighlighter()
+        val firstEditor = mockEditor(firstHighlighter)
+        val secondEditor = mockEditor(secondHighlighter)
+
+        CopySelectionHighlighter.update(firstEditor.editor, 1, 1)
+        CopySelectionHighlighter.update(secondEditor.editor, 1, 1)
+
+        verify(exactly = 0) {
+            secondEditor.markupModel.removeHighlighter(firstHighlighter)
+            firstEditor.markupModel.removeHighlighter(secondHighlighter)
+        }
+    }
+
+    @Test
+    fun `previous highlighter is replaced within the same editor`() {
+        val previousHighlighter = mockHighlighter()
+        val replacementHighlighter = mockHighlighter()
+        val editor = mockEditor(previousHighlighter, replacementHighlighter)
+
+        CopySelectionHighlighter.update(editor.editor, 1, 1)
+        CopySelectionHighlighter.update(editor.editor, 1, 1)
+
+        verify(exactly = 1) {
+            editor.markupModel.removeHighlighter(previousHighlighter)
+        }
+    }
+
+    private fun mockEditor(vararg highlighters: RangeHighlighter): EditorFixture {
+        val editor = mockk<Editor>()
+        val document = mockk<Document>()
+        val markupModel = mockk<MarkupModel>()
+        var storedHighlighter: RangeHighlighter? = null
+
+        every { editor.document } returns document
+        every { editor.markupModel } returns markupModel
+        every { document.getLineStartOffset(0) } returns 0
+        every { document.getLineEndOffset(0) } returns 10
+        every { markupModel.addRangeHighlighter(
+            0,
+            10,
+            HighlighterLayer.ADDITIONAL_SYNTAX,
+            null,
+            HighlighterTargetArea.LINES_IN_RANGE,
+        ) } returnsMany highlighters.toList()
+        every { editor.getUserData(any<Key<RangeHighlighter>>()) } answers {
+            storedHighlighter
+        }
+        every {
+            editor.putUserData(any<Key<RangeHighlighter>>(), any<RangeHighlighter>())
+        } answers {
+            storedHighlighter = secondArg()
+        }
+        every { markupModel.removeHighlighter(any()) } just Runs
+
+        return EditorFixture(editor, markupModel)
+    }
+
+    private fun mockHighlighter() = mockk<RangeHighlighter>().also { highlighter ->
+        every { highlighter.isValid } returns true
+        every { highlighter.gutterIconRenderer = any() } just Runs
+    }
+
+    private data class EditorFixture(
+        val editor: Editor,
+        val markupModel: MarkupModel,
+    )
+}


### PR DESCRIPTION
## Summary
- replace the process-wide `RangeHighlighter` reference with editor-scoped user data
- remove a previous highlighter only through its owning editor's `MarkupModel`
- add regression coverage for cross-editor ownership and same-editor replacement
- document the highlighter lifecycle component

## Root cause
`CopySelectionBaseAction` stored one static highlighter for every editor. Invoking the action in another editor attempted to remove that highlighter from the new editor's interval tree, triggering the `RangeHighlighterTree` ownership assertion.

## Verification
- `gradlew.bat --no-daemon -Pkotlin.compiler.execution.strategy=in-process test buildPlugin verifyPluginConfiguration --stacktrace`
- 154 tests passed
- `gradlew.bat --no-daemon -Pkotlin.compiler.execution.strategy=in-process verifyPlugin --stacktrace`
- Plugin Verifier: compatible with IntelliJ IDEA 2024.3, 2025.1, 2025.2, 2025.3, 2026.1.5, and 2026.2

Fixes #1