### PR TITLE
docs: add Chinese and Japanese READMEs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Single flat package: `com.github.hon454.copyselectioncontext/`
 - **Plugin ID**: `com.github.hon454.copy-selection-context` (kebab-case)
 - **Notification Group ID**: `"CopySelectionContext"` (PascalCase, no spaces)
 - **PRs**: One feature per PR, include manual testing steps, update AGENTS.md if architecture changes
-- **README**: Bilingual — `README.md` (English, primary) and `README.ko.md` (Korean). Any README change MUST be applied to both files. Keep section structure, order, and content in sync between the two.
+- **README**: Multilingual — `README.md` (English, primary), `README.ko.md` (Korean), `README.zh-CN.md` (Simplified Chinese), and `README.ja.md` (Japanese). Any README change MUST be applied to all four files. Keep section structure, order, and content in sync across them.
 
 ### Commit Convention
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,132 @@
+# Copy Selection Context
+
+[![JetBrains Marketplace](https://img.shields.io/jetbrains/plugin/v/com.github.hon454.copy-selection-context?label=Marketplace)](https://plugins.jetbrains.com/plugin/30262-copy-selection-context)
+[![Release](https://img.shields.io/github/v/release/hon454/copy-selection-context)](https://github.com/hon454/copy-selection-context/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/hon454/copy-selection-context/total)](https://github.com/hon454/copy-selection-context/releases)
+[![Contributors](https://img.shields.io/github/contributors/hon454/copy-selection-context)](https://github.com/hon454/copy-selection-context/graphs/contributors)
+[![License](https://img.shields.io/github/license/hon454/copy-selection-context)](LICENSE)
+
+**[English](README.md)** · **[한국어](README.ko.md)** · **[简体中文](README.zh-CN.md)** · **日本語**
+
+> ファイルパス、行番号、コードを1つのショートカットでクリップボードにコピー。AIアシスタントへそのまま貼り付けられる形式です。
+
+ClaudeやChatGPTなどのAIコーディングアシスタントにコードのコンテキストを共有するとき、ファイルパスや行番号を手入力していませんか？ **Copy Selection Context**なら、1つのショートカットで`@path#Lline`形式のコンテキストをクリップボードにコピーできます。
+
+## 機能
+
+- **ショートカットでコピー** — `Ctrl+Alt+C`でファイルパスと行番号をすぐにコピー
+- **相対パスまたは絶対パス** — プロジェクト相対パスと絶対パスから選択可能
+- **コード内容を含める** — 選択したコードをMarkdownコードブロックとして追加可能
+- **コピー履歴** — `Ctrl+Alt+H`で最近のコピー履歴を表示
+- **GitHub/GitLabパーマリンク** — 選択した行のGitパーマリンクをコピー
+- **スマートな行番号処理** — テキストが選択されていない場合は現在の行番号をコピー
+- **コンテキストメニュー** — エディターの右クリックメニューからすべてのアクションにアクセス
+- **クロスプラットフォーム** — Windows、macOS、Linuxに対応
+
+## インストール
+
+### JetBrains Marketplaceから
+
+1. `File` → `Settings` → `Plugins`
+2. **「Copy Selection Context」**を検索
+3. `Install`をクリック
+
+### ディスクから
+
+1. [Releases](https://github.com/hon454/copy-selection-context/releases)ページから最新の`.zip`をダウンロード
+2. `File` → `Settings` → `Plugins` → ⚙️ → `Install Plugin from Disk...`
+3. ダウンロードした`.zip`を選択 → IDEを再起動
+
+## 使い方
+
+### キーボードショートカット
+
+| アクション | Windows/Linux | macOS |
+|------------|---------------|-------|
+| Copy Selection Context | `Ctrl+Alt+C` | `Cmd+Alt+C` |
+| Show Copy History | `Ctrl+Alt+H` | `Ctrl+Alt+H` |
+
+> ショートカットは`Settings` → `Keymap`で変更できます。
+
+### コンテキストメニュー
+
+エディター内で右クリック → **Copy Selection Context**サブメニュー：
+
+| アクション | 説明 |
+|------------|------|
+| Copy Selection Context | 設定に基づいてパスと行番号をコピー（メインアクション） |
+| Copy Relative Path with Line Numbers | プロジェクト相対パスでコピー |
+| Copy Absolute Path with Line Numbers | 絶対パスでコピー |
+| Copy with Code Content | パス、行番号、コードブロックをコピー |
+| Copy GitHub/GitLab Permalink | Gitリモートリポジトリのパーマリンクをコピー |
+| Show Copy History | 最近のコピー履歴ポップアップを表示 |
+
+### 出力形式
+
+AIアシスタントにそのまま貼り付けられる`@path#Lline`形式で出力します。
+
+**パスのみ（デフォルト）**：
+- 1行：`@src/main/kotlin/App.kt#L42`
+- 複数行：`@src/main/kotlin/App.kt#L250-253`
+
+**コード内容を含める（設定で有効化）**：
+````
+@src/main/kotlin/App.kt#L42-53
+```kotlin
+fun calculateTotal(items: List<Item>): Double {
+    return items.sumOf { it.price }
+}
+```
+````
+
+### 設定
+
+`Settings` → `Tools` → `Copy Selection Context`：
+
+- **Path type** — Absolute（デフォルト）またはRelative
+- **Include code content** — コードブロックを含めるかどうか
+
+#### 設定画面
+
+![Copy Selection Contextの設定画面](docs/images/settings-copy-selection-context.png)
+
+パスの種類、出力形式、コードを含めるかどうか、通知の動作、履歴オプションを1つの画面で設定できます。
+
+## 対応IDE
+
+IntelliJ Platform 2024.3以降をベースとするすべてのIDEで動作します：
+
+IntelliJ IDEA · Android Studio · PyCharm · WebStorm · PhpStorm · CLion · GoLand · Rider · RubyMine
+
+## 開発
+
+```bash
+git clone https://github.com/hon454/copy-selection-context.git
+cd copy-selection-context
+
+# Unix / macOS
+./gradlew buildPlugin    # Build plugin ZIP
+./gradlew runIde         # Run dev IDE with plugin
+./gradlew test           # Run tests
+
+# Windows
+gradlew.bat buildPlugin
+gradlew.bat runIde
+gradlew.bat test
+```
+
+開発とリリースの詳しいガイドについては、[CONTRIBUTING.md](CONTRIBUTING.md)をご覧ください。
+
+## サポート
+
+このプラグインが役に立ったら、ぜひコーヒーをごちそうしてください！
+
+<a href="https://www.buymeacoffee.com/hon454s" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+
+## ライセンス
+
+Apache License 2.0 — 詳細は[LICENSE](LICENSE)をご覧ください。
+
+## 作者
+
+[@hon454](https://github.com/hon454)が開発

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,7 +6,7 @@
 [![Contributors](https://img.shields.io/github/contributors/hon454/copy-selection-context)](https://github.com/hon454/copy-selection-context/graphs/contributors)
 [![License](https://img.shields.io/github/license/hon454/copy-selection-context)](LICENSE)
 
-**[English](README.md)**
+**[English](README.md)** · **한국어** · **[简体中文](README.zh-CN.md)** · **[日本語](README.ja.md)**
 
 > 파일 경로 + 라인 번호 + 코드를 한 번의 단축키로 클립보드에 복사 — AI 어시스턴트에 바로 붙여넣기 가능한 형식으로.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Contributors](https://img.shields.io/github/contributors/hon454/copy-selection-context)](https://github.com/hon454/copy-selection-context/graphs/contributors)
 [![License](https://img.shields.io/github/license/hon454/copy-selection-context)](LICENSE)
 
-**[한국어](README.ko.md)**
+**English** · **[한국어](README.ko.md)** · **[简体中文](README.zh-CN.md)** · **[日本語](README.ja.md)**
 
 > Copy file path + line numbers + code to clipboard in one shortcut — formatted for AI assistants.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,132 @@
+# Copy Selection Context
+
+[![JetBrains Marketplace](https://img.shields.io/jetbrains/plugin/v/com.github.hon454.copy-selection-context?label=Marketplace)](https://plugins.jetbrains.com/plugin/30262-copy-selection-context)
+[![Release](https://img.shields.io/github/v/release/hon454/copy-selection-context)](https://github.com/hon454/copy-selection-context/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/hon454/copy-selection-context/total)](https://github.com/hon454/copy-selection-context/releases)
+[![Contributors](https://img.shields.io/github/contributors/hon454/copy-selection-context)](https://github.com/hon454/copy-selection-context/graphs/contributors)
+[![License](https://img.shields.io/github/license/hon454/copy-selection-context)](LICENSE)
+
+**[English](README.md)** · **[한국어](README.ko.md)** · **简体中文** · **[日本語](README.ja.md)**
+
+> 使用一个快捷键将文件路径、行号和代码复制到剪贴板——采用可直接粘贴到 AI 助手的格式。
+
+向 Claude、ChatGPT 等 AI 编程助手提供代码上下文时，还在手动输入文件路径和行号吗？**Copy Selection Context** 只需一个快捷键，即可将 `@path#Lline` 格式的上下文复制到剪贴板。
+
+## 功能
+
+- **快捷键复制** — 按下 `Ctrl+Alt+C`，立即复制文件路径和行号
+- **相对或绝对路径** — 可选择项目相对路径或绝对路径
+- **包含代码内容** — 可选择将所选代码以 Markdown 代码块形式包含在内
+- **复制历史** — 按下 `Ctrl+Alt+H` 浏览最近的复制历史
+- **GitHub/GitLab 永久链接** — 复制所选行对应的 Git 永久链接
+- **智能行号处理** — 未选择文本时复制光标所在行的行号
+- **上下文菜单** — 可从编辑器右键菜单访问所有操作
+- **跨平台** — 支持 Windows、macOS 和 Linux
+
+## 安装
+
+### 从 JetBrains Marketplace 安装
+
+1. `File` → `Settings` → `Plugins`
+2. 搜索 **“Copy Selection Context”**
+3. 点击 `Install`
+
+### 从磁盘安装
+
+1. 从 [Releases](https://github.com/hon454/copy-selection-context/releases) 页面下载最新的 `.zip` 文件
+2. `File` → `Settings` → `Plugins` → ⚙️ → `Install Plugin from Disk...`
+3. 选择下载的 `.zip` 文件 → 重启 IDE
+
+## 使用方法
+
+### 键盘快捷键
+
+| 操作 | Windows/Linux | macOS |
+|------|---------------|-------|
+| Copy Selection Context | `Ctrl+Alt+C` | `Cmd+Alt+C` |
+| Show Copy History | `Ctrl+Alt+H` | `Ctrl+Alt+H` |
+
+> 可在 `Settings` → `Keymap` 中自定义快捷键。
+
+### 上下文菜单
+
+在编辑器中右键单击 → **Copy Selection Context** 子菜单：
+
+| 操作 | 说明 |
+|------|------|
+| Copy Selection Context | 根据设置复制路径和行号（主要操作） |
+| Copy Relative Path with Line Numbers | 使用项目相对路径复制 |
+| Copy Absolute Path with Line Numbers | 使用绝对路径复制 |
+| Copy with Code Content | 复制路径、行号和代码块 |
+| Copy GitHub/GitLab Permalink | 复制 Git 远程仓库永久链接 |
+| Show Copy History | 显示最近的复制历史弹窗 |
+
+### 输出格式
+
+输出为 `@path#Lline` 格式，可直接粘贴到 AI 助手中。
+
+**仅路径（默认）**：
+- 单行：`@src/main/kotlin/App.kt#L42`
+- 多行：`@src/main/kotlin/App.kt#L250-253`
+
+**包含代码内容（在设置中启用）**：
+````
+@src/main/kotlin/App.kt#L42-53
+```kotlin
+fun calculateTotal(items: List<Item>): Double {
+    return items.sumOf { it.price }
+}
+```
+````
+
+### 设置
+
+`Settings` → `Tools` → `Copy Selection Context`：
+
+- **Path type** — Absolute（默认）或 Relative
+- **Include code content** — 是否包含代码块
+
+#### 设置界面
+
+![Copy Selection Context 设置界面](docs/images/settings-copy-selection-context.png)
+
+可在一个界面中配置路径类型、输出格式、是否包含代码、通知行为和历史记录选项。
+
+## 兼容的 IDE
+
+支持所有基于 IntelliJ Platform 2024.3+ 的 IDE：
+
+IntelliJ IDEA · Android Studio · PyCharm · WebStorm · PhpStorm · CLion · GoLand · Rider · RubyMine
+
+## 开发
+
+```bash
+git clone https://github.com/hon454/copy-selection-context.git
+cd copy-selection-context
+
+# Unix / macOS
+./gradlew buildPlugin    # Build plugin ZIP
+./gradlew runIde         # Run dev IDE with plugin
+./gradlew test           # Run tests
+
+# Windows
+gradlew.bat buildPlugin
+gradlew.bat runIde
+gradlew.bat test
+```
+
+有关开发和发布的详细指南，请参阅 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+## 支持
+
+如果这个插件对你有帮助，欢迎请我喝杯咖啡！
+
+<a href="https://www.buymeacoffee.com/hon454s" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+
+## 许可证
+
+本项目采用 Apache License 2.0，详情请参阅 [LICENSE](LICENSE)。
+
+## 作者
+
+由 [@hon454](https://github.com/hon454) 开发


### PR DESCRIPTION
## Summary
- add Simplified Chinese and Japanese README translations
- add consistent four-language navigation to every README
- update the repository documentation rule to keep all translations synchronized

## Verification
- `git diff --check`
- confirmed all four README files have matching 132-line section structures
- confirmed referenced local documentation and image paths exist

## Manual testing
- reviewed language switch links across English, Korean, Simplified Chinese, and Japanese READMEs
- reviewed Markdown tables and fenced code blocks in both new translations