### PR TITLE
feat: improve multiline custom template editing and validation

### DIFF
--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionConfigurable.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionConfigurable.kt
@@ -1,23 +1,27 @@
 package com.github.hon454.copyselectioncontext
 
+import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.dsl.builder.*
 import javax.swing.JComponent
 import javax.swing.JComboBox
-import javax.swing.JLabel
-import javax.swing.JTextField
+import javax.swing.JTextArea
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
 
-class CopySelectionConfigurable : Configurable {
-    private val settings = CopySelectionSettings.getInstance()
+class CopySelectionConfigurable internal constructor(
+    private val settings: CopySelectionSettings,
+    private val trimOpenProjectHistory: (Int) -> Unit = CopyHistoryService::trimOpenProjects
+) : Configurable {
+    constructor() : this(CopySelectionSettings.getInstance())
+
     private var dialogPanel: DialogPanel? = null
     private var outputFormatCombo: JComboBox<OutputFormatOption>? = null
     private var presetCombo: JComboBox<String>? = null
-    private var templateTextField: JTextField? = null
-    private var previewLabel: JLabel? = null
-    private var validationLabel: JLabel? = null
+    private var templateTextArea: JTextArea? = null
+    private var previewTextArea: JTextArea? = null
+    private var updatingPresetSelection = false
 
     override fun getDisplayName() = CopySelectionBundle.message("settings.title")
 
@@ -53,29 +57,54 @@ class CopySelectionConfigurable : Configurable {
                         }
                 }
                 row(CopySelectionBundle.message("settings.template.label")) {
-                    textField()
+                    textArea()
+                        .rows(TEMPLATE_EDITOR_ROWS)
+                        .columns(TEMPLATE_COLUMNS)
+                        .align(AlignX.FILL)
+                        .resizableColumn()
                         .bindText(state::customFormatTemplate)
                         .comment(CopySelectionBundle.message("settings.template.variables.comment"))
+                        .accessibleName(CopySelectionBundle.message("settings.template.label"))
+                        .accessibleDescription(CopySelectionBundle.message("settings.template.variables.comment"))
+                        .validationOnApply { component ->
+                            if (isTemplateFormatSelected()) {
+                                templateValidationMessage(component.text)?.let { error(it) }
+                            } else {
+                                null
+                            }
+                        }
+                        .validationOnInput { component ->
+                            if (isTemplateFormatSelected()) {
+                                templateValidationMessage(component.text)?.let { error(it) }
+                            } else {
+                                null
+                            }
+                        }
                         .also { cell ->
-                            templateTextField = cell.component
+                            templateTextArea = cell.component
                             cell.component.document.addDocumentListener(object : DocumentListener {
-                                override fun insertUpdate(e: DocumentEvent) = updatePreviewAndValidation()
-                                override fun removeUpdate(e: DocumentEvent) = updatePreviewAndValidation()
-                                override fun changedUpdate(e: DocumentEvent) = updatePreviewAndValidation()
+                                override fun insertUpdate(e: DocumentEvent) = updatePreview()
+                                override fun removeUpdate(e: DocumentEvent) = updatePreview()
+                                override fun changedUpdate(e: DocumentEvent) = updatePreview()
                             })
                         }
-                }
+                }.resizableRow()
                 row(CopySelectionBundle.message("settings.template.preview.label")) {
-                    label("")
-                        .also { cell -> previewLabel = cell.component }
-                }
-                row {
-                    label("")
-                        .also { cell ->
-                            validationLabel = cell.component
-                            cell.component.isVisible = false
+                    textArea()
+                        .rows(PREVIEW_ROWS)
+                        .columns(TEMPLATE_COLUMNS)
+                        .align(AlignX.FILL)
+                        .resizableColumn()
+                        .accessibleName(CopySelectionBundle.message("settings.template.preview.label"))
+                        .accessibleDescription(CopySelectionBundle.message("settings.template.preview.description"))
+                        .applyToComponent {
+                            isEditable = false
+                            isFocusable = true
                         }
-                }
+                        .also { cell ->
+                            previewTextArea = cell.component
+                        }
+                }.resizableRow()
                 row {
                     checkBox(CopySelectionBundle.message("settings.include.code"))
                         .bindSelected(state::includeCodeContent)
@@ -107,25 +136,47 @@ class CopySelectionConfigurable : Configurable {
         }
         dialogPanel = panel
         updatePresetSelection()
-        updatePreviewAndValidation()
+        updatePreview()
         updateTemplateControls()
         return panel
     }
 
     override fun isModified() = dialogPanel?.isModified() ?: false
+
     override fun apply() {
+        val validationMessage = if (isTemplateFormatSelected()) {
+            templateValidationMessage(templateTextArea?.text.orEmpty())
+        } else {
+            null
+        }
+        if (validationMessage != null) {
+            throw ConfigurationException(validationMessage)
+        }
         dialogPanel?.apply()
-        CopyHistoryService.trimOpenProjects(settings.state.copyHistorySize)
+        trimOpenProjectHistory(settings.state.copyHistorySize)
     }
 
     override fun reset() {
         dialogPanel?.reset()
         updatePresetSelection()
-        updatePreviewAndValidation()
+        updatePreview()
         updateTemplateControls()
     }
 
+    override fun disposeUIResources() {
+        dialogPanel = null
+        outputFormatCombo = null
+        presetCombo = null
+        templateTextArea = null
+        previewTextArea = null
+        updatingPresetSelection = false
+    }
+
     private fun applySelectedPreset() {
+        if (updatingPresetSelection) {
+            return
+        }
+
         val customLabel = CopySelectionBundle.message("settings.template.preset.custom")
         val selected = presetCombo?.selectedItem as? String ?: return
         if (selected == customLabel) {
@@ -133,30 +184,47 @@ class CopySelectionConfigurable : Configurable {
         }
 
         val presetTemplate = TemplateFormatter.PRESETS.find { it.first == selected }?.second ?: return
-        templateTextField?.text = presetTemplate
-        updatePreviewAndValidation()
+        templateTextArea?.text = presetTemplate
+        updatePreview()
     }
 
     private fun updatePresetSelection() {
-        val currentTemplate = templateTextField?.text ?: settings.state.customFormatTemplate
+        val currentTemplate = templateTextArea?.text ?: settings.state.customFormatTemplate
         val customLabel = CopySelectionBundle.message("settings.template.preset.custom")
         val presetName = TemplateFormatter.PRESETS.find { it.second == currentTemplate }?.first ?: customLabel
         if (presetCombo?.selectedItem != presetName) {
-            presetCombo?.selectedItem = presetName
+            updatingPresetSelection = true
+            try {
+                presetCombo?.selectedItem = presetName
+            } finally {
+                updatingPresetSelection = false
+            }
         }
     }
 
     private fun updateTemplateControls() {
-        val isTemplate = outputFormatCombo?.selectedItem == OutputFormatOption.TEMPLATE
+        val isTemplate = isTemplateFormatSelected()
         presetCombo?.isEnabled = isTemplate
-        templateTextField?.isEnabled = isTemplate
-        previewLabel?.isEnabled = isTemplate
-        validationLabel?.isEnabled = isTemplate
+        templateTextArea?.isEnabled = isTemplate
+        previewTextArea?.isEnabled = isTemplate
     }
 
-    private fun updatePreviewAndValidation() {
-        val template = templateTextField?.text ?: settings.state.customFormatTemplate
-        val sampleContext = FormatContext(
+    private fun updatePreview() {
+        val template = templateTextArea?.text ?: settings.state.customFormatTemplate
+        previewTextArea?.text = renderTemplatePreview(template)
+        previewTextArea?.caretPosition = 0
+        updatePresetSelection()
+    }
+
+    private fun isTemplateFormatSelected() =
+        outputFormatCombo?.selectedItem == OutputFormatOption.TEMPLATE
+
+    companion object {
+        internal const val TEMPLATE_EDITOR_ROWS = 6
+        internal const val PREVIEW_ROWS = 6
+        private const val TEMPLATE_COLUMNS = 60
+
+        private val SAMPLE_CONTEXT = FormatContext(
             path = "src/main/kotlin/Example.kt",
             startLine = 42,
             endLine = 53,
@@ -165,28 +233,17 @@ class CopySelectionConfigurable : Configurable {
             filename = "Example.kt"
         )
 
-        val rendered = if (template.isBlank()) "" else TemplateFormatter(template).format(sampleContext)
-        previewLabel?.text = toHtml(rendered)
+        internal fun renderTemplatePreview(template: String): String =
+            if (template.isBlank()) "" else TemplateFormatter(template).format(SAMPLE_CONTEXT)
 
-        val unknownVariables = TemplateFormatter.findUnknownVariables(template)
-        if (unknownVariables.isEmpty()) {
-            validationLabel?.isVisible = false
-            validationLabel?.text = ""
-        } else {
+        internal fun templateValidationMessage(template: String): String? {
+            val unknownVariables = TemplateFormatter.findUnknownVariables(template)
+            if (unknownVariables.isEmpty()) {
+                return null
+            }
+
             val unknowns = unknownVariables.joinToString(", ") { "{$it}" }
-            validationLabel?.text = CopySelectionBundle.message("settings.template.validation.unknown", unknowns)
-            validationLabel?.isVisible = true
+            return CopySelectionBundle.message("settings.template.validation.unknown", unknowns)
         }
-
-        updatePresetSelection()
-    }
-
-    private fun toHtml(text: String): String {
-        val escaped = text
-            .replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace("\n", "<br>")
-        return "<html>$escaped</html>"
     }
 }

--- a/src/main/resources/messages/CopySelectionBundle.properties
+++ b/src/main/resources/messages/CopySelectionBundle.properties
@@ -39,4 +39,5 @@ settings.history.size.comment=Set to 0 to disable history. History is stored onl
 settings.template.preset.label=Template preset:
 settings.template.preset.custom=Custom
 settings.template.preview.label=Preview:
+settings.template.preview.description=Read-only live preview of the formatted clipboard output
 settings.template.validation.unknown=Unknown variable(s): {0}

--- a/src/main/resources/messages/CopySelectionBundle_ko.properties
+++ b/src/main/resources/messages/CopySelectionBundle_ko.properties
@@ -39,4 +39,5 @@ settings.history.size.comment=0\uc73c\ub85c \uc124\uc815\ud558\uba74 \ud788\uc2a
 settings.template.preset.label=\ud15c\ud50c\ub9bf \ud504\ub9ac\uc14b:
 settings.template.preset.custom=\uc0ac\uc6a9\uc790 \uc815\uc758
 settings.template.preview.label=\ubbf8\ub9ac\ubcf4\uae30:
+settings.template.preview.description=\ud615\uc2dd\uc774 \uc801\uc6a9\ub41c \ud074\ub9bd\ubcf4\ub4dc \ucd9c\ub825\uc758 \uc77d\uae30 \uc804\uc6a9 \uc2e4\uc2dc\uac04 \ubbf8\ub9ac\ubcf4\uae30
 settings.template.validation.unknown=\uc54c \uc218 \uc5c6\ub294 \ubcc0\uc218: {0}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionConfigurableTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionConfigurableTest.kt
@@ -1,0 +1,132 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.options.ConfigurationException
+import java.awt.Component
+import java.awt.Container
+import javax.swing.JComboBox
+import javax.swing.JTextArea
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class CopySelectionConfigurableTest {
+    @Test
+    fun `multiline preset populates editor and preview without flattening line breaks`() = onEdt {
+        val fixture = createFixture()
+
+        fixture.outputFormat.selectedItem = OutputFormatOption.TEMPLATE
+        fixture.preset.selectedItem = "With Code Block"
+
+        assertEquals(TemplateFormatter.PRESET_WITH_CODE_BLOCK, fixture.editor.text)
+        assertEquals(
+            "src/main/kotlin/Example.kt:42-53\n```kotlin\nfun hello() = println(\"world\")\n```",
+            fixture.preview.text
+        )
+    }
+
+    @Test
+    fun `unknown template variables prevent apply and preserve settings`() = onEdt {
+        val fixture = createFixture()
+
+        fixture.outputFormat.selectedItem = OutputFormatOption.TEMPLATE
+        fixture.editor.text = "{path}\n{unknown}"
+
+        val exception = assertFailsWith<ConfigurationException> {
+            fixture.configurable.apply()
+        }
+        assertTrue(exception.localizedMessage.orEmpty().contains("{unknown}"))
+        assertEquals("claude", fixture.settings.state.outputFormat)
+        assertEquals("", fixture.settings.state.customFormatTemplate)
+    }
+
+    @Test
+    fun `valid multiline template applies and reset restores persisted content`() = onEdt {
+        val fixture = createFixture()
+        val template = "{path}:{range}\n```{lang}\n{code}\n```"
+
+        fixture.outputFormat.selectedItem = OutputFormatOption.TEMPLATE
+        fixture.editor.text = template
+        fixture.configurable.apply()
+
+        assertEquals("template", fixture.settings.state.outputFormat)
+        assertEquals(template, fixture.settings.state.customFormatTemplate)
+
+        fixture.editor.text = "temporary edit"
+        fixture.configurable.reset()
+
+        assertEquals(template, fixture.editor.text)
+        assertEquals(CopySelectionConfigurable.renderTemplatePreview(template), fixture.preview.text)
+    }
+
+    @Test
+    fun `template editor and preview are bounded and accessible`() = onEdt {
+        val fixture = createFixture()
+
+        assertEquals(CopySelectionConfigurable.TEMPLATE_EDITOR_ROWS, fixture.editor.rows)
+        assertEquals(CopySelectionConfigurable.PREVIEW_ROWS, fixture.preview.rows)
+        assertTrue(fixture.editor.isEditable)
+        assertFalse(fixture.preview.isEditable)
+        assertTrue(fixture.preview.isFocusable)
+        assertTrue(fixture.editor.accessibleContext.accessibleName.isNotBlank())
+        assertTrue(fixture.editor.accessibleContext.accessibleDescription.isNotBlank())
+        assertTrue(fixture.preview.accessibleContext.accessibleName.isNotBlank())
+        assertTrue(fixture.preview.accessibleContext.accessibleDescription.isNotBlank())
+    }
+
+    private fun createFixture(): Fixture {
+        val settings = CopySelectionSettings()
+        val configurable = CopySelectionConfigurable(settings, trimOpenProjectHistory = {})
+        val component = configurable.createComponent()
+        val comboBoxes = descendantsOfType<JComboBox<*>>(component)
+        val textAreas = descendantsOfType<JTextArea>(component)
+
+        val outputFormat = comboBoxes.firstOrNull { combo -> combo.items().contains(OutputFormatOption.TEMPLATE) }
+        val preset = comboBoxes.firstOrNull { combo -> combo.items().contains("With Code Block") }
+        val editor = textAreas.firstOrNull { it.isEditable }
+        val preview = textAreas.firstOrNull { !it.isEditable }
+
+        return Fixture(
+            configurable = configurable,
+            settings = settings,
+            outputFormat = assertNotNull(outputFormat),
+            preset = assertNotNull(preset),
+            editor = assertNotNull(editor),
+            preview = assertNotNull(preview)
+        )
+    }
+
+    private fun JComboBox<*>.items(): List<Any?> =
+        (0 until itemCount).map { getItemAt(it) }
+
+    private inline fun <reified T : Component> descendantsOfType(root: Component): List<T> =
+        descendantsOfType(root, T::class.java)
+
+    private fun <T : Component> descendantsOfType(root: Component, type: Class<T>): List<T> = buildList {
+        if (type.isInstance(root)) {
+            add(type.cast(root))
+        }
+        if (root is Container) {
+            root.components.forEach { addAll(descendantsOfType(it, type)) }
+        }
+    }
+
+    private fun <T> onEdt(block: () -> T): T {
+        var result: Result<T>? = null
+        javax.swing.SwingUtilities.invokeAndWait {
+            result = runCatching(block)
+        }
+        return requireNotNull(result).getOrThrow()
+    }
+
+    private data class Fixture(
+        val configurable: CopySelectionConfigurable,
+        val settings: CopySelectionSettings,
+        val outputFormat: JComboBox<*>,
+        val preset: JComboBox<*>,
+        val editor: JTextArea,
+        val preview: JTextArea
+    )
+}


### PR DESCRIPTION
## Rationale

Custom templates support line breaks and code fences, but the settings UI only offered a single-line editor and did not prevent unknown variables from being saved.

## Implementation

- Replace the template field and label preview with bounded, scrollable multiline text areas.
- Keep preset selection and the read-only preview synchronized without document-listener re-entry.
- Use standard Configurable validation for unknown variables and block apply before settings mutate.
- Add accessible names and descriptions for the editor and preview.
- Add focused settings UI tests for multiline presets, live preview, validation, apply/reset, bounds, and accessibility.

## Verification

- env JAVA_HOME=<bundled JBR 21> ./gradlew test — BUILD SUCCESSFUL
- env JAVA_HOME=<bundled JBR 21> ./gradlew verifyPlugin — BUILD SUCCESSFUL
- Plugin Verifier: Compatible with IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97

Closes #15