### PR TITLE
ci: gate packaging on tests and plugin verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,23 @@ jobs:
 
       - name: Ensure gradlew is executable
         run: chmod +x ./gradlew
-      
+
+      - name: Run test suite
+        run: ./gradlew test --stacktrace --console=plain
+
+      - name: Verify plugin project and structure
+        run: >-
+          ./gradlew
+          verifyPluginProjectConfiguration
+          verifyPluginStructure
+          --stacktrace
+          --console=plain
+
+      - name: Verify plugin compatibility
+        run: ./gradlew verifyPlugin --stacktrace --console=plain
+
       - name: Build plugin
-        run: ./gradlew buildPlugin --stacktrace
+        run: ./gradlew buildPlugin --stacktrace --console=plain
 
       - name: Verify plugin ZIP exists
         run: |
@@ -46,6 +60,19 @@ jobs:
           fi
           echo "Plugin ZIP found:"
           ls -la build/distributions/*.zip
+
+      - name: Upload validation reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: validation-reports
+          path: |
+            build/reports/tests/
+            build/test-results/
+            build/reports/pluginVerifier/
+            build/reports/problems/
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,22 @@ jobs:
             echo "Release ${{ steps.version.outputs.tag }}" > release-notes.md
           fi
 
+      - name: Run test suite
+        run: ./gradlew test --stacktrace --console=plain
+
+      - name: Verify plugin project and structure
+        run: >-
+          ./gradlew
+          verifyPluginProjectConfiguration
+          verifyPluginStructure
+          --stacktrace
+          --console=plain
+
+      - name: Verify plugin compatibility
+        run: ./gradlew verifyPlugin --stacktrace --console=plain
+
       - name: Build plugin
-        run: ./gradlew buildPlugin --stacktrace
+        run: ./gradlew buildPlugin --stacktrace --console=plain
 
       - name: Verify plugin ZIP exists
         run: |
@@ -83,6 +97,19 @@ jobs:
           fi
           echo "Plugin ZIP found:"
           ls -la build/distributions/*.zip
+
+      - name: Upload validation reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: validation-reports
+          path: |
+            build/reports/tests/
+            build/test-results/
+            build/reports/pluginVerifier/
+            build/reports/problems/
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
@@ -1,0 +1,84 @@
+package com.github.hon454.copyselectioncontext
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class CiWorkflowTest {
+    @Test
+    fun `build validates before packaging and artifact upload`() {
+        assertValidationPipeline(
+            workflowName = "build.yml",
+            publicationStep = "Upload build artifact",
+        )
+    }
+
+    @Test
+    fun `release validates before packaging and publication`() {
+        assertValidationPipeline(
+            workflowName = "release.yml",
+            publicationStep = "Create GitHub Release",
+        )
+    }
+
+    private fun assertValidationPipeline(
+        workflowName: String,
+        publicationStep: String,
+    ) {
+        val workflow = readWorkflow(workflowName)
+
+        assertInOrder(
+            workflow,
+            "name: Run test suite",
+            "name: Verify plugin project and structure",
+            "name: Verify plugin compatibility",
+            "name: Build plugin",
+            "name: Upload validation reports",
+            "name: $publicationStep",
+        )
+        assertTrue(
+            workflow.contains("run: ./gradlew test --stacktrace --console=plain"),
+            "$workflowName must run the complete test task with diagnostic output",
+        )
+        assertTrue(
+            workflow.contains("verifyPluginProjectConfiguration") &&
+                workflow.contains("verifyPluginStructure") &&
+                workflow.contains("run: ./gradlew verifyPlugin --stacktrace --console=plain"),
+            "$workflowName must run project, structure, and compatibility verification",
+        )
+        assertTrue(
+            workflow.contains("name: Upload validation reports\n        if: always()"),
+            "$workflowName must preserve validation reports when a gate fails",
+        )
+        assertTrue(
+            workflow.contains("build/reports/pluginVerifier/") &&
+                workflow.contains("build/reports/tests/") &&
+                workflow.contains("build/test-results/"),
+            "$workflowName must upload plugin verification and test diagnostics",
+        )
+        assertTrue(
+            workflow.contains("uses: gradle/actions/setup-gradle@v6"),
+            "$workflowName must cache Gradle dependencies used by plugin verification",
+        )
+    }
+
+    private fun readWorkflow(workflowName: String): String {
+        val path = Path.of(".github", "workflows", workflowName)
+        assertTrue(Files.isRegularFile(path), "Workflow not found: $path")
+        return Files.readString(path)
+    }
+
+    private fun assertInOrder(
+        workflow: String,
+        vararg markers: String,
+    ) {
+        var previousIndex = -1
+        markers.forEach { marker ->
+            val markerIndex = workflow.indexOf(marker)
+            assertTrue(markerIndex >= 0, "Missing workflow step: $marker")
+            assertTrue(markerIndex > previousIndex, "Workflow step is out of order: $marker")
+            previousIndex = markerIndex
+        }
+    }
+}


### PR DESCRIPTION
## Rationale

Packaging and release publication currently proceed without explicit test, project configuration, plugin structure, or compatibility gates. This change makes those validations mandatory while retaining useful diagnostics on failures.

## Implementation

- Run the complete Gradle test suite before packaging in build and release workflows.
- Run project configuration, plugin structure, and compatibility verification before build artifacts or releases are published.
- Upload test, Plugin Verifier, and Gradle problem reports with always() so failed gates remain diagnosable.
- Keep recommended IDE coverage and Gradle dependency caching in place for expensive compatibility checks.
- Add CiWorkflowTest to prevent gate ordering, diagnostics, or caching from regressing in either workflow.

## Verification

- `actionlint -color` — passed with no findings.
- `./gradlew test --stacktrace --console=plain` — BUILD SUCCESSFUL; CiWorkflowTest: 2 tests, 0 failures.
- `./gradlew test verifyPluginProjectConfiguration verifyPluginStructure verifyPlugin buildPlugin --stacktrace --console=plain` — BUILD SUCCESSFUL.
- Plugin Verifier 1.410 — Compatible with IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97.

Manual testing is not applicable to this workflow-only change; the commands above exercise the complete validation and packaging path.

Closes #12