### PR TITLE
feat(history): add privacy controls for copy history

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -6,10 +6,11 @@
 2. **CopySelectionContextAction** reads settings (path type + code content toggle)
 3. **Action** extracts editor context (file path, line range, optionally code)
 4. **CopyPasteManager** writes formatted text to clipboard
-5. **CopySelectionHighlighter** replaces the gutter marker scoped to the active editor
-6. **CopySelectionNotifier** shows toast notification (BALLOON type)
-7. **CopySelectionStatusBarWidget** updates (currently stub, prints to console)
-8. **CopySelectionSettings** provides path type and code content preferences
+5. **CopyHistoryService** stores the result in local, non-roaming workspace state when history is enabled
+6. **CopySelectionHighlighter** replaces the gutter marker scoped to the active editor
+7. **CopySelectionNotifier** shows toast notification (BALLOON type)
+8. **CopySelectionStatusBarWidget** updates (currently stub, prints to console)
+9. **CopySelectionSettings** provides formatting, behavior, and history preferences
 
 ## Output Formats
 
@@ -45,11 +46,15 @@ fun example() {
 
 - **GitPermalinkGenerator.kt**: Normalizes supported GitHub/GitLab HTTPS and SSH remote forms and percent-encodes repository-relative file paths.
 
+- **CopyHistoryService.kt**: Project-level history service persisted in the IDE's local workspace state with roaming disabled. Size zero disables and clears history; shrinking retains the newest entries deterministically. The deprecated `copySelectionHistory.xml` storage entry migrates and cleans up legacy shareable state.
+
+- **CopyHistoryPopup.kt**: Popup chooser for re-copying local history entries, with a clear-all action.
+
 - **CopySelectionNotifier.kt** (~17 lines): Singleton. `NotificationGroupManager` BALLOON notifications with checkmark prefix. Group ID: `"CopySelectionContext"` (must match plugin.xml).
 
 - **CopySelectionStatusBarWidget.kt** (~9 lines): Stub (console only). Full impl needs `StatusBarWidget` + `TextPresentation` + `getAlignment(): Float` + Factory class.
 
-- **CopySelectionSettings.kt** (~39 lines): `@Service` + `@State`. Persists to `CopySelectionPlugin.xml`. Settings: `defaultPathType` (ABSOLUTE), `includeCodeContent` (false). `PathType` enum: RELATIVE, ABSOLUTE.
+- **CopySelectionSettings.kt**: `@Service` + `@State`. Persists to `CopySelectionPlugin.xml`. Includes output, notification, analytics, and copy history size preferences. `PathType` enum: RELATIVE, ABSOLUTE.
 
 - **CopySelectionConfigurable.kt** (~70 lines): Settings UI under Tools menu. Swing radio buttons (path type) + checkbox (code content). Implements `Configurable` lifecycle: `isModified()`, `apply()`, `reset()`, `disposeUIResources()`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ Single flat package: `com.github.hon454.copyselectioncontext/`
 | `CopySelectionContextAction.kt` | Main unified action (`Ctrl+Alt+C` shortcut) |
 | `CopySelectionBaseAction.kt` | Abstract base with clipboard logic |
 | `CopySelectionHighlighter.kt` | Editor-scoped gutter highlighter lifecycle |
+| `CopyHistoryService.kt` | Project history in local, non-roaming workspace state |
+| `CopyHistoryPopup.kt` | Browse, re-copy, and clear local history |
 | `CopyRelativePathAction.kt` | Relative path (context menu only) |
 | `CopyAbsolutePathAction.kt` | Absolute path (context menu only) |
 | `CopyWithCodeContentAction.kt` | Path + markdown code block (context menu only) |
@@ -69,7 +71,7 @@ Single flat package: `com.github.hon454.copyselectioncontext/`
 | `GitRepositoryMetadataResolver.kt` | Worktree-aware Git metadata and ref resolution |
 | `GitPermalinkGenerator.kt` | Remote URL normalization and encoded permalink generation |
 
-**Flow**: User trigger -> Action reads settings -> Extract editor context -> CopyPasteManager -> Notification
+**Flow**: User trigger -> Action reads settings -> Extract editor context -> CopyPasteManager -> Local history (when enabled) -> Notification
 
 ## Conventions
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -85,6 +85,9 @@ fun calculateTotal(items: List<Item>): Double {
 
 - **Path type** — Absolute（デフォルト）またはRelative
 - **Include code content** — コードブロックを含めるかどうか
+- **Copy history size** — 最大100件を保持するか、`0`に設定して履歴を無効化
+
+コピー履歴にはコピーしたコードが含まれる場合があります。データはIDEのローカルな非ローミングワークスペースにのみ保存され、共有可能なプロジェクト設定には書き込まれません。履歴ポップアップ下部の **Clear all history** ですべての項目を削除できます。最大件数を減らすと古い項目はすぐに削除され、以前 `copySelectionHistory.xml` に保存された履歴はローカルワークスペースストレージへ移行された後、IDEによって旧ファイルが削除されます。
 
 #### 設定画面
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -85,6 +85,9 @@ fun calculateTotal(items: List<Item>): Double {
 
 - **Path type** — Absolute (기본) 또는 Relative
 - **Include code content** — 코드 블록 포함 여부
+- **Copy history size** — 최대 100개까지 보관하거나 `0`으로 설정해 이력 비활성화
+
+복사 이력에는 복사한 코드가 포함될 수 있습니다. 이 데이터는 IDE의 로컬 비로밍 작업 공간에만 저장되며 공유 가능한 프로젝트 설정에는 기록되지 않습니다. 이력 팝업 하단의 **모든 히스토리 삭제**로 전체 항목을 지울 수 있습니다. 최대 크기를 줄이면 오래된 항목이 즉시 제거되며, 기존 `copySelectionHistory.xml`의 이력은 로컬 작업 공간 저장소로 마이그레이션된 후 IDE가 레거시 파일을 정리합니다.
 
 #### 설정 화면
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ fun calculateTotal(items: List<Item>): Double {
 
 - **Path type** — Absolute (default) or Relative
 - **Include code content** — Whether to include the code block
+- **Copy history size** — Keep up to 100 entries, or set to `0` to disable history
+
+Copy history may contain copied code. It is stored only in the IDE's local, non-roaming workspace data and is not written to shareable project settings. Use **Clear all history** at the bottom of the history popup to remove every entry. When the maximum size is reduced, older entries are removed immediately; history previously stored in `copySelectionHistory.xml` is migrated to local workspace storage and the legacy file is cleaned up by the IDE.
 
 #### Settings Screen
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -85,6 +85,9 @@ fun calculateTotal(items: List<Item>): Double {
 
 - **Path type** — Absolute（默认）或 Relative
 - **Include code content** — 是否包含代码块
+- **Copy history size** — 最多保留 100 条记录，或设为 `0` 以禁用历史记录
+
+复制历史可能包含已复制的代码。数据仅存储在 IDE 的本地非漫游工作区中，不会写入可共享的项目设置。可使用历史弹窗底部的 **Clear all history** 删除所有记录。减小最大数量时，较旧的记录会立即删除；先前存储在 `copySelectionHistory.xml` 中的历史会迁移到本地工作区存储，旧文件随后由 IDE 清理。
 
 #### 设置界面
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -85,6 +85,9 @@ fun calculateTotal(items: List<Item>): Double {
 
 - **Path type** — Absolute（預設）或 Relative
 - **Include code content** — 是否包含程式碼區塊
+- **Copy history size** — 最多保留 100 筆記錄，或設為 `0` 以停用歷史記錄
+
+複製歷史記錄可能包含已複製的程式碼。資料僅儲存在 IDE 的本機、非漫遊工作區中，不會寫入可共享的專案設定。使用歷史記錄彈出視窗底部的 **Clear all history** 可移除所有項目。縮小最大筆數時，較舊的項目會立即移除；先前儲存在 `copySelectionHistory.xml` 的歷史記錄會遷移至本機工作區儲存空間，之後 IDE 會清理舊檔案。
 
 #### 設定畫面
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.changelog.Changelog
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -22,11 +23,15 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter-api:6.1.3")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:6.1.3")
-    testRuntimeOnly("junit:junit:4.13.2")
-    testImplementation("io.mockk:mockk:1.14.11")
+    testImplementation("junit:junit:4.13.2")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:6.1.3")
+    testImplementation("io.mockk:mockk:1.14.11") {
+        exclude(group = "org.jetbrains.kotlinx")
+    }
 
     intellijPlatform {
         intellijIdeaCommunity("2024.3")
+        testFramework(TestFrameworkType.Bundled)
     }
 }
 

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyHistoryPopup.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyHistoryPopup.kt
@@ -9,8 +9,14 @@ import java.awt.datatransfer.StringSelection
 import javax.swing.JComponent
 
 object CopyHistoryPopup {
-    private data class PopupItem(val preview: String, val content: String) {
-        override fun toString(): String = preview
+    internal sealed interface PopupItem {
+        data class Entry(val preview: String, val content: String) : PopupItem {
+            override fun toString(): String = preview
+        }
+
+        data object ClearAll : PopupItem {
+            override fun toString(): String = CopySelectionBundle.message("history.popup.clear.all")
+        }
     }
 
     fun show(project: Project, component: JComponent? = null) {
@@ -18,17 +24,14 @@ object CopyHistoryPopup {
         val entries = service.getEntries()
         if (entries.isEmpty()) return
 
-        val items = entries.map { entry ->
-            PopupItem(
-                preview = entry.content.take(80).replace("\n", " "),
-                content = entry.content
-            )
-        }
+        val items = createItems(entries)
 
         val popup = JBPopupFactory.getInstance().createPopupChooserBuilder(items)
             .setTitle(CopySelectionBundle.message("history.popup.title"))
             .setItemChosenCallback { selected ->
-                CopyPasteManager.getInstance().setContents(StringSelection(selected.content))
+                handleSelection(service, selected) { content ->
+                    CopyPasteManager.getInstance().setContents(StringSelection(content))
+                }
             }
             .createPopup()
 
@@ -36,6 +39,25 @@ object CopyHistoryPopup {
             popup.show(RelativePoint(component, Point(0, 0)))
         } else {
             popup.showInFocusCenter()
+        }
+    }
+
+    internal fun createItems(entries: List<CopyHistoryService.HistoryEntry>): List<PopupItem> =
+        entries.map { entry ->
+            PopupItem.Entry(
+                preview = entry.content.take(80).replace("\n", " "),
+                content = entry.content
+            )
+        } + PopupItem.ClearAll
+
+    internal fun handleSelection(
+        service: CopyHistoryService,
+        selected: PopupItem,
+        copyContent: (String) -> Unit
+    ) {
+        when (selected) {
+            is PopupItem.Entry -> copyContent(selected.content)
+            PopupItem.ClearAll -> service.clear()
         }
     }
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyHistoryService.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyHistoryService.kt
@@ -19,9 +19,9 @@ import com.intellij.openapi.project.ProjectManager
 )
 class CopyHistoryService : PersistentStateComponent<CopyHistoryService.State> {
 
-    data class HistoryEntry(val content: String = "", val timestamp: Long = 0L)
+    data class HistoryEntry(var content: String = "", var timestamp: Long = 0L)
 
-    data class State(val entries: MutableList<HistoryEntry> = mutableListOf())
+    data class State(var entries: MutableList<HistoryEntry> = mutableListOf())
 
     private var myState = State()
 

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyHistoryService.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyHistoryService.kt
@@ -1,13 +1,22 @@
 package com.github.hon454.copyselectioncontext
 
 import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.RoamingType
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.StoragePathMacros
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
 
 @Service(Service.Level.PROJECT)
-@State(name = "CopySelectionHistory", storages = [Storage("copySelectionHistory.xml")])
+@State(
+    name = "CopySelectionHistory",
+    storages = [
+        Storage(StoragePathMacros.WORKSPACE_FILE, roamingType = RoamingType.DISABLED),
+        Storage(value = "copySelectionHistory.xml", deprecated = true)
+    ]
+)
 class CopyHistoryService : PersistentStateComponent<CopyHistoryService.State> {
 
     data class HistoryEntry(val content: String = "", val timestamp: Long = 0L)
@@ -23,10 +32,14 @@ class CopyHistoryService : PersistentStateComponent<CopyHistoryService.State> {
     }
 
     fun addEntry(content: String, maxSize: Int = 50) {
-        myState.entries.add(0, HistoryEntry(content = content, timestamp = System.currentTimeMillis()))
-        if (myState.entries.size > maxSize) {
-            myState.entries.removeAt(myState.entries.size - 1)
+        val limit = maxSize.coerceAtLeast(0)
+        if (limit == 0) {
+            clear()
+            return
         }
+
+        myState.entries.add(0, HistoryEntry(content = content, timestamp = System.currentTimeMillis()))
+        trimToSize(limit)
     }
 
     fun getEntries(): List<HistoryEntry> = myState.entries.toList()
@@ -35,8 +48,21 @@ class CopyHistoryService : PersistentStateComponent<CopyHistoryService.State> {
         myState.entries.clear()
     }
 
+    fun trimToSize(maxSize: Int) {
+        val limit = maxSize.coerceAtLeast(0)
+        if (myState.entries.size > limit) {
+            myState.entries.subList(limit, myState.entries.size).clear()
+        }
+    }
+
     companion object {
         fun getInstance(project: Project): CopyHistoryService =
             project.getService(CopyHistoryService::class.java)
+
+        fun trimOpenProjects(maxSize: Int) {
+            ProjectManager.getInstance().openProjects.forEach { project ->
+                project.getService(CopyHistoryService::class.java)?.trimToSize(maxSize)
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionConfigurable.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionConfigurable.kt
@@ -93,8 +93,9 @@ class CopySelectionConfigurable : Configurable {
             }
             group(CopySelectionBundle.message("settings.history.size")) {
                 row(CopySelectionBundle.message("settings.history.size.label")) {
-                    spinner(1..100)
+                    spinner(0..100)
                         .bindIntValue(state::copyHistorySize)
+                        .comment(CopySelectionBundle.message("settings.history.size.comment"))
                 }
             }
             group(CopySelectionBundle.message("settings.group.analytics")) {
@@ -112,7 +113,10 @@ class CopySelectionConfigurable : Configurable {
     }
 
     override fun isModified() = dialogPanel?.isModified() ?: false
-    override fun apply() { dialogPanel?.apply() }
+    override fun apply() {
+        dialogPanel?.apply()
+        CopyHistoryService.trimOpenProjects(settings.state.copyHistorySize)
+    }
 
     override fun reset() {
         dialogPanel?.reset()

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionSettings.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionSettings.kt
@@ -29,6 +29,7 @@ class CopySelectionSettings : PersistentStateComponent<CopySelectionSettings.Sta
     override fun getState(): State = myState
 
     override fun loadState(state: State) {
+        state.copyHistorySize = state.copyHistorySize.coerceIn(0, 100)
         myState = state
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,13 +15,13 @@ One shortcut (<code>Ctrl+Alt+C</code> / <code>Cmd+Alt+C</code>) copies your curr
     <li><strong>One-shortcut copy</strong> — <code>Ctrl+Alt+C</code> (Windows/Linux) / <code>Cmd+Alt+C</code> (macOS) copies path + line numbers based on your settings</li>
     <li><strong>Relative or absolute paths</strong> — choose project-relative or full absolute paths per your workflow</li>
     <li><strong>Code content as markdown</strong> — include the selected code as a fenced markdown code block with language tag</li>
-    <li><strong>Copy History browser</strong> — <code>Ctrl+Alt+H</code> opens a popup to browse and re-copy recent entries</li>
+    <li><strong>Private copy history</strong> — <code>Ctrl+Alt+H</code> opens locally stored history with clear-all and disable controls</li>
     <li><strong>GitHub/GitLab permalink</strong> — generate a permanent link to the exact lines in your remote repository</li>
     <li><strong>Template-based output formatting</strong> — choose from built-in presets (Claude Code, Path:Line, GitHub Permalink, Custom) or define your own template with variable placeholders</li>
     <li><strong>Live template preview</strong> — settings UI shows a real-time preview and validates template variables before you save</li>
     <li><strong>Smart line handling</strong> — copies the current line number when no text is selected, so the shortcut always produces useful output</li>
     <li><strong>Status bar widget</strong> — displays the last copied text in the IDE status bar; click it to copy again</li>
-    <li><strong>Configurable settings</strong> — path type, output format, code trimming, notification toggle, and history size all adjustable at <em>Settings → Tools → Copy Selection Context</em></li>
+    <li><strong>Configurable settings</strong> — path type, output format, code trimming, notification toggle, and local history size (set to 0 to disable) all adjustable at <em>Settings → Tools → Copy Selection Context</em></li>
     <li><strong>Context menu integration</strong> — all actions available in the editor right-click menu under the Copy Selection Context submenu</li>
 </ul>
 <h3>Output Format</h3>

--- a/src/main/resources/messages/CopySelectionBundle.properties
+++ b/src/main/resources/messages/CopySelectionBundle.properties
@@ -5,6 +5,7 @@ widget.tooltip=Copy Selection Context \u2014 last copied
 widget.empty=No copy yet
 history.popup.title=Copy History
 history.popup.empty=No history
+history.popup.clear.all=Clear all history
 settings.title=Copy Selection Context
 settings.group.output=Output Format
 settings.group.behavior=Behavior
@@ -34,6 +35,7 @@ settings.format.output.label=Output format:
 settings.format.output.comment=claude = @path#L format, pathline = path:line format, template = custom
 settings.template.variables.comment={path} {line} {range} {code} {lang} {filename}
 settings.history.size.label=History size:
+settings.history.size.comment=Set to 0 to disable history. History is stored only in the local IDE workspace.
 settings.template.preset.label=Template preset:
 settings.template.preset.custom=Custom
 settings.template.preview.label=Preview:

--- a/src/main/resources/messages/CopySelectionBundle_ko.properties
+++ b/src/main/resources/messages/CopySelectionBundle_ko.properties
@@ -5,6 +5,7 @@ widget.tooltip=Copy Selection Context \u2014 \ub9c8\uc9c0\ub9c9 \ubcf5\uc0ac
 widget.empty=\ubcf5\uc0ac \uc5c6\uc74c
 history.popup.title=\ubcf5\uc0ac \ud788\uc2a4\ud1a0\ub9ac
 history.popup.empty=\ud788\uc2a4\ud1a0\ub9ac \uc5c6\uc74c
+history.popup.clear.all=\ubaa8\ub4e0 \ud788\uc2a4\ud1a0\ub9ac \uc0ad\uc81c
 settings.title=Copy Selection Context
 settings.group.output=\ucd9c\ub825 \ud615\uc2dd
 settings.group.behavior=\ub3d9\uc791
@@ -34,6 +35,7 @@ settings.format.output.label=\ucd9c\ub825 \ud615\uc2dd:
 settings.format.output.comment=claude = @path#L \ud615\uc2dd, pathline = path:line \ud615\uc2dd, template = \uc0ac\uc6a9\uc790 \uc815\uc758
 settings.template.variables.comment={path} {line} {range} {code} {lang} {filename}
 settings.history.size.label=\ud788\uc2a4\ud1a0\ub9ac \ud06c\uae30:
+settings.history.size.comment=0\uc73c\ub85c \uc124\uc815\ud558\uba74 \ud788\uc2a4\ud1a0\ub9ac\uac00 \ube44\ud65c\uc131\ud654\ub429\ub2c8\ub2e4. \ud788\uc2a4\ud1a0\ub9ac\ub294 \ub85c\uceec IDE \uc791\uc5c5 \uacf5\uac04\uc5d0\ub9cc \uc800\uc7a5\ub429\ub2c8\ub2e4.
 settings.project.title=Copy Selection Context (\ud504\ub85c\uc81d\ud2b8)
 settings.project.group=\ud504\ub85c\uc81d\ud2b8 \uc124\uc815
 settings.project.use.project=\ud504\ub85c\uc81d\ud2b8\ubcc4 \uc124\uc815 \uc0ac\uc6a9 (\uc560\ud50c\ub9ac\ucf00\uc774\uc158 \uc124\uc815 \uc7ac\uc815\uc758)

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopyHistoryPersistenceTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopyHistoryPersistenceTest.kt
@@ -1,0 +1,241 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.configurationStore.ProjectStoreImpl
+import com.intellij.mock.MockProject
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PathMacroManager
+import com.intellij.openapi.components.impl.ProjectPathMacroManager
+import com.intellij.openapi.components.impl.stores.ComponentStoreOwner
+import com.intellij.openapi.components.impl.stores.IComponentStore
+import com.intellij.openapi.extensions.ExtensionPoint
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.JDOMUtil
+import com.intellij.serviceContainer.ComponentManagerImpl
+import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.fixture.tempPathFixture
+import com.intellij.util.xmlb.XmlSerializer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.jdom.Element
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Proxy
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@TestApplication
+class CopyHistoryPersistenceTest {
+    private val projectRootFixture = tempPathFixture()
+
+    private lateinit var fixtureDisposable: Disposable
+    private lateinit var fixtureProject: StoreBackedMockProject
+    private lateinit var fixtureStore: ProjectStoreImpl
+    private lateinit var service: CopyHistoryService
+
+    @BeforeEach
+    fun setUpStoreFixture() {
+        val projectRoot = projectRootFixture.get()
+        writeLegacyHistory(projectRoot, LEGACY_MARKER)
+
+        fixtureDisposable = Disposer.newDisposable("copy-history-store-fixture")
+        fixtureProject = StoreBackedMockProject(fixtureDisposable)
+        fixtureProject.extensionArea.registerExtensionPoint(
+            "com.intellij.streamProviderFactory",
+            "com.intellij.configurationStore.StreamProviderFactory",
+            ExtensionPoint.Kind.INTERFACE,
+            false,
+        )
+        fixtureProject.registerService(
+            PathMacroManager::class.java,
+            ProjectPathMacroManager.createInstance(
+                { projectRoot.resolve(".idea").resolve("misc.xml").toString() },
+                { projectRoot.toString() },
+                { projectRoot.fileName.toString() },
+            ),
+        )
+        registerProjectIdManager(fixtureProject)
+        registerCoroutineScopeService(
+            fixtureProject,
+            fixtureDisposable,
+            "com.intellij.configurationStore.statistic.eventLog.FeatureUsageSettingsEvents",
+        )
+        registerCoroutineScopeService(
+            fixtureProject,
+            fixtureDisposable,
+            "com.jetbrains.rdserver.settings.BackendBroadcastSettingsStorageService",
+        )
+
+        fixtureStore = object : ProjectStoreImpl(fixtureProject) {
+            override val serviceContainer: ComponentManagerImpl
+                get() = ApplicationManager.getApplication() as ComponentManagerImpl
+        }
+        fixtureStore.setPath(projectRoot)
+        fixtureProject.store = fixtureStore
+
+        service = CopyHistoryService()
+        fixtureProject.registerService(CopyHistoryService::class.java, service)
+        fixtureStore.initComponent(service, null, PLUGIN_ID)
+    }
+
+    @AfterEach
+    fun tearDownStoreFixture() {
+        fixtureStore.release()
+        Disposer.dispose(fixtureDisposable)
+    }
+
+    @Test
+    fun `legacy history migrates to workspace and reloads from there`() {
+        val projectRoot = projectRootFixture.get()
+        val legacyStorage = legacyStorage(projectRoot)
+
+        assertEquals(listOf(LEGACY_MARKER), historyContents())
+        saveProjectStore()
+
+        val workspaceStorage = workspaceStorage(projectRoot)
+        assertTrue(workspaceStorage.exists())
+        assertTrue(workspaceStorage.readText().contains(LEGACY_MARKER))
+        assertFalse(legacyStorage.exists())
+
+        service.clear()
+        fixtureStore.reloadState(CopyHistoryService::class.java)
+        assertEquals(listOf(LEGACY_MARKER), historyContents())
+    }
+
+    @Test
+    fun `zero size clears persisted history across reload`() {
+        val projectRoot = projectRootFixture.get()
+        val legacyStorage = legacyStorage(projectRoot)
+
+        assertEquals(listOf(LEGACY_MARKER), historyContents())
+        service.addEntry("must-not-persist", maxSize = 0)
+        saveProjectStore()
+
+        assertFalse(legacyStorage.exists())
+        assertWorkspaceDoesNotContain(projectRoot, LEGACY_MARKER, "must-not-persist")
+
+        service.addEntry("in-memory-only")
+        service.loadState(CopyHistoryService.State())
+        fixtureStore.reloadState(CopyHistoryService::class.java)
+        assertTrue(historyContents().isEmpty())
+    }
+
+    @Test
+    fun `clear removes persisted history across reload`() {
+        val projectRoot = projectRootFixture.get()
+        val legacyStorage = legacyStorage(projectRoot)
+
+        assertEquals(listOf(LEGACY_MARKER), historyContents())
+        service.clear()
+        saveProjectStore()
+
+        assertFalse(legacyStorage.exists())
+        assertWorkspaceDoesNotContain(projectRoot, LEGACY_MARKER)
+
+        service.addEntry("in-memory-only")
+        service.loadState(CopyHistoryService.State())
+        fixtureStore.reloadState(CopyHistoryService::class.java)
+        assertTrue(historyContents().isEmpty())
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun registerProjectIdManager(project: StoreBackedMockProject) {
+        val serviceClass =
+            Class.forName("com.intellij.configurationStore.ProjectIdManager") as Class<Any>
+        var projectId = "copy-history-store-fixture"
+        val service = Proxy.newProxyInstance(
+            serviceClass.classLoader,
+            arrayOf(serviceClass),
+        ) { _, method, arguments ->
+            when (method.name) {
+                "getId" -> projectId
+                "setId" -> {
+                    projectId = requireNotNull(arguments).single() as String
+                    Unit
+                }
+                "toString" -> "ProjectIdManager($projectId)"
+                else -> null
+            }
+        }
+        project.registerService(serviceClass, service)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun registerCoroutineScopeService(
+        project: StoreBackedMockProject,
+        parentDisposable: Disposable,
+        className: String,
+    ) {
+        val serviceClass = Class.forName(className) as Class<Any>
+        val scope = CoroutineScope(SupervisorJob())
+        Disposer.register(parentDisposable) { scope.cancel() }
+        val service = serviceClass.getConstructor(CoroutineScope::class.java).newInstance(scope)
+        project.registerService(serviceClass, service)
+    }
+
+    private fun writeLegacyHistory(projectRoot: Path, content: String): Path {
+        val component = Element("component").apply {
+            setAttribute("name", COMPONENT_NAME)
+            XmlSerializer.serializeInto(
+                CopyHistoryService.State(
+                    mutableListOf(CopyHistoryService.HistoryEntry(content = content, timestamp = 42L))
+                ),
+                this,
+            )
+        }
+        val projectElement = Element("project").apply {
+            setAttribute("version", "4")
+            addContent(component)
+        }
+        return projectRoot.resolve(".idea").createDirectories()
+            .resolve("copySelectionHistory.xml")
+            .also { JDOMUtil.write(projectElement, it) }
+    }
+
+    private fun historyContents(): List<String> =
+        CopyHistoryService.getInstance(fixtureProject).getEntries().map { it.content }
+
+    private fun saveProjectStore() = runBlocking {
+        fixtureStore.save(true)
+    }
+
+    private fun legacyStorage(projectRoot: Path): Path =
+        projectRoot.resolve(".idea").resolve("copySelectionHistory.xml")
+
+    private fun workspaceStorage(projectRoot: Path): Path =
+        projectRoot.resolve(".idea").resolve("workspace.xml")
+
+    private fun assertWorkspaceDoesNotContain(projectRoot: Path, vararg contents: String) {
+        val workspaceStorage = workspaceStorage(projectRoot)
+        if (!workspaceStorage.exists()) return
+
+        val persisted = workspaceStorage.readText()
+        contents.forEach { content ->
+            assertFalse(persisted.contains(content), "Workspace must not contain '$content'")
+        }
+    }
+
+    private class StoreBackedMockProject(parentDisposable: Disposable) :
+        MockProject(null, parentDisposable),
+        ComponentStoreOwner {
+        lateinit var store: IComponentStore
+
+        override val componentStore: IComponentStore
+            get() = store
+    }
+
+    companion object {
+        private const val COMPONENT_NAME = "CopySelectionHistory"
+        private const val LEGACY_MARKER = "legacy-history-marker"
+        private val PLUGIN_ID = PluginId.getId("com.github.hon454.copy-selection-context")
+    }
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopyHistoryServiceTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopyHistoryServiceTest.kt
@@ -1,7 +1,11 @@
 package com.github.hon454.copyselectioncontext
 
+import com.intellij.openapi.components.RoamingType
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.StoragePathMacros
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class CopyHistoryServiceTest {
@@ -32,6 +36,28 @@ class CopyHistoryServiceTest {
     }
 
     @Test
+    fun `zero size disables history and removes existing entries`() {
+        val service = CopyHistoryService()
+        service.addEntry("existing")
+
+        service.addEntry("must not persist", maxSize = 0)
+
+        assertTrue(service.getEntries().isEmpty())
+    }
+
+    @Test
+    fun `trimToSize immediately keeps the newest entries deterministically`() {
+        val service = CopyHistoryService()
+        listOf("first", "second", "third", "fourth").forEach { content ->
+            service.addEntry(content, maxSize = 10)
+        }
+
+        service.trimToSize(2)
+
+        assertEquals(listOf("fourth", "third"), service.getEntries().map { it.content })
+    }
+
+    @Test
     fun `clear removes all entries`() {
         val service = CopyHistoryService()
 
@@ -52,5 +78,36 @@ class CopyHistoryServiceTest {
         val entries = service.getEntries()
         assertEquals("newer", entries[0].content)
         assertEquals("older", entries[1].content)
+    }
+
+    @Test
+    fun `history persists only in the local workspace storage`() {
+        val state = CopyHistoryService::class.java.getAnnotation(State::class.java)
+        val workspaceStorage = state.storages.first()
+
+        assertEquals(StoragePathMacros.WORKSPACE_FILE, workspaceStorage.value)
+        assertEquals(RoamingType.DISABLED, workspaceStorage.roamingType)
+        assertFalse(workspaceStorage.deprecated)
+    }
+
+    @Test
+    fun `legacy project history storage is migrated and cleaned up`() {
+        val state = CopyHistoryService::class.java.getAnnotation(State::class.java)
+        val legacyStorage = state.storages.single { it.value == "copySelectionHistory.xml" }
+
+        assertTrue(legacyStorage.deprecated)
+    }
+
+    @Test
+    fun `popup clear-all action removes every entry`() {
+        val service = CopyHistoryService()
+        service.addEntry("first")
+        service.addEntry("second")
+        val clearAll = CopyHistoryPopup.createItems(service.getEntries()).last()
+
+        CopyHistoryPopup.handleSelection(service, clearAll) { error("Clear must not copy content") }
+
+        assertEquals(CopyHistoryPopup.PopupItem.ClearAll, clearAll)
+        assertTrue(service.getEntries().isEmpty())
     }
 }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBundleTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBundleTest.kt
@@ -69,7 +69,8 @@ class CopySelectionBundleTest {
             "widget.tooltip",
             "widget.empty",
             "history.popup.title",
-            "history.popup.empty"
+            "history.popup.empty",
+            "history.popup.clear.all"
         ).forEach { key ->
             assertTrue(CopySelectionBundle.message(key).isNotBlank(), "Key '$key' should resolve to non-blank string")
         }
@@ -85,6 +86,7 @@ class CopySelectionBundleTest {
             "settings.notification.enable",
             "settings.trimming.enable",
             "settings.history.size",
+            "settings.history.size.comment",
             "settings.template.label"
         ).forEach { key ->
             assertTrue(CopySelectionBundle.message(key).isNotBlank(), "Key '$key' should resolve to non-blank string")

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionSettingsTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionSettingsTest.kt
@@ -95,4 +95,24 @@ class CopySelectionSettingsTest {
         assertEquals("verbose", state.outputFormat)
         assertEquals(50, state.copyHistorySize)
     }
+
+    @Test
+    fun `loadState accepts zero to disable history`() {
+        val settings = CopySelectionSettings()
+
+        settings.loadState(CopySelectionSettings.State(copyHistorySize = 0))
+
+        assertEquals(0, settings.state.copyHistorySize)
+    }
+
+    @Test
+    fun `loadState clamps invalid history sizes`() {
+        val settings = CopySelectionSettings()
+
+        settings.loadState(CopySelectionSettings.State(copyHistorySize = -1))
+        assertEquals(0, settings.state.copyHistorySize)
+
+        settings.loadState(CopySelectionSettings.State(copyHistorySize = 101))
+        assertEquals(100, settings.state.copyHistorySize)
+    }
 }


### PR DESCRIPTION
## Rationale

Copy history could persist copied code in a shareable project-level XML file, with no way to disable or clear the history and incomplete trimming after a size reduction. This change keeps useful local history while preventing copied context from being written to shareable project settings.

## Implementation

- persist project history in the IDE's local, non-roaming workspace storage and mark `copySelectionHistory.xml` as the deprecated migration source
- treat a history size of `0` as disabled, clear existing entries in that mode, and deterministically retain only the newest entries after any size reduction
- apply the configured limit immediately to all open projects and add a clear-all item to the history popup
- make the persisted history bean writable so IntelliJ's XML serializer saves and reloads entries instead of emitting an empty component
- document the privacy, disable, clear, shrink, and legacy cleanup behavior in all five README variants, including the Traditional Chinese guide added on the latest `main`, and in plugin metadata
- add an actual `ProjectStoreImpl` fixture that loads a marker from the legacy file, saves it only to `workspace.xml`, verifies legacy cleanup, reloads the migrated marker, and covers size-zero and clear persistence after state reset/reload
- align the test runtime with IntelliJ's bundled framework so platform tests use the IDE-patched coroutine classes rather than a shadowing transitive MockK dependency

## Verification

- rebased onto latest `main` (`5c7b806`) before the final validation pass
- focused history persistence/service/settings/bundle tests: passed
- `./gradlew test --rerun-tasks` with JDK 21: passed; 164 tests, 0 failures
- `./gradlew buildPlugin verifyPluginConfiguration --rerun-tasks`: passed; generated `build/distributions/copy-selection-context-1.0.4.zip`
- `unzip -t build/distributions/copy-selection-context-1.0.4.zip`: passed; no archive errors
- isolated `./gradlew verifyPlugin --rerun-tasks` with a fresh `plugin.verifier.home.dir`: passed with Plugin Verifier 1.410; compatible with IntelliJ IDEA IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97

Closes #10
