### PR TITLE
fix(settings): localize output format names

### DIFF
--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionConfigurable.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionConfigurable.kt
@@ -13,7 +13,7 @@ import javax.swing.event.DocumentListener
 class CopySelectionConfigurable : Configurable {
     private val settings = CopySelectionSettings.getInstance()
     private var dialogPanel: DialogPanel? = null
-    private var outputFormatCombo: JComboBox<String>? = null
+    private var outputFormatCombo: JComboBox<OutputFormatOption>? = null
     private var presetCombo: JComboBox<String>? = null
     private var templateTextField: JTextField? = null
     private var previewLabel: JLabel? = null
@@ -32,10 +32,10 @@ class CopySelectionConfigurable : Configurable {
             }
             group(CopySelectionBundle.message("settings.group.output")) {
                 row(CopySelectionBundle.message("settings.format.output.label")) {
-                    comboBox(listOf("claude", "pathline", "template"))
+                    comboBox(OutputFormatOption.entries)
                         .bindItem(
-                            { state.outputFormat },
-                            { state.outputFormat = it ?: "claude" }
+                            { OutputFormatOption.fromKey(state.outputFormat) },
+                            { state.outputFormat = (it ?: OutputFormatOption.default).key }
                         )
                         .comment(CopySelectionBundle.message("settings.format.output.comment"))
                         .also { cell -> outputFormatCombo = cell.component }
@@ -147,7 +147,7 @@ class CopySelectionConfigurable : Configurable {
     }
 
     private fun updateTemplateControls() {
-        val isTemplate = (outputFormatCombo?.selectedItem as? String) == "template"
+        val isTemplate = outputFormatCombo?.selectedItem == OutputFormatOption.TEMPLATE
         presetCombo?.isEnabled = isTemplate
         templateTextField?.isEnabled = isTemplate
         previewLabel?.isEnabled = isTemplate

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionSettings.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionSettings.kt
@@ -33,6 +33,7 @@ class CopySelectionSettings : PersistentStateComponent<CopySelectionSettings.Sta
         if (state.outputFormat == LEGACY_GITHUB_FORMAT) {
             state.outputFormat = DEFAULT_OUTPUT_FORMAT
         }
+        state.outputFormat = OutputFormatOption.fromKey(state.outputFormat).key
         myState = state
     }
 

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/OutputFormatOption.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/OutputFormatOption.kt
@@ -1,0 +1,19 @@
+package com.github.hon454.copyselectioncontext
+
+enum class OutputFormatOption(
+    val key: String,
+    val messageKey: String
+) {
+    CLAUDE("claude", "settings.format.claude"),
+    PATH_LINE("pathline", "settings.format.pathline"),
+    TEMPLATE("template", "settings.format.template");
+
+    override fun toString(): String = CopySelectionBundle.message(messageKey)
+
+    companion object {
+        val default: OutputFormatOption = CLAUDE
+
+        fun fromKey(key: String?): OutputFormatOption =
+            entries.firstOrNull { it.key == key } ?: default
+    }
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionSettingsTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionSettingsTest.kt
@@ -133,4 +133,24 @@ class CopySelectionSettingsTest {
 
         assertEquals("pathline", settings.state.outputFormat)
     }
+
+    @Test
+    fun `loadState preserves supported output format keys`() {
+        OutputFormatOption.entries.forEach { option ->
+            val settings = CopySelectionSettings()
+
+            settings.loadState(CopySelectionSettings.State(outputFormat = option.key))
+
+            assertEquals(option.key, settings.state.outputFormat)
+        }
+    }
+
+    @Test
+    fun `loadState replaces unknown persisted output format with default key`() {
+        val settings = CopySelectionSettings()
+
+        settings.loadState(CopySelectionSettings.State(outputFormat = "legacy-format"))
+
+        assertEquals("claude", settings.state.outputFormat)
+    }
 }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/OutputFormatOptionTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/OutputFormatOptionTest.kt
@@ -1,0 +1,45 @@
+package com.github.hon454.copyselectioncontext
+
+import java.util.Locale
+import java.util.ResourceBundle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OutputFormatOptionTest {
+    @Test
+    fun `known persisted keys map to stable output format options`() {
+        assertEquals(OutputFormatOption.CLAUDE, OutputFormatOption.fromKey("claude"))
+        assertEquals(OutputFormatOption.PATH_LINE, OutputFormatOption.fromKey("pathline"))
+        assertEquals(OutputFormatOption.TEMPLATE, OutputFormatOption.fromKey("template"))
+
+        assertEquals("claude", OutputFormatOption.CLAUDE.key)
+        assertEquals("pathline", OutputFormatOption.PATH_LINE.key)
+        assertEquals("template", OutputFormatOption.TEMPLATE.key)
+    }
+
+    @Test
+    fun `unknown and legacy persisted keys fall back to claude`() {
+        assertEquals(OutputFormatOption.CLAUDE, OutputFormatOption.fromKey(""))
+        assertEquals(OutputFormatOption.CLAUDE, OutputFormatOption.fromKey("custom"))
+        assertEquals(OutputFormatOption.CLAUDE, OutputFormatOption.fromKey("Claude Code (@path#L)"))
+    }
+
+    @Test
+    fun `English and Korean bundles localize every output format option`() {
+        val control = ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_PROPERTIES)
+        val english = ResourceBundle.getBundle("messages.CopySelectionBundle", Locale.ENGLISH, control)
+        val korean = ResourceBundle.getBundle("messages.CopySelectionBundle", Locale.KOREAN, control)
+
+        OutputFormatOption.entries.forEach { option ->
+            assertTrue(english.getString(option.messageKey).isNotBlank())
+            assertTrue(korean.getString(option.messageKey).isNotBlank())
+            assertEquals(CopySelectionBundle.message(option.messageKey), option.toString())
+        }
+
+        assertEquals("Path:Line (path:line)", english.getString(OutputFormatOption.PATH_LINE.messageKey))
+        assertEquals("경로:줄 (path:line)", korean.getString(OutputFormatOption.PATH_LINE.messageKey))
+        assertEquals("Custom Template", english.getString(OutputFormatOption.TEMPLATE.messageKey))
+        assertEquals("사용자 정의 템플릿", korean.getString(OutputFormatOption.TEMPLATE.messageKey))
+    }
+}


### PR DESCRIPTION
## Rationale

The output-format combo box displayed persistence keys such as `claude`, `pathline`, and `template`, even though localized English and Korean names already exist in the message bundles.

## Implementation

- Add key-backed output-format options whose UI labels resolve through `CopySelectionBundle`.
- Bind the settings combo box to localized option objects while persisting only stable internal keys.
- Normalize unknown or legacy persisted format values to the safe Claude default when settings load.
- Cover key mapping, fallback behavior, settings-state loading, and English/Korean bundle values with focused tests.

## Verification

- `./gradlew --no-daemon --rerun-tasks test` — passed; 159 tests executed.
- `./gradlew --no-daemon verifyPlugin` with an isolated Plugin Verifier home — passed against IntelliJ IDEA IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97; all reported Compatible.
- `git diff --check` — passed.

## Manual testing steps

- [ ] With the IDE language set to English, open Settings > Tools > Copy Selection Context and confirm the output-format choices show `Claude Code (@path#L)`, `Path:Line (path:line)`, and `Custom Template`.
- [ ] With the IDE language set to Korean, reopen the same settings page and confirm the output-format choices show the Korean bundle values.
- [ ] Select each format, apply settings, and confirm the persisted `outputFormat` value remains `claude`, `pathline`, or `template`.

Closes #13
