### PR TITLE
docs: align release guidance with changelog workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,10 +42,11 @@ cmd //c "gradlew.bat publishPlugin"  # Publish to Marketplace (requires PUBLISH_
 
 ### Release Process
 
-1. Bump `version` in `build.gradle.kts` to match the tag
-2. Commit, tag (`v<major>.<minor>.<patch>`), push
-3. `release.yml` auto-creates GitHub Release with commit-based release notes
-4. JetBrains Marketplace publish activates when signing secrets are configured
+1. Update the `[Unreleased]` entries in `CHANGELOG.md`
+2. Bump `version` in `build.gradle.kts`, then run `cmd //c "gradlew.bat patchChangelog"`
+3. Commit the version and changelog, tag (`v<major>.<minor>.<patch>`), and push
+4. `release.yml` generates GitHub Release notes from the matching `CHANGELOG.md` section with `getChangelog`
+5. JetBrains Marketplace publishing runs only when `PUBLISH_TOKEN`, `CERTIFICATE_CHAIN`, and `PRIVATE_KEY` are all non-empty
 
 **Version rule**: Tag version must match `build.gradle.kts` `version` — workflow fails on mismatch.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,45 +45,68 @@ src/main/kotlin/com/github/hon454/copyselectioncontext/
 
 ## Release Process
 
-Releases are automated via GitHub Actions. Pushing a version tag triggers the workflow.
+Releases are automated by [`.github/workflows/release.yml`](.github/workflows/release.yml). Pushing a tag that starts with `v` triggers the workflow.
 
 ### Steps
 
-1. **Update the version** in `build.gradle.kts`:
+1. **Update the `[Unreleased]` section** in [`CHANGELOG.md`](CHANGELOG.md) with the user-visible changes in the release. Keep entries under the appropriate Keep a Changelog headings, such as `Added`, `Changed`, or `Fixed`.
+
+2. **Update the version** in `build.gradle.kts`:
    ```kotlin
    version = "1.2.0"
    ```
 
-2. **Commit the version bump**:
+3. **Patch the changelog** with the Gradle Changelog Plugin. The task moves the `[Unreleased]` entries into a versioned `1.2.0` section and creates a new `[Unreleased]` section:
    ```bash
-   git add build.gradle.kts
-   git commit -m "chore: bump version to 1.2.0"
+   # Unix / macOS
+   ./gradlew patchChangelog
+
+   # Windows
+   gradlew.bat patchChangelog
    ```
 
-3. **Create and push the tag**:
+4. **Preview the release notes** with the same changelog task options used by the release workflow:
+   ```bash
+   ./gradlew getChangelog \
+     --console=plain \
+     -q \
+     --no-header \
+     --no-links \
+     --no-summary
+   ```
+
+5. **Commit the version and changelog updates** using the repository's commit convention:
+   ```bash
+   git add build.gradle.kts CHANGELOG.md
+   git commit -m "chore(release): prepare 1.2.0" \
+     -m "Move the accumulated changelog entries into the 1.2.0 release and align the Gradle project version with the release tag."
+   ```
+
+6. **Create and push the tag** after the release commit is on `main`:
    ```bash
    git tag v1.2.0
    git push origin main v1.2.0
    ```
 
-4. The **Release workflow** (`release.yml`) runs automatically and:
+7. The **Release workflow** runs automatically and:
    - Verifies the tag version matches `build.gradle.kts`
+   - Generates release notes from the matching version section in `CHANGELOG.md`
    - Builds the plugin
-   - Creates a GitHub Release with commit-based release notes
+   - Creates a non-draft, non-prerelease GitHub Release named after the tag
    - Attaches the plugin ZIP to the release
-   - Publishes to JetBrains Marketplace (if signing secrets are configured)
+   - Publishes to JetBrains Marketplace only when `PUBLISH_TOKEN`, `CERTIFICATE_CHAIN`, and `PRIVATE_KEY` are all non-empty
 
 ### Version Rules
 
-- Tag format: `v<major>.<minor>.<patch>` (e.g., `v1.2.0`)
-- Tag version **must match** the `version` in `build.gradle.kts` — the workflow fails otherwise
+- The workflow is triggered by any pushed tag matching `v*`; release tags use `v<major>.<minor>.<patch>` (for example, `v1.2.0`)
+- The part after `v` **must match exactly** the `version` in `build.gradle.kts` — the workflow fails otherwise
 - Follow [Semantic Versioning](https://semver.org/): breaking → major, feature → minor, fix → patch
 
 ### Release Notes
 
-Release notes are generated automatically from the commit history between the previous tag and the current tag. Merge commits are excluded. Each entry links to the full commit on GitHub.
+[`CHANGELOG.md`](CHANGELOG.md) is the single source of truth for release notes. The workflow runs `getChangelog` for the project version without the section header, comparison links, or summary and writes the result to `release-notes.md`. If that output is empty, it uses `Release v<version>` as a fallback.
 
-Since commit messages become the public release notes, write them clearly following the [Commit Convention](#commit-convention) below.
+Keep `[Unreleased]` current as changes land, then run `patchChangelog` after setting the release version so the workflow can find the matching version section. Commit messages remain important for review and repository history, but they are not used to generate release notes.
 
 ### JetBrains Marketplace Publishing
 
@@ -94,7 +117,9 @@ Publishing activates automatically when the following GitHub repository secrets 
 | `PUBLISH_TOKEN` | JetBrains Marketplace API token |
 | `CERTIFICATE_CHAIN` | Plugin signing certificate (`chain.crt` contents) |
 | `PRIVATE_KEY` | Unencrypted private key (`private.pem` contents) |
-| `PRIVATE_KEY_PASSWORD` | Private key password |
+| `PRIVATE_KEY_PASSWORD` | Password for an encrypted private key; passed to Gradle when configured |
+
+The workflow checks `PUBLISH_TOKEN`, `CERTIFICATE_CHAIN`, and `PRIVATE_KEY` before running `publishPlugin`. If any of those three values is empty, the GitHub Release is still created but Marketplace publishing is skipped. `PRIVATE_KEY_PASSWORD` is available to the signing configuration but is not part of the workflow condition, so it may be empty when the private key is unencrypted.
 
 To generate signing certificates:
 
@@ -106,15 +131,20 @@ openssl req -key private.pem -new -x509 -days 365 -out chain.crt
 
 ## Commit Convention
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/) format.
+Follow [Conventional Commits](https://www.conventionalcommits.org/) and the repository rules in [`AGENTS.md`](AGENTS.md#commit-convention).
 
 ```
-type[(scope)]: concise subject
+type[(scope)]: concise subject (imperative mood, lowercase, no period)
 
-Body explaining WHY this change was made.
+Body paragraph explaining WHY this change was made and WHAT it accomplishes.
+Include context that is not obvious from the diff alone.
 ```
 
 **Allowed types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, `perf`, `style`, `build`, `asset`
+
+- Keep the subject at 72 characters or fewer, use imperative mood, start the text after the colon in lowercase, and omit a trailing period
+- Include a body for every non-trivial commit, separated from the subject by a blank line
+- Do not add AI agent attribution, co-author trailers, or tool-credit footers
 
 ## Pull Requests
 

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseDocumentationTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseDocumentationTest.kt
@@ -1,0 +1,70 @@
+package com.github.hon454.copyselectioncontext
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class ReleaseDocumentationTest {
+    private val projectRoot: Path = Path.of(System.getProperty("user.dir"))
+    private val contributing = readProjectFile("CONTRIBUTING.md")
+    private val agents = readProjectFile("AGENTS.md")
+    private val releaseWorkflow = readProjectFile(".github/workflows/release.yml")
+
+    @Test
+    fun `release guidance uses the changelog workflow commands`() {
+        val getChangelogArguments = listOf(
+            "./gradlew getChangelog",
+            "--console=plain",
+            "-q",
+            "--no-header",
+            "--no-links",
+            "--no-summary",
+        )
+
+        assertContains(contributing, "CHANGELOG.md")
+        assertContains(contributing, "./gradlew patchChangelog")
+        getChangelogArguments.forEach { argument ->
+            assertContains(contributing, argument)
+            assertContains(releaseWorkflow, argument)
+        }
+        assertFalse(contributing.contains("commit-based release notes"))
+        assertFalse(agents.contains("commit-based release notes"))
+    }
+
+    @Test
+    fun `release guidance matches tag and marketplace workflow conditions`() {
+        assertContains(releaseWorkflow, "- 'v*'")
+        assertContains(contributing, "any pushed tag matching `v*`")
+        assertContains(contributing, "must match exactly")
+        assertContains(releaseWorkflow, "env.PUBLISH_TOKEN != '' &&")
+        assertContains(releaseWorkflow, "env.CERTIFICATE_CHAIN != '' &&")
+        assertContains(releaseWorkflow, "env.PRIVATE_KEY != ''")
+        assertContains(
+            contributing,
+            "`PUBLISH_TOKEN`, `CERTIFICATE_CHAIN`, and `PRIVATE_KEY` are all non-empty",
+        )
+        assertContains(contributing, "`PRIVATE_KEY_PASSWORD` is available to the signing configuration")
+    }
+
+    @Test
+    fun `contributing commit types stay aligned with agent guidance`() {
+        assertEquals(commitTypes(agents), commitTypes(contributing))
+        assertContains(contributing, "72 characters or fewer")
+        assertContains(contributing, "body for every non-trivial commit")
+        assertContains(contributing, "Do not add AI agent attribution")
+    }
+
+    private fun readProjectFile(relativePath: String): String =
+        Files.readString(projectRoot.resolve(relativePath))
+
+    private fun commitTypes(document: String): List<String> =
+        Regex("\\*\\*Allowed types:\\*\\* ([^\\n]+)")
+            .find(document)
+            ?.groupValues
+            ?.get(1)
+            ?.split(", ")
+            ?: emptyList()
+}


### PR DESCRIPTION
## Rationale

`CONTRIBUTING.md` still described commit-history release notes even though `release.yml` now builds them from `CHANGELOG.md`. This update makes the maintainer instructions match the automated release path and the repository's commit rules.

## Implementation

- document updating `[Unreleased]`, bumping the Gradle version, running `patchChangelog`, and previewing notes with the workflow's `getChangelog` options
- clarify the `v*` trigger, exact tag/version match, GitHub Release behavior, signing inputs, and conditional Marketplace publishing
- synchronize the concise release summary in `AGENTS.md` without changing the multilingual README files introduced by PR #4
- add `ReleaseDocumentationTest` to detect drift between `CONTRIBUTING.md`, `release.yml`, and the `AGENTS.md` commit convention

## Verification

- `mise exec java@21 -- ./gradlew test --stacktrace` — passed the full test suite
- `mise exec java@21 -- ./gradlew test --tests com.github.hon454.copyselectioncontext.ReleaseDocumentationTest --stacktrace` — passed all 3 focused documentation contract tests
- `mise exec java@21 -- ./gradlew buildPlugin --stacktrace` — built `build/distributions/copy-selection-context-1.0.4.zip`
- `mise exec java@21 -- ./gradlew getChangelog --console=plain -q --no-header --no-links --no-summary` — produced the current version's `Changed` and `Fixed` release notes
- `mise exec java@21 -- ./gradlew verifyPlugin --stacktrace --no-parallel --max-workers=1` with an isolated Java user home — verified compatible with IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97
- `git diff --check` — passed
- checked Markdown fence balance and confirmed every local link added to `CONTRIBUTING.md` resolves

## Manual testing

- compared each documented release step and publishing condition with `.github/workflows/release.yml`
- reviewed the rendered Markdown structure, command blocks, tables, and relative links

Closes #18
