### PR TITLE
fix: honor exclusive selection end offsets

### DIFF
--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyGitPermalinkAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyGitPermalinkAction.kt
@@ -3,7 +3,6 @@ package com.github.hon454.copyselectioncontext
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.ProjectLevelVcsManager
@@ -18,7 +17,7 @@ class CopyGitPermalinkAction : AnAction() {
         val editor = e.getData(CommonDataKeys.EDITOR) ?: return
         val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
 
-        val (startLine, endLine) = resolveLineNumbers(editor)
+        val (startLine, endLine) = CopySelectionUtils.resolveLineNumbers(editor)
         val permalink = tryBuildPermalink(project, file, startLine, endLine)
             ?: fallbackPath(project, file, startLine, endLine)
 
@@ -29,19 +28,6 @@ class CopyGitPermalinkAction : AnAction() {
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabledAndVisible = e.getData(CommonDataKeys.PROJECT) != null &&
             e.getData(CommonDataKeys.EDITOR) != null
-    }
-
-    private fun resolveLineNumbers(editor: Editor): Pair<Int, Int> {
-        val selectionModel = editor.selectionModel
-        val document = editor.document
-        return if (selectionModel.hasSelection()) {
-            val startLine = document.getLineNumber(selectionModel.selectionStart) + 1
-            val endLine = document.getLineNumber(selectionModel.selectionEnd) + 1
-            Pair(startLine, endLine)
-        } else {
-            val currentLine = editor.caretModel.logicalPosition.line + 1
-            Pair(currentLine, currentLine)
-        }
     }
 
     private fun tryBuildPermalink(

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
@@ -80,16 +80,7 @@ abstract class CopySelectionBaseAction : AnAction() {
     }
 
     protected fun resolveLineNumbers(editor: Editor): Pair<Int, Int> {
-        val selectionModel = editor.selectionModel
-        val document = editor.document
-        return if (selectionModel.hasSelection()) {
-            val startLine = document.getLineNumber(selectionModel.selectionStart) + 1
-            val endLine = document.getLineNumber(selectionModel.selectionEnd) + 1
-            Pair(startLine, endLine)
-        } else {
-            val currentLine = editor.caretModel.logicalPosition.line + 1
-            Pair(currentLine, currentLine)
-        }
+        return CopySelectionUtils.resolveLineNumbers(editor)
     }
 
     protected fun formatWithSettings(path: String, startLine: Int, endLine: Int, code: String? = null, language: String = ""): String {

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionUtils.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionUtils.kt
@@ -70,24 +70,23 @@ object CopySelectionUtils {
     }
 
     fun resolveLineRange(editor: Editor): String {
+        val (startLine, endLine) = resolveLineNumbers(editor)
+        return toLineRange(startLine, endLine)
+    }
+
+    fun resolveLineNumbers(editor: Editor): Pair<Int, Int> {
         val selectionModel = editor.selectionModel
-        val document = editor.document
         return if (selectionModel.hasSelection()) {
-            val startLine = document.getLineNumber(selectionModel.selectionStart) + 1
-            val endLine = document.getLineNumber(selectionModel.selectionEnd) + 1
-            if (startLine == endLine) "$startLine" else "$startLine-$endLine"
+            resolveSelectedLineNumbers(editor, selectionModel.selectionStart, selectionModel.selectionEnd)
         } else {
             val currentLine = editor.caretModel.logicalPosition.line + 1
-            "$currentLine"
+            Pair(currentLine, currentLine)
         }
     }
 
     fun resolveLineNumbers(editor: Editor, caret: Caret): Pair<Int, Int> {
-        val document = editor.document
         return if (caret.hasSelection()) {
-            val startLine = document.getLineNumber(caret.selectionStart) + 1
-            val endLine = document.getLineNumber(caret.selectionEnd) + 1
-            Pair(startLine, endLine)
+            resolveSelectedLineNumbers(editor, caret.selectionStart, caret.selectionEnd)
         } else {
             val currentLine = caret.logicalPosition.line + 1
             Pair(currentLine, currentLine)
@@ -118,6 +117,14 @@ object CopySelectionUtils {
 
     fun toLineRange(startLine: Int, endLine: Int): String {
         return if (startLine == endLine) "$startLine" else "$startLine-$endLine"
+    }
+
+    private fun resolveSelectedLineNumbers(editor: Editor, selectionStart: Int, selectionEnd: Int): Pair<Int, Int> {
+        val document = editor.document
+        val startLine = document.getLineNumber(selectionStart) + 1
+        val finalIncludedOffset = selectionEnd - 1
+        val endLine = document.getLineNumber(finalIncludedOffset) + 1
+        return Pair(startLine, endLine)
     }
 
     fun getCodeContent(editor: Editor): String {

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionActionTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionActionTest.kt
@@ -30,7 +30,7 @@ class CopySelectionActionTest {
         every { selectionModel.selectionStart } returns 0
         every { selectionModel.selectionEnd } returns 20
         every { document.getLineNumber(0) } returns 0
-        every { document.getLineNumber(20) } returns 2
+        every { document.getLineNumber(19) } returns 2
 
         val result = CopySelectionUtils.resolveLineRange(editor)
 

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionUtilsTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionUtilsTest.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.VirtualFile
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -53,12 +54,10 @@ class CopySelectionUtilsTest {
         every { caret1.selectionStart } returns 0
         every { caret1.selectionEnd } returns 10
         every { document.getLineNumber(0) } returns 0
-        every { document.getLineNumber(10) } returns 1
+        every { document.getLineNumber(9) } returns 1
 
-        every { caret2.hasSelection() } returns true
-        every { caret2.selectionStart } returns 30
-        every { caret2.selectionEnd } returns 30
-        every { document.getLineNumber(30) } returns 3
+        every { caret2.hasSelection() } returns false
+        every { caret2.logicalPosition } returns LogicalPosition(3, 0)
 
         every { caretModel.runForEachCaret(any<CaretAction>()) } answers {
             val action = firstArg<CaretAction>()
@@ -126,11 +125,87 @@ class CopySelectionUtilsTest {
         every { selectionModel.selectionStart } returns 10
         every { selectionModel.selectionEnd } returns 20
         every { document.getLineNumber(10) } returns 1
-        every { document.getLineNumber(20) } returns 3
+        every { document.getLineNumber(19) } returns 3
 
         val result = CopySelectionUtils.resolveLineRange(editor)
 
         assertEquals("2-4", result)
+    }
+
+    @Test
+    fun `resolveLineNumbers excludes the line at the selection end offset`() {
+        val editor = mockk<Editor>()
+        val selectionModel = mockk<SelectionModel>()
+        val document = mockk<Document>()
+
+        every { editor.selectionModel } returns selectionModel
+        every { editor.document } returns document
+        every { selectionModel.hasSelection() } returns true
+        every { selectionModel.selectionStart } returns 0
+        every { selectionModel.selectionEnd } returns 6
+        every { document.getLineNumber(0) } returns 0
+        every { document.getLineNumber(5) } returns 0
+
+        val result = CopySelectionUtils.resolveLineNumbers(editor)
+
+        assertEquals(Pair(1, 1), result)
+        verify(exactly = 0) { document.getLineNumber(6) }
+    }
+
+    @Test
+    fun `resolveLineNumbers handles a selection ending at EOF`() {
+        val editor = mockk<Editor>()
+        val selectionModel = mockk<SelectionModel>()
+        val document = mockk<Document>()
+
+        every { editor.selectionModel } returns selectionModel
+        every { editor.document } returns document
+        every { selectionModel.hasSelection() } returns true
+        every { selectionModel.selectionStart } returns 6
+        every { selectionModel.selectionEnd } returns 12
+        every { document.getLineNumber(6) } returns 1
+        every { document.getLineNumber(11) } returns 1
+
+        val result = CopySelectionUtils.resolveLineNumbers(editor)
+
+        assertEquals(Pair(2, 2), result)
+    }
+
+    @Test
+    fun `resolveLineNumbers excludes the empty line after a trailing newline`() {
+        val editor = mockk<Editor>()
+        val selectionModel = mockk<SelectionModel>()
+        val document = mockk<Document>()
+
+        every { editor.selectionModel } returns selectionModel
+        every { editor.document } returns document
+        every { selectionModel.hasSelection() } returns true
+        every { selectionModel.selectionStart } returns 0
+        every { selectionModel.selectionEnd } returns 6
+        every { document.getLineNumber(0) } returns 0
+        every { document.getLineNumber(5) } returns 0
+
+        val result = CopySelectionUtils.resolveLineNumbers(editor)
+
+        assertEquals(Pair(1, 1), result)
+    }
+
+    @Test
+    fun `resolveLineNumbers uses the current line for an empty selection`() {
+        val editor = mockk<Editor>()
+        val selectionModel = mockk<SelectionModel>()
+        val caretModel = mockk<CaretModel>()
+
+        every { editor.selectionModel } returns selectionModel
+        every { editor.caretModel } returns caretModel
+        every { selectionModel.hasSelection() } returns false
+        every { selectionModel.selectionStart } returns 8
+        every { selectionModel.selectionEnd } returns 8
+        every { caretModel.logicalPosition } returns LogicalPosition(2, 4)
+
+        val result = CopySelectionUtils.resolveLineNumbers(editor)
+
+        assertEquals(Pair(3, 3), result)
     }
 
     @Test
@@ -269,7 +344,7 @@ class CopySelectionUtilsTest {
         every { selectionModel.selectionStart } returns 10
         every { selectionModel.selectionEnd } returns 15
         every { document.getLineNumber(10) } returns 5
-        every { document.getLineNumber(15) } returns 5
+        every { document.getLineNumber(14) } returns 5
 
         val result = CopySelectionUtils.resolveLineRange(editor)
 


### PR DESCRIPTION
## Rationale

IntelliJ selection end offsets are exclusive, so resolving the end offset directly can add the following line when a selection stops at that line's first character.

## Implementation

- Resolve non-empty selection end lines from the final included character (`selectionEnd - 1`).
- Centralize editor and caret line-number resolution in `CopySelectionUtils`.
- Reuse the centralized calculation from regular copy, multi-caret copy, highlighting, and Git permalink actions.
- Add focused regressions for line-start boundaries, EOF, trailing newlines, and empty-selection current-line fallback.

## Verification

- `env JAVA_HOME=/private/tmp/copy-selection-context-jdk21/Contents/Home GRADLE_USER_HOME=/private/tmp/copy-selection-context-gradle-home ./gradlew test`
  - `BUILD SUCCESSFUL`; 158 tests, 0 failures, 0 errors.
- `env JAVA_HOME=/private/tmp/copy-selection-context-jdk21/Contents/Home GRADLE_USER_HOME=/private/tmp/copy-selection-context-gradle-home JAVA_TOOL_OPTIONS=-Dplugin.verifier.home.dir=/private/tmp/copy-selection-context-plugin-verifier ./gradlew verifyPlugin`
  - `BUILD SUCCESSFUL`; compatible with IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97.
- `git diff --check`
  - Passed with no whitespace errors.

Closes #6
