### PR TITLE
fix: synchronize Korean resource bundle keys

### DIFF
--- a/src/main/resources/messages/CopySelectionBundle_ko.properties
+++ b/src/main/resources/messages/CopySelectionBundle_ko.properties
@@ -36,7 +36,7 @@ settings.format.output.comment=claude = @path#L \ud615\uc2dd, pathline = path:li
 settings.template.variables.comment={path} {line} {range} {code} {lang} {filename}
 settings.history.size.label=\ud788\uc2a4\ud1a0\ub9ac \ud06c\uae30:
 settings.history.size.comment=0\uc73c\ub85c \uc124\uc815\ud558\uba74 \ud788\uc2a4\ud1a0\ub9ac\uac00 \ube44\ud65c\uc131\ud654\ub429\ub2c8\ub2e4. \ud788\uc2a4\ud1a0\ub9ac\ub294 \ub85c\uceec IDE \uc791\uc5c5 \uacf5\uac04\uc5d0\ub9cc \uc800\uc7a5\ub429\ub2c8\ub2e4.
-settings.project.title=Copy Selection Context (\ud504\ub85c\uc81d\ud2b8)
-settings.project.group=\ud504\ub85c\uc81d\ud2b8 \uc124\uc815
-settings.project.use.project=\ud504\ub85c\uc81d\ud2b8\ubcc4 \uc124\uc815 \uc0ac\uc6a9 (\uc560\ud50c\ub9ac\ucf00\uc774\uc158 \uc124\uc815 \uc7ac\uc815\uc758)
-settings.project.path.label=\uacbd\ub85c \uc720\ud615:
+settings.template.preset.label=\ud15c\ud50c\ub9bf \ud504\ub9ac\uc14b:
+settings.template.preset.custom=\uc0ac\uc6a9\uc790 \uc815\uc758
+settings.template.preview.label=\ubbf8\ub9ac\ubcf4\uae30:
+settings.template.validation.unknown=\uc54c \uc218 \uc5c6\ub294 \ubcc0\uc218: {0}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBundleTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBundleTest.kt
@@ -1,9 +1,24 @@
 package com.github.hon454.copyselectioncontext
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.util.Properties
 
 class CopySelectionBundleTest {
+
+    @Test
+    fun `Korean bundle has the same keys as the base bundle`() {
+        val baseKeys = loadBundleKeys("messages/CopySelectionBundle.properties")
+        val koreanKeys = loadBundleKeys("messages/CopySelectionBundle_ko.properties")
+
+        assertEquals(
+            baseKeys,
+            koreanKeys,
+            "Korean bundle keys must match the base bundle. " +
+                "Missing: ${baseKeys - koreanKeys}; Extra: ${koreanKeys - baseKeys}"
+        )
+    }
 
     @Test
     fun `notification copied key resolves`() {
@@ -91,5 +106,14 @@ class CopySelectionBundleTest {
         ).forEach { key ->
             assertTrue(CopySelectionBundle.message(key).isNotBlank(), "Key '$key' should resolve to non-blank string")
         }
+    }
+
+    private fun loadBundleKeys(resourcePath: String): Set<String> {
+        val properties = Properties()
+        val stream = requireNotNull(javaClass.classLoader.getResourceAsStream(resourcePath)) {
+            "Missing test resource: $resourcePath"
+        }
+        stream.use(properties::load)
+        return properties.stringPropertyNames()
     }
 }


### PR DESCRIPTION
## Rationale

The Korean resource bundle fell back to English for the active template preset, preview, and validation controls, while still carrying project-setting keys that no runtime code uses.

## Implementation

- add Korean translations for the four active template settings keys
- remove the four obsolete `settings.project.*` entries after confirming there are no runtime, test, or plugin descriptor references
- add a bundle parity test that reports missing and extra Korean keys when the base bundle changes

## Verification

- `./gradlew test --rerun-tasks` — 155 tests passed with 0 failures and 0 errors
- `./gradlew verifyPlugin` — compatible with IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97
- `./gradlew runIde -Duser.language=ko -Duser.country=KR` — sandbox IDE launched and exited successfully with the Korean JVM locale
- `git diff --check` — passed

## Manual testing

- reviewed the Korean resource values for `템플릿 프리셋`, `사용자 정의`, `미리보기`, and `알 수 없는 변수: {0}`
- confirmed `settings.project.*` has no references under `src/main` or `src/test`
- the sandbox IDE exposed a nonstandard JBR `Main` process, so automated accessibility inspection of the live settings dialog was not available

Closes #14
