### PR TITLE
fix: keep copy previews concise and safe

### DIFF
--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyPreview.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyPreview.kt
@@ -1,0 +1,87 @@
+package com.github.hon454.copyselectioncontext
+
+import java.lang.Character.isISOControl
+import java.lang.Character.isSpaceChar
+import java.lang.Character.isWhitespace
+
+internal object CopyPreview {
+    const val NOTIFICATION_MAX_LENGTH = 120
+    const val STATUS_MAX_LENGTH = 40
+    const val TOOLTIP_MAX_LENGTH = 120
+
+    private const val ELLIPSIS = "…"
+
+    fun notification(content: String): String = create(content, NOTIFICATION_MAX_LENGTH)
+
+    fun status(content: String, maxLength: Int = STATUS_MAX_LENGTH): String = create(content, maxLength)
+
+    fun tooltip(content: String): String = create(content, TOOLTIP_MAX_LENGTH)
+
+    internal fun create(content: String, maxLength: Int): String {
+        require(maxLength > 0) { "maxLength must be positive" }
+
+        val preview = StringBuilder(maxLength)
+        val tokenLengths = ArrayDeque<Int>()
+        var index = 0
+        var pendingSpace = false
+
+        while (index < content.length) {
+            val codePoint = content.codePointAt(index)
+            index += Character.charCount(codePoint)
+
+            if (isPreviewWhitespace(codePoint)) {
+                pendingSpace = preview.isNotEmpty()
+                continue
+            }
+
+            if (pendingSpace) {
+                if (!appendToken(preview, tokenLengths, " ", maxLength)) {
+                    return appendEllipsis(preview, tokenLengths, maxLength)
+                }
+                pendingSpace = false
+            }
+
+            val token = escapeMarkup(codePoint)
+            if (!appendToken(preview, tokenLengths, token, maxLength)) {
+                return appendEllipsis(preview, tokenLengths, maxLength)
+            }
+        }
+
+        return preview.toString()
+    }
+
+    private fun isPreviewWhitespace(codePoint: Int): Boolean =
+        isWhitespace(codePoint) || isSpaceChar(codePoint) || isISOControl(codePoint)
+
+    private fun escapeMarkup(codePoint: Int): String = when (codePoint) {
+        '&'.code -> "&amp;"
+        '<'.code -> "&lt;"
+        '>'.code -> "&gt;"
+        '"'.code -> "&quot;"
+        '\''.code -> "&#39;"
+        else -> String(Character.toChars(codePoint))
+    }
+
+    private fun appendToken(
+        preview: StringBuilder,
+        tokenLengths: ArrayDeque<Int>,
+        token: String,
+        maxLength: Int
+    ): Boolean {
+        if (preview.length + token.length > maxLength) return false
+        preview.append(token)
+        tokenLengths.addLast(token.length)
+        return true
+    }
+
+    private fun appendEllipsis(
+        preview: StringBuilder,
+        tokenLengths: ArrayDeque<Int>,
+        maxLength: Int
+    ): String {
+        while (preview.length + ELLIPSIS.length > maxLength && tokenLengths.isNotEmpty()) {
+            preview.setLength(preview.length - tokenLengths.removeLast())
+        }
+        return preview.append(ELLIPSIS).toString()
+    }
+}

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionNotifier.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionNotifier.kt
@@ -8,11 +8,11 @@ object CopySelectionNotifier {
     fun notify(project: Project?, message: String) {
         if (project == null) return
         if (!CopySelectionSettings.getInstance().state.enableNotification) return
-        
+
         NotificationGroupManager.getInstance()
             .getNotificationGroup("CopySelectionContext")
             .createNotification(
-                CopySelectionBundle.message("notification.copied", message),
+                notificationText(message),
                 NotificationType.INFORMATION
             )
             .notify(project)
@@ -29,4 +29,7 @@ object CopySelectionNotifier {
             )
             .notify(project)
     }
+
+    internal fun notificationText(message: String): String =
+        CopySelectionBundle.message("notification.copied", CopyPreview.notification(message))
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionStatusBarWidget.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionStatusBarWidget.kt
@@ -15,21 +15,28 @@ class CopySelectionStatusBarWidget(project: Project) :
 
     companion object {
         const val ID = "CopySelectionStatusBarWidget"
+        private const val STATUS_PREFIX = "📋 "
     }
 
     private val lastCopied = AtomicReference("")
 
     override fun ID() = ID
     override fun getPresentation() = this
-    override fun getText() = lastCopied.get().let { if (it.isBlank()) "" else "📋 ${it.take(40)}" }
-    override fun getTooltipText() = lastCopied.get().ifBlank { CopySelectionBundle.message("widget.tooltip") }
+    override fun getText() = lastCopied.get().let { content ->
+        if (content.isBlank()) {
+            ""
+        } else {
+            STATUS_PREFIX + CopyPreview.status(content, CopyPreview.STATUS_MAX_LENGTH - STATUS_PREFIX.length)
+        }
+    }
+
+    override fun getTooltipText() = lastCopied.get().let { content ->
+        if (content.isBlank()) CopySelectionBundle.message("widget.tooltip") else CopyPreview.tooltip(content)
+    }
     override fun getAlignment() = 0f
 
     override fun getClickConsumer() = Consumer<MouseEvent> {
-        val content = lastCopied.get()
-        if (content.isNotBlank()) {
-            CopyPasteManager.getInstance().setContents(StringSelection(content))
-        }
+        copyLastValue()
     }
 
     override fun install(statusBar: StatusBar) {
@@ -39,5 +46,12 @@ class CopySelectionStatusBarWidget(project: Project) :
     fun update(content: String) {
         lastCopied.set(content)
         myStatusBar?.updateWidget(ID)
+    }
+
+    private fun copyLastValue() {
+        val content = lastCopied.get()
+        if (content.isNotBlank()) {
+            CopyPasteManager.getInstance().setContents(StringSelection(content))
+        }
     }
 }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopyHistoryServiceTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopyHistoryServiceTest.kt
@@ -110,4 +110,14 @@ class CopyHistoryServiceTest {
         assertEquals(CopyHistoryPopup.PopupItem.ClearAll, clearAll)
         assertTrue(service.getEntries().isEmpty())
     }
+
+    @Test
+    fun `history preserves complete copied content`() {
+        val service = CopyHistoryService()
+        val content = "src/App.kt:10-20\n<script>😀 ${"x".repeat(10_000)}</script>"
+
+        service.addEntry(content)
+
+        assertEquals(content, service.getEntries().single().content)
+    }
 }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopyPreviewTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopyPreviewTest.kt
@@ -1,0 +1,64 @@
+package com.github.hon454.copyselectioncontext
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CopyPreviewTest {
+    @Test
+    fun `multiline content becomes a single line`() {
+        val content = "src/main/App.kt:10-12\r\n```kotlin\n\tfun main() = Unit\n```"
+
+        val preview = CopyPreview.create(content, 120)
+
+        assertEquals(
+            "src/main/App.kt:10-12 ```kotlin fun main() = Unit ```",
+            preview
+        )
+        assertFalse(preview.any { it == '\n' || it == '\r' || it == '\t' })
+    }
+
+    @Test
+    fun `very large content is bounded and marked as truncated`() {
+        val content = "src/main/Large.kt:1-5000\n" + "x".repeat(100_000)
+
+        val preview = CopyPreview.create(content, 80)
+
+        assertTrue(preview.startsWith("src/main/Large.kt:1-5000 "))
+        assertTrue(preview.endsWith("…"))
+        assertTrue(preview.length <= 80)
+    }
+
+    @Test
+    fun `unicode content is not split during truncation`() {
+        val preview = CopyPreview.create("가😀나다라마바사", 5)
+
+        assertEquals("가😀나…", preview)
+        assertTrue(preview.hasOnlyPairedSurrogates())
+        assertTrue(preview.length <= 5)
+    }
+
+    @Test
+    fun `markup-like content is escaped without partial entities`() {
+        val preview = CopyPreview.create("src/App.kt:7\n<script title=\"x\">& 'value'</script>", 120)
+
+        assertEquals(
+            "src/App.kt:7 &lt;script title=&quot;x&quot;&gt;&amp; &#39;value&#39;&lt;/script&gt;",
+            preview
+        )
+        assertFalse(preview.contains("<script"))
+    }
+
+    private fun String.hasOnlyPairedSurrogates(): Boolean {
+        forEachIndexed { index, character ->
+            if (character.isHighSurrogate()) {
+                if (index + 1 >= length || !this[index + 1].isLowSurrogate()) return false
+            }
+            if (character.isLowSurrogate()) {
+                if (index == 0 || !this[index - 1].isHighSurrogate()) return false
+            }
+        }
+        return true
+    }
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionNotifierTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionNotifierTest.kt
@@ -7,6 +7,8 @@ import io.mockk.unmockkObject
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class CopySelectionNotifierTest {
 
@@ -42,5 +44,18 @@ class CopySelectionNotifierTest {
         val mockProject = mockk<com.intellij.openapi.project.Project>()
         
         CopySelectionNotifier.notify(mockProject, "test message")
+    }
+
+    @Test
+    fun `notification text uses a safe bounded preview`() {
+        val message = "src/App.kt:10-20\n<script>😀 ${"x".repeat(1_000)}</script>"
+
+        val notification = CopySelectionNotifier.notificationText(message)
+
+        assertTrue(notification.contains("src/App.kt:10-20"))
+        assertTrue(notification.length <= CopyPreview.NOTIFICATION_MAX_LENGTH + 20)
+        assertFalse(notification.any { it == '\n' || it == '\r' })
+        assertFalse(notification.contains("<script>"))
+        assertTrue(notification.contains("&lt;script&gt;"))
     }
 }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionStatusBarWidgetTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionStatusBarWidgetTest.kt
@@ -1,0 +1,55 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.project.Project
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CopySelectionStatusBarWidgetTest {
+    @Test
+    fun `status and tooltip use safe bounded previews`() {
+        val widget = CopySelectionStatusBarWidget(mockk<Project>(relaxed = true))
+        val content = "src/App.kt:10-20\n<script>😀 ${"x".repeat(1_000)}</script>"
+
+        widget.update(content)
+
+        assertTrue(widget.getText().length <= CopyPreview.STATUS_MAX_LENGTH)
+        assertTrue(widget.getTooltipText().length <= CopyPreview.TOOLTIP_MAX_LENGTH)
+        assertFalse(widget.getText().any { it == '\n' || it == '\r' })
+        assertFalse(widget.getTooltipText().any { it == '\n' || it == '\r' })
+        assertFalse(widget.getText().contains("<script>"))
+        assertFalse(widget.getTooltipText().contains("<script>"))
+    }
+
+    @Test
+    fun `re-copy writes the complete original value`() {
+        val manager = mockk<CopyPasteManager>()
+        val copied = slot<Transferable>()
+        mockkStatic(CopyPasteManager::class)
+        try {
+            every { CopyPasteManager.getInstance() } returns manager
+            every { manager.setContents(capture(copied)) } just runs
+
+            val widget = CopySelectionStatusBarWidget(mockk<Project>(relaxed = true))
+            val content = "src/App.kt:10-20\n<script>😀 ${"x".repeat(1_000)}</script>"
+            widget.update(content)
+
+            widget.getClickConsumer().consume(mockk(relaxed = true))
+
+            assertEquals(content, copied.captured.getTransferData(DataFlavor.stringFlavor))
+        } finally {
+            unmockkStatic(CopyPasteManager::class)
+        }
+    }
+}


### PR DESCRIPTION
## Rationale

Large or markup-like copied selections were passed unchanged to notification balloons and status-bar text, which could produce oversized, multiline, or unsafe rendering.

## Implementation

- Add a shared Unicode-aware preview formatter that collapses whitespace, escapes markup, truncates on complete character/entity boundaries, and adds an ellipsis when needed.
- Use bounded previews for notification content, status text, and status tooltip.
- Keep the complete copied value in the clipboard, project history, and status widget so clicking the widget re-copies the original value without loss.
- Cover multiline, 100k-character, Unicode, and markup-like content, plus full-value history and widget re-copy behavior.

## Verification

- `JAVA_HOME=/Users/van/.gradle/caches/9.7.1/transforms/24c9cf0ce1ebf320cf8b4423b256afe6/transformed/ideaIC-2024.3-aarch64/jbr/Contents/Home JAVA_TOOL_OPTIONS=-Dplugin.verifier.home.dir=/Users/van/.codex/worktrees/79af/copy-selection-context/build/pluginVerifierHome ./gradlew test verifyPlugin --rerun`
  - `BUILD SUCCESSFUL in 27s`
  - Full test suite: 162 tests, 0 failures, 0 errors, 0 skipped
  - IntelliJ Plugin Verifier 1.410: Compatible with IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97
- Manual code-path review confirmed that only previews are transformed and the click handler still sends the complete stored value to `CopyPasteManager`.

Closes #11
