### PR TITLE
fix: make Git permalinks reliable across worktrees

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -39,6 +39,12 @@ fun example() {
 
 - **CopyWithCodeContentAction.kt** (~104 lines): Path + line + markdown code block. Overrides `actionPerformed()` for custom format. Uses settings for path type. Includes `detectLanguage()` and `getCodeContent()`. Context menu only.
 
+- **CopyGitPermalinkAction.kt**: Captures editor and VCS context, resolves Git metadata on a pooled thread, then copies a GitHub/GitLab permalink on the UI thread. Reports an error without changing the clipboard when resolution fails.
+
+- **GitRepositoryMetadataResolver.kt**: NIO-based resolver for standard repositories and linked worktrees. Reads the common Git config, detached or symbolic HEAD, loose refs, packed refs, and the branch-tracking remote with deterministic fallbacks.
+
+- **GitPermalinkGenerator.kt**: Normalizes supported GitHub/GitLab HTTPS and SSH remote forms and percent-encodes repository-relative file paths.
+
 - **CopySelectionNotifier.kt** (~17 lines): Singleton. `NotificationGroupManager` BALLOON notifications with checkmark prefix. Group ID: `"CopySelectionContext"` (must match plugin.xml).
 
 - **CopySelectionStatusBarWidget.kt** (~9 lines): Stub (console only). Full impl needs `StatusBarWidget` + `TextPresentation` + `getAlignment(): Float` + Factory class.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,9 @@ Single flat package: `com.github.hon454.copyselectioncontext/`
 | `CopySelectionStatusBarWidget.kt` | Status bar widget (stub) |
 | `CopySelectionSettings.kt` | Settings persistence (`@Service` + `@State`) |
 | `CopySelectionConfigurable.kt` | Settings UI (Tools menu) |
+| `CopyGitPermalinkAction.kt` | Async GitHub/GitLab permalink action |
+| `GitRepositoryMetadataResolver.kt` | Worktree-aware Git metadata and ref resolution |
+| `GitPermalinkGenerator.kt` | Remote URL normalization and encoded permalink generation |
 
 **Flow**: User trigger -> Action reads settings -> Extract editor context -> CopyPasteManager -> Notification
 

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyGitPermalinkAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyGitPermalinkAction.kt
@@ -3,12 +3,11 @@ package com.github.hon454.copyselectioncontext
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ide.CopyPasteManager
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.ProjectLevelVcsManager
-import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.VirtualFile
 import java.awt.datatransfer.StringSelection
+import java.nio.file.Path
 
 class CopyGitPermalinkAction : AnAction() {
 
@@ -18,11 +17,31 @@ class CopyGitPermalinkAction : AnAction() {
         val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
 
         val (startLine, endLine) = CopySelectionUtils.resolveLineNumbers(editor)
-        val permalink = tryBuildPermalink(project, file, startLine, endLine)
-            ?: fallbackPath(project, file, startLine, endLine)
+        val vcsManager = ProjectLevelVcsManager.getInstance(project)
+        if (vcsManager.getVcsFor(file) == null) {
+            CopySelectionNotifier.notifyPermalinkFailure(project)
+            return
+        }
+        val rootPath = vcsManager.getVcsRootFor(file)?.path
+        if (rootPath == null) {
+            CopySelectionNotifier.notifyPermalinkFailure(project)
+            return
+        }
+        val filePath = file.path
+        val application = ApplicationManager.getApplication()
 
-        CopyPasteManager.getInstance().setContents(StringSelection(permalink))
-        CopySelectionNotifier.notify(project, permalink)
+        application.executeOnPooledThread {
+            val permalink = tryBuildPermalink(rootPath, filePath, startLine, endLine)
+            application.invokeLater {
+                if (project.isDisposed) return@invokeLater
+                if (permalink == null) {
+                    CopySelectionNotifier.notifyPermalinkFailure(project)
+                } else {
+                    CopyPasteManager.getInstance().setContents(StringSelection(permalink))
+                    CopySelectionNotifier.notify(project, permalink)
+                }
+            }
+        }
     }
 
     override fun update(e: AnActionEvent) {
@@ -31,92 +50,26 @@ class CopyGitPermalinkAction : AnAction() {
     }
 
     private fun tryBuildPermalink(
-        project: Project,
-        file: VirtualFile,
+        rootPath: String,
+        filePath: String,
         startLine: Int,
         endLine: Int
     ): String? {
         return try {
-            val vcsManager = ProjectLevelVcsManager.getInstance(project)
-            vcsManager.getVcsFor(file) ?: return null
-            val root = vcsManager.getVcsRootFor(file) ?: return null
-            val relativePath = file.path
-                .removePrefix(root.path)
-                .trimStart('/', '\\')
-                .replace('\\', '/')
-
-            val gitDir = resolveGitDir(root) ?: return null
-            val configFile = gitDir.findFileByRelativePath("config") ?: return null
-            val remoteUrl = extractRemoteUrl(String(configFile.contentsToByteArray())) ?: return null
-
-            val sha = resolveHeadSha(gitDir) ?: return null
-            GitPermalinkGenerator.buildPermalinkFromRemote(remoteUrl, sha, relativePath, startLine, endLine)
+            val root = Path.of(rootPath).toAbsolutePath().normalize()
+            val file = Path.of(filePath).toAbsolutePath().normalize()
+            if (!file.startsWith(root)) return null
+            val relativePath = root.relativize(file).toString().replace('\\', '/')
+            val metadata = GitRepositoryMetadataResolver.resolve(root) ?: return null
+            GitPermalinkGenerator.buildPermalinkFromRemote(
+                metadata.remoteUrl,
+                metadata.commitSha,
+                relativePath,
+                startLine,
+                endLine
+            )
         } catch (_: Exception) {
             null
         }
-    }
-
-    private fun resolveGitDir(root: VirtualFile): VirtualFile? {
-        val dotGit = root.findChild(".git") ?: return null
-        if (dotGit.isDirectory) {
-            return dotGit
-        }
-
-        val marker = String(dotGit.contentsToByteArray())
-            .lineSequence()
-            .firstOrNull { it.trim().startsWith("gitdir:") }
-            ?.substringAfter("gitdir:")
-            ?.trim()
-            ?: return null
-
-        val resolvedPath = if (marker.startsWith("/") || Regex("""^[A-Za-z]:[/\\].*""").matches(marker)) {
-            marker
-        } else {
-            "${root.path}/$marker"
-        }
-        return LocalFileSystem.getInstance().refreshAndFindFileByPath(resolvedPath.replace('\\', '/'))
-    }
-
-    private fun resolveHeadSha(gitDir: VirtualFile): String? {
-        val headFile = gitDir.findFileByRelativePath("HEAD") ?: return null
-        val headContent = String(headFile.contentsToByteArray()).trim()
-        if (!headContent.startsWith("ref: ")) {
-            return headContent
-        }
-
-        val refPath = headContent.removePrefix("ref: ").trim()
-        val refFile = gitDir.findFileByRelativePath(refPath) ?: return null
-        return String(refFile.contentsToByteArray()).trim()
-    }
-
-    private fun extractRemoteUrl(gitConfig: String): String? {
-        val lines = gitConfig.lines()
-        var inRemoteOrigin = false
-        for (line in lines) {
-            val trimmed = line.trim()
-            if (trimmed == "[remote \"origin\"]") {
-                inRemoteOrigin = true
-                continue
-            }
-            if (inRemoteOrigin && trimmed.startsWith("[")) {
-                inRemoteOrigin = false
-            }
-            if (inRemoteOrigin && trimmed.startsWith("url =")) {
-                return trimmed.removePrefix("url =").trim()
-            }
-        }
-        return null
-    }
-
-    private fun fallbackPath(
-        project: Project,
-        file: VirtualFile,
-        startLine: Int,
-        endLine: Int
-    ): String {
-        val basePath = project.basePath ?: ""
-        val relativePath = file.path.removePrefix(basePath).trimStart('/', '\\').replace('\\', '/')
-        val lineFragment = if (startLine == endLine) "L$startLine" else "L$startLine-L$endLine"
-        return "@$relativePath#$lineFragment"
     }
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyGitPermalinkAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyGitPermalinkAction.kt
@@ -8,13 +8,16 @@ import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.vcs.ProjectLevelVcsManager
 import java.awt.datatransfer.StringSelection
 import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicLong
 
 class CopyGitPermalinkAction : AnAction() {
+    private val requests = LatestPermalinkRequestTracker()
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.getData(CommonDataKeys.PROJECT) ?: return
         val editor = e.getData(CommonDataKeys.EDITOR) ?: return
         val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+        val requestId = requests.begin()
 
         val (startLine, endLine) = CopySelectionUtils.resolveLineNumbers(editor)
         val vcsManager = ProjectLevelVcsManager.getInstance(project)
@@ -34,11 +37,13 @@ class CopyGitPermalinkAction : AnAction() {
             val permalink = tryBuildPermalink(rootPath, filePath, startLine, endLine)
             application.invokeLater {
                 if (project.isDisposed) return@invokeLater
-                if (permalink == null) {
-                    CopySelectionNotifier.notifyPermalinkFailure(project)
-                } else {
-                    CopyPasteManager.getInstance().setContents(StringSelection(permalink))
-                    CopySelectionNotifier.notify(project, permalink)
+                requests.runIfCurrent(requestId) {
+                    if (permalink == null) {
+                        CopySelectionNotifier.notifyPermalinkFailure(project)
+                    } else {
+                        CopyPasteManager.getInstance().setContents(StringSelection(permalink))
+                        CopySelectionNotifier.notify(project, permalink)
+                    }
                 }
             }
         }
@@ -71,5 +76,17 @@ class CopyGitPermalinkAction : AnAction() {
         } catch (_: Exception) {
             null
         }
+    }
+}
+
+internal class LatestPermalinkRequestTracker {
+    private val latestRequestId = AtomicLong()
+
+    fun begin(): Long = latestRequestId.incrementAndGet()
+
+    fun runIfCurrent(requestId: Long, action: () -> Unit): Boolean {
+        if (latestRequestId.get() != requestId) return false
+        action()
+        return true
     }
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionNotifier.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionNotifier.kt
@@ -17,4 +17,16 @@ object CopySelectionNotifier {
             )
             .notify(project)
     }
+
+    fun notifyPermalinkFailure(project: Project?) {
+        if (project == null) return
+
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("CopySelectionContext")
+            .createNotification(
+                CopySelectionBundle.message("notification.permalink.failed"),
+                NotificationType.ERROR
+            )
+            .notify(project)
+    }
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/GitPermalinkGenerator.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/GitPermalinkGenerator.kt
@@ -58,12 +58,19 @@ object GitPermalinkGenerator {
 
     private fun canonicalRepository(host: String, rawPath: String): Pair<String, String>? {
         val normalizedHost = host.lowercase()
-        val repositoryPath = rawPath
-            .trim()
-            .trim('/')
-            .removeSuffix(".git")
-            .takeIf { it.count { character -> character == '/' } >= 1 }
-            ?: return null
+        if (rawPath != rawPath.trim()) return null
+        val repositoryPath = rawPath.removePrefix("/").removeSuffix(".git")
+        val segments = repositoryPath.split('/')
+        if (repositoryPath.contains('\\') ||
+            segments.any { it.isEmpty() || it == "." || it == ".." }
+        ) return null
+        val validNamespace = when (normalizedHost) {
+            "github.com" -> segments.size == 2
+            "gitlab.com" -> segments.size >= 2
+            else -> false
+        }
+        if (!validNamespace) return null
+
         return Pair("https://$normalizedHost/$repositoryPath", normalizedHost)
     }
 

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/GitPermalinkGenerator.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/GitPermalinkGenerator.kt
@@ -1,27 +1,31 @@
 package com.github.hon454.copyselectioncontext
 
+import java.net.URI
+
 object GitPermalinkGenerator {
 
     fun parseRemoteUrl(remoteUrl: String): Pair<String, String>? {
         val normalizedRemoteUrl = remoteUrl.trim()
 
-        val sshPattern = Regex("""git@(github\.com|gitlab\.com):([^/]+)/(.+?)(?:\.git)?$""")
+        val sshPattern = Regex("""git@(github\.com|gitlab\.com):(.+)$""", RegexOption.IGNORE_CASE)
         sshPattern.matchEntire(normalizedRemoteUrl)?.let { match ->
-            val host = match.groupValues[1]
-            val owner = match.groupValues[2]
-            val repo = match.groupValues[3]
-            return Pair("https://$host/$owner/$repo", host)
+            return canonicalRepository(match.groupValues[1], match.groupValues[2])
         }
 
-        val httpsPattern = Regex("""https?://(github\.com|gitlab\.com)/([^/]+)/(.+?)(?:\.git)?$""")
-        httpsPattern.matchEntire(normalizedRemoteUrl)?.let { match ->
-            val host = match.groupValues[1]
-            val owner = match.groupValues[2]
-            val repo = match.groupValues[3]
-            return Pair("https://$host/$owner/$repo", host)
+        val uri = runCatching { URI(normalizedRemoteUrl) }.getOrNull() ?: return null
+        val scheme = uri.scheme?.lowercase()
+        if (scheme !in setOf("http", "https", "ssh", "git", "git+ssh")) return null
+        val remoteHost = uri.host?.lowercase() ?: return null
+        if (scheme == "ssh" || scheme == "git+ssh") {
+            if (uri.userInfo != "git") return null
+        }
+        val host = when {
+            remoteHost == "github.com" || remoteHost == "gitlab.com" -> remoteHost
+            remoteHost == "ssh.github.com" && scheme == "ssh" && uri.port == 443 -> "github.com"
+            else -> return null
         }
 
-        return null
+        return canonicalRepository(host, uri.path)
     }
 
     fun buildPermalink(
@@ -38,7 +42,7 @@ object GitPermalinkGenerator {
             normalizedHost == "github.com" || normalizedHost == "gitlab.com" -> "L$startLine-L$endLine"
             else -> "L$startLine-L$endLine"
         }
-        return "$repoUrl/blob/$sha/$filePath#$lineFragment"
+        return "$repoUrl/blob/$sha/${encodeFilePath(filePath)}#$lineFragment"
     }
 
     fun buildPermalinkFromRemote(
@@ -51,4 +55,40 @@ object GitPermalinkGenerator {
         val (repoUrl, host) = parseRemoteUrl(remoteUrl) ?: return null
         return buildPermalink(repoUrl, host, sha, filePath, startLine, endLine)
     }
+
+    private fun canonicalRepository(host: String, rawPath: String): Pair<String, String>? {
+        val normalizedHost = host.lowercase()
+        val repositoryPath = rawPath
+            .trim()
+            .trim('/')
+            .removeSuffix(".git")
+            .takeIf { it.count { character -> character == '/' } >= 1 }
+            ?: return null
+        return Pair("https://$normalizedHost/$repositoryPath", normalizedHost)
+    }
+
+    private fun encodeFilePath(filePath: String): String = filePath
+        .replace('\\', '/')
+        .trimStart('/')
+        .split('/')
+        .joinToString("/") { segment -> encodePathSegment(segment) }
+
+    private fun encodePathSegment(segment: String): String = buildString {
+        segment.toByteArray(Charsets.UTF_8).forEach { byte ->
+            val value = byte.toInt() and 0xff
+            val isUnreserved = value in 'a'.code..'z'.code ||
+                value in 'A'.code..'Z'.code ||
+                value in '0'.code..'9'.code ||
+                value == '-'.code || value == '.'.code || value == '_'.code || value == '~'.code
+            if (isUnreserved) {
+                append(value.toChar())
+            } else {
+                append('%')
+                append(HEX[value ushr 4])
+                append(HEX[value and 0x0f])
+            }
+        }
+    }
+
+    private const val HEX = "0123456789ABCDEF"
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/GitRepositoryMetadataResolver.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/GitRepositoryMetadataResolver.kt
@@ -1,0 +1,145 @@
+package com.github.hon454.copyselectioncontext
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal data class GitRepositoryMetadata(
+    val remoteUrl: String,
+    val commitSha: String
+)
+
+internal object GitRepositoryMetadataResolver {
+    private val objectIdPattern = Regex("^[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$")
+    private val sectionPattern = Regex("""^\[\s*([A-Za-z0-9.-]+)(?:\s+\"((?:\\.|[^\"])*)\")?\s*]$""")
+    private val valuePattern = Regex("""^([A-Za-z][A-Za-z0-9-]*)\s*=\s*(.*)$""")
+
+    fun resolve(root: Path): GitRepositoryMetadata? {
+        val gitDir = resolveGitDir(root) ?: return null
+        val commonDir = resolveCommonDir(gitDir) ?: return null
+        val head = resolveHead(gitDir, commonDir) ?: return null
+        val config = readText(commonDir.resolve("config")) ?: return null
+        val remoteUrl = extractRemoteUrl(config, head.branchName) ?: return null
+
+        return GitRepositoryMetadata(remoteUrl, head.commitSha)
+    }
+
+    private fun resolveGitDir(root: Path): Path? {
+        val dotGit = root.toAbsolutePath().normalize().resolve(".git")
+        if (Files.isDirectory(dotGit)) return dotGit
+        if (!Files.isRegularFile(dotGit)) return null
+
+        val marker = readText(dotGit)
+            ?.lineSequence()
+            ?.map(String::trim)
+            ?.firstOrNull { it.startsWith("gitdir:", ignoreCase = true) }
+            ?.substringAfter(':')
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+            ?: return null
+        val markerPath = Path.of(marker)
+        val resolved = if (markerPath.isAbsolute) markerPath else dotGit.parent.resolve(markerPath)
+
+        return resolved.normalize().takeIf(Files::isDirectory)
+    }
+
+    private fun resolveCommonDir(gitDir: Path): Path? {
+        val commonDirFile = gitDir.resolve("commondir")
+        if (!Files.exists(commonDirFile)) return gitDir
+
+        val marker = readText(commonDirFile)?.trim()?.takeIf(String::isNotEmpty) ?: return null
+        val markerPath = Path.of(marker)
+        val resolved = if (markerPath.isAbsolute) markerPath else gitDir.resolve(markerPath)
+
+        return resolved.normalize().takeIf(Files::isDirectory)
+    }
+
+    private fun resolveHead(gitDir: Path, commonDir: Path): HeadResolution? {
+        val headContent = readText(gitDir.resolve("HEAD"))?.trim() ?: return null
+        if (!headContent.startsWith("ref: ")) {
+            return headContent.takeIf(::isObjectId)?.let { HeadResolution(it.lowercase(), null) }
+        }
+
+        val refName = headContent.removePrefix("ref: ").trim()
+        val commitSha = resolveRef(refName, gitDir, commonDir) ?: return null
+        val branchName = refName.removePrefix("refs/heads/").takeIf { refName.startsWith("refs/heads/") }
+        return HeadResolution(commitSha, branchName)
+    }
+
+    private fun resolveRef(refName: String, gitDir: Path, commonDir: Path): String? {
+        val relativeRef = safeRelativePath(refName) ?: return null
+        val looseRef = sequenceOf(gitDir, commonDir)
+            .distinct()
+            .mapNotNull { directory -> readText(directory.resolve(relativeRef))?.trim() }
+            .firstOrNull()
+        if (looseRef != null) return looseRef.takeIf(::isObjectId)?.lowercase()
+
+        return sequenceOf(gitDir, commonDir)
+            .distinct()
+            .mapNotNull { directory -> resolvePackedRef(directory.resolve("packed-refs"), refName) }
+            .firstOrNull()
+    }
+
+    private fun resolvePackedRef(packedRefs: Path, refName: String): String? =
+        readText(packedRefs)
+            ?.lineSequence()
+            ?.map(String::trim)
+            ?.filterNot { it.isEmpty() || it.startsWith('#') || it.startsWith('^') }
+            ?.mapNotNull { line ->
+                val separator = line.indexOf(' ')
+                if (separator <= 0) return@mapNotNull null
+                val objectId = line.substring(0, separator)
+                val candidateRef = line.substring(separator + 1).trim()
+                objectId.takeIf { candidateRef == refName && isObjectId(it) }?.lowercase()
+            }
+            ?.firstOrNull()
+
+    private fun extractRemoteUrl(config: String, branchName: String?): String? {
+        val remotes = linkedMapOf<String, String>()
+        val branchRemotes = mutableMapOf<String, String>()
+        var section: ConfigSection? = null
+
+        config.lineSequence().forEach { line ->
+            val trimmed = line.trim()
+            if (trimmed.isEmpty() || trimmed.startsWith('#') || trimmed.startsWith(';')) return@forEach
+
+            sectionPattern.matchEntire(trimmed)?.let { match ->
+                section = ConfigSection(
+                    type = match.groupValues[1].lowercase(),
+                    name = match.groupValues[2].replace("\\\"", "\"").replace("\\\\", "\\")
+                )
+                return@forEach
+            }
+
+            val currentSection = section ?: return@forEach
+            val valueMatch = valuePattern.matchEntire(trimmed) ?: return@forEach
+            val key = valueMatch.groupValues[1].lowercase()
+            val value = valueMatch.groupValues[2].trim().removeSurrounding("\"")
+            when {
+                currentSection.type == "remote" && key == "url" ->
+                    remotes.putIfAbsent(currentSection.name, value)
+                currentSection.type == "branch" && key == "remote" ->
+                    branchRemotes.putIfAbsent(currentSection.name, value)
+            }
+        }
+
+        branchName?.let { branchRemotes[it] }?.let { remoteName ->
+            remotes[remoteName]?.let { return it }
+        }
+        remotes["origin"]?.let { return it }
+        return remotes.values.singleOrNull()
+    }
+
+    private fun safeRelativePath(refName: String): Path? {
+        val path = runCatching { Path.of(refName) }.getOrNull() ?: return null
+        if (path.isAbsolute || path.any { it.toString() == ".." }) return null
+        return path
+    }
+
+    private fun readText(path: Path): String? =
+        runCatching { Files.readString(path) }.getOrNull()
+
+    private fun isObjectId(value: String): Boolean = objectIdPattern.matches(value)
+
+    private data class HeadResolution(val commitSha: String, val branchName: String?)
+    private data class ConfigSection(val type: String, val name: String)
+}

--- a/src/main/resources/messages/CopySelectionBundle.properties
+++ b/src/main/resources/messages/CopySelectionBundle.properties
@@ -1,4 +1,5 @@
 notification.copied=\u2713 Copied: {0}
+notification.permalink.failed=Unable to create a Git permalink. Check the repository remote and commit state.
 notification.group=CopySelectionContext
 widget.tooltip=Copy Selection Context \u2014 last copied
 widget.empty=No copy yet

--- a/src/main/resources/messages/CopySelectionBundle_ko.properties
+++ b/src/main/resources/messages/CopySelectionBundle_ko.properties
@@ -1,4 +1,5 @@
 notification.copied=\u2713 \ubcf5\uc0ac\ub428: {0}
+notification.permalink.failed=Git \ud37c\uba38\ub9c1\ud06c\ub97c \uc0dd\uc131\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4. \uc800\uc7a5\uc18c \uc6d0\uaca9 \uc124\uc815\uacfc \ucee4\ubc0b \uc0c1\ud0dc\ub97c \ud655\uc778\ud558\uc138\uc694.
 notification.group=CopySelectionContext
 widget.tooltip=Copy Selection Context \u2014 \ub9c8\uc9c0\ub9c9 \ubcf5\uc0ac
 widget.empty=\ubcf5\uc0ac \uc5c6\uc74c

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBundleTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBundleTest.kt
@@ -12,6 +12,12 @@ class CopySelectionBundleTest {
     }
 
     @Test
+    fun `permalink failure key resolves`() {
+        val msg = CopySelectionBundle.message("notification.permalink.failed")
+        assertTrue(msg.isNotBlank())
+    }
+
+    @Test
     fun `history popup title key resolves`() {
         val msg = CopySelectionBundle.message("history.popup.title")
         assertTrue(msg.isNotBlank())

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/GitPermalinkGeneratorTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/GitPermalinkGeneratorTest.kt
@@ -80,6 +80,23 @@ class GitPermalinkGeneratorTest {
     }
 
     @Test
+    fun `remote path traversal returns null`() {
+        listOf(
+            "https://github.com/owner/../victim.git",
+            "https://github.com/owner/%2e%2e/victim.git",
+            "https://github.com/owner/./repo.git",
+            "https://github.com/owner//repo.git",
+            "https://github.com/owner/repo/extra.git",
+            "git@gitlab.com:group//project.git"
+        ).forEach { remoteUrl ->
+            assertNull(
+                GitPermalinkGenerator.parseRemoteUrl(remoteUrl),
+                "Remote '$remoteUrl' should be rejected"
+            )
+        }
+    }
+
+    @Test
     fun `build permalink single line`() {
         val url = GitPermalinkGenerator.buildPermalink(
             repoUrl = "https://github.com/owner/repo",

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/GitPermalinkGeneratorTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/GitPermalinkGeneratorTest.kt
@@ -13,7 +13,7 @@ class GitPermalinkGeneratorTest {
         val result = GitPermalinkGenerator.parseRemoteUrl("git@github.com:owner/repo.git")
 
         assertNotNull(result)
-        assertEquals("https://github.com/owner/repo", result!!.first)
+        assertEquals("https://github.com/owner/repo", result.first)
         assertEquals("github.com", result.second)
     }
 
@@ -22,7 +22,7 @@ class GitPermalinkGeneratorTest {
         val result = GitPermalinkGenerator.parseRemoteUrl("https://github.com/owner/repo.git")
 
         assertNotNull(result)
-        assertEquals("https://github.com/owner/repo", result!!.first)
+        assertEquals("https://github.com/owner/repo", result.first)
         assertEquals("github.com", result.second)
     }
 
@@ -31,7 +31,36 @@ class GitPermalinkGeneratorTest {
         val result = GitPermalinkGenerator.parseRemoteUrl("git@gitlab.com:owner/repo.git")
 
         assertNotNull(result)
-        assertTrue(result!!.first.contains("gitlab.com"))
+        assertTrue(result.first.contains("gitlab.com"))
+        assertEquals("gitlab.com", result.second)
+    }
+
+    @Test
+    fun `parse SSH URI github remote url`() {
+        val result = GitPermalinkGenerator.parseRemoteUrl("ssh://git@github.com/owner/repo.git")
+
+        assertNotNull(result)
+        assertEquals("https://github.com/owner/repo", result.first)
+        assertEquals("github.com", result.second)
+    }
+
+    @Test
+    fun `parse github SSH over HTTPS port remote url`() {
+        val result = GitPermalinkGenerator.parseRemoteUrl(
+            "ssh://git@ssh.github.com:443/owner/repo.git"
+        )
+
+        assertNotNull(result)
+        assertEquals("https://github.com/owner/repo", result.first)
+        assertEquals("github.com", result.second)
+    }
+
+    @Test
+    fun `parse git plus SSH URI with nested gitlab namespace`() {
+        val result = GitPermalinkGenerator.parseRemoteUrl("git+ssh://git@gitlab.com/group/subgroup/repo.git")
+
+        assertNotNull(result)
+        assertEquals("https://gitlab.com/group/subgroup/repo", result.first)
         assertEquals("gitlab.com", result.second)
     }
 
@@ -40,7 +69,7 @@ class GitPermalinkGeneratorTest {
         val result = GitPermalinkGenerator.parseRemoteUrl("https://github.com/owner/repo")
 
         assertNotNull(result)
-        assertEquals("https://github.com/owner/repo", result!!.first)
+        assertEquals("https://github.com/owner/repo", result.first)
     }
 
     @Test
@@ -76,6 +105,23 @@ class GitPermalinkGeneratorTest {
         )
 
         assertEquals("https://github.com/owner/repo/blob/abc123/src/Main.kt#L10-L20", url)
+    }
+
+    @Test
+    fun `build permalink encodes URL sensitive and unicode path characters`() {
+        val url = GitPermalinkGenerator.buildPermalink(
+            repoUrl = "https://github.com/owner/repo",
+            host = "github.com",
+            sha = "abc123",
+            filePath = "src/My file #1/한글.kt",
+            startLine = 7,
+            endLine = 7
+        )
+
+        assertEquals(
+            "https://github.com/owner/repo/blob/abc123/src/My%20file%20%231/%ED%95%9C%EA%B8%80.kt#L7",
+            url
+        )
     }
 
     @Test

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/GitRepositoryMetadataResolverTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/GitRepositoryMetadataResolverTest.kt
@@ -1,0 +1,111 @@
+package com.github.hon454.copyselectioncontext
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class GitRepositoryMetadataResolverTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `resolve normal repository with loose ref`() {
+        val root = tempDir.resolve("repository")
+        val gitDir = root.resolve(".git")
+        write(gitDir.resolve("HEAD"), "ref: refs/heads/main\n")
+        write(gitDir.resolve("refs/heads/main"), "$MAIN_SHA\n")
+        write(gitDir.resolve("config"), remoteConfig("origin", "https://github.com/owner/repo.git"))
+
+        val result = GitRepositoryMetadataResolver.resolve(root)
+
+        assertNotNull(result)
+        assertEquals("https://github.com/owner/repo.git", result?.remoteUrl)
+        assertEquals(MAIN_SHA, result?.commitSha)
+    }
+
+    @Test
+    fun `resolve linked worktree from common git directory`() {
+        val repositoryRoot = tempDir.resolve("repository")
+        val commonDir = repositoryRoot.resolve(".git")
+        val worktreeRoot = tempDir.resolve("linked-worktree")
+        val worktreeGitDir = commonDir.resolve("worktrees/linked-worktree")
+        write(worktreeRoot.resolve(".git"), "gitdir: ${worktreeGitDir.toAbsolutePath()}\n")
+        write(worktreeGitDir.resolve("commondir"), "../..\n")
+        write(worktreeGitDir.resolve("HEAD"), "ref: refs/heads/feature/worktree\n")
+        write(commonDir.resolve("refs/heads/feature/worktree"), "$FEATURE_SHA\n")
+        write(
+            commonDir.resolve("config"),
+            """
+                [remote "origin"]
+                    url = https://github.com/owner/origin.git
+                [remote "upstream"]
+                    url = git@gitlab.com:team/project.git
+                [branch "feature/worktree"]
+                    remote = upstream
+            """.trimIndent()
+        )
+
+        val result = GitRepositoryMetadataResolver.resolve(worktreeRoot)
+
+        assertNotNull(result)
+        assertEquals("git@gitlab.com:team/project.git", result?.remoteUrl)
+        assertEquals(FEATURE_SHA, result?.commitSha)
+    }
+
+    @Test
+    fun `resolve branch from packed refs`() {
+        val root = tempDir.resolve("packed-repository")
+        val gitDir = root.resolve(".git")
+        write(gitDir.resolve("HEAD"), "ref: refs/heads/release\n")
+        write(
+            gitDir.resolve("packed-refs"),
+            """
+                # pack-refs with: peeled fully-peeled sorted
+                $PACKED_SHA refs/heads/release
+                ${"1".repeat(40)} refs/tags/v1.0.0
+                ^${"2".repeat(40)}
+            """.trimIndent()
+        )
+        write(gitDir.resolve("config"), remoteConfig("origin", "git@github.com:owner/repo.git"))
+
+        val result = GitRepositoryMetadataResolver.resolve(root)
+
+        assertNotNull(result)
+        assertEquals(PACKED_SHA, result?.commitSha)
+    }
+
+    @Test
+    fun `resolve detached head`() {
+        val root = tempDir.resolve("detached-repository")
+        val gitDir = root.resolve(".git")
+        write(gitDir.resolve("HEAD"), "$DETACHED_SHA\n")
+        write(gitDir.resolve("config"), remoteConfig("origin", "https://gitlab.com/team/project.git"))
+
+        val result = GitRepositoryMetadataResolver.resolve(root)
+
+        assertNotNull(result)
+        assertEquals(DETACHED_SHA, result?.commitSha)
+        assertEquals("https://gitlab.com/team/project.git", result?.remoteUrl)
+    }
+
+    private fun remoteConfig(name: String, url: String): String =
+        """
+            [remote "$name"]
+                url = $url
+        """.trimIndent()
+
+    private fun write(path: Path, content: String) {
+        Files.createDirectories(path.parent)
+        Files.writeString(path, content)
+    }
+
+    private companion object {
+        const val MAIN_SHA = "0123456789abcdef0123456789abcdef01234567"
+        const val FEATURE_SHA = "123456789abcdef0123456789abcdef012345678"
+        const val PACKED_SHA = "23456789abcdef0123456789abcdef0123456789"
+        const val DETACHED_SHA = "3456789abcdef0123456789abcdef0123456789a"
+    }
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/LatestPermalinkRequestTrackerTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/LatestPermalinkRequestTrackerTest.kt
@@ -1,0 +1,42 @@
+package com.github.hon454.copyselectioncontext
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+class LatestPermalinkRequestTrackerTest {
+    @Test
+    fun `stale completion cannot apply after newer request starts`() {
+        val tracker = LatestPermalinkRequestTracker()
+        val sideEffects = CopyOnWriteArrayList<String>()
+        val releaseFirstCompletion = CountDownLatch(1)
+        val firstCompletionFinished = CountDownLatch(1)
+        val firstRequest = tracker.begin()
+        var firstApplied = true
+
+        val firstWorker = thread(name = "stale-permalink-completion") {
+            releaseFirstCompletion.await()
+            firstApplied = tracker.runIfCurrent(firstRequest) {
+                sideEffects += "first"
+            }
+            firstCompletionFinished.countDown()
+        }
+
+        val secondRequest = tracker.begin()
+        val secondApplied = tracker.runIfCurrent(secondRequest) {
+            sideEffects += "second"
+        }
+        releaseFirstCompletion.countDown()
+
+        assertTrue(firstCompletionFinished.await(5, TimeUnit.SECONDS))
+        firstWorker.join()
+        assertTrue(secondApplied)
+        assertFalse(firstApplied)
+        assertEquals(listOf("second"), sideEffects)
+    }
+}


### PR DESCRIPTION
## Rationale

The permalink action treated a linked worktree's private Git directory as the repository's common metadata directory. That made config lookup and branch resolution fail for standard worktrees, while packed refs, detached HEADs, additional SSH URL forms, and URL-sensitive file names were also handled incompletely. The action then copied a non-link fallback as though permalink generation had succeeded.

## Implementation

- Resolve `.git` pointers and `commondir` metadata for standard repositories and linked worktrees.
- Resolve detached HEADs, loose refs, and packed refs, and choose the branch-tracking remote with deterministic `origin` and single-remote fallbacks.
- Normalize supported GitHub and GitLab HTTPS, SCP-style SSH, SSH URI, `git+ssh`, and GitHub SSH-over-443 remote forms.
- Percent-encode repository-relative file paths in generated URLs.
- Gate asynchronous completions with a latest-request token so superseded tasks cannot update the clipboard or emit stale notifications.
- Reject empty, dot, dot-dot, backslash, and invalid host-specific repository path shapes before generating a permalink.
- Move Git metadata file access to a pooled thread and report a localized error without changing the clipboard when permalink generation fails.
- Add focused fixtures for normal repositories, linked worktrees, packed refs, detached HEADs, remote selection, unsupported remotes, SSH variants, encoded paths, malformed remote paths, and out-of-order async completions.

## Verification

- Focused permalink tests — passed: 18 tests covering request ordering, remote parsing, and Git metadata resolution.
- `./gradlew test --stacktrace` — passed: 165 tests, 0 failures, 0 errors, 0 skipped.
- `./gradlew buildPlugin --stacktrace` — passed; produced `copy-selection-context-1.0.4.zip`.
- `./gradlew verifyPlugin` — passed with an isolated Plugin Verifier home: compatible with IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97.
- `git diff --check` — passed.

Closes #9
