### PR TITLE
fix: populate filename in runtime format context

### DIFF
--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
@@ -63,7 +63,7 @@ abstract class CopySelectionBaseAction : AnAction() {
 
     protected open fun buildContent(path: String, lineRange: String, file: VirtualFile, editor: Editor, project: Project? = null): String {
         val (startLine, endLine) = resolveLineNumbers(editor)
-        return formatWithSettings(path, startLine, endLine)
+        return formatWithSettings(path, startLine, endLine, file)
     }
 
     protected open fun buildContentForCaret(
@@ -92,10 +92,24 @@ abstract class CopySelectionBaseAction : AnAction() {
         }
     }
 
-    protected fun formatWithSettings(path: String, startLine: Int, endLine: Int, code: String? = null, language: String = ""): String {
+    protected fun formatWithSettings(
+        path: String,
+        startLine: Int,
+        endLine: Int,
+        file: VirtualFile,
+        code: String? = null,
+        language: String = ""
+    ): String {
         val settings = CopySelectionSettings.getInstance().state
         val formatter = OutputFormatterFactory.getFormatterForSettings(settings)
-        val context = FormatContext(path = path, startLine = startLine, endLine = endLine, code = code, language = language)
+        val context = FormatContext(
+            path = path,
+            startLine = startLine,
+            endLine = endLine,
+            code = code,
+            language = language,
+            filename = file.name
+        )
         return formatter.format(context)
     }
 

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionContextAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionContextAction.kt
@@ -16,9 +16,9 @@ class CopySelectionContextAction : CopySelectionBaseAction() {
             var code = getCodeContent(editor)
             code = applyCodeTrimming(code)
             val language = detectLanguage(file)
-            formatWithSettings(path, startLine, endLine, code, language)
+            formatWithSettings(path, startLine, endLine, file, code, language)
         } else {
-            formatWithSettings(path, startLine, endLine)
+            formatWithSettings(path, startLine, endLine, file)
         }
     }
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyWithCodeContentAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyWithCodeContentAction.kt
@@ -15,6 +15,6 @@ class CopyWithCodeContentAction : CopySelectionBaseAction() {
         var code = getCodeContent(editor)
         code = applyCodeTrimming(code)
         val language = detectLanguage(file)
-        return formatWithSettings(path, startLine, endLine, code, language)
+        return formatWithSettings(path, startLine, endLine, file, code, language)
     }
 }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionActionTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionActionTest.kt
@@ -2,11 +2,19 @@ package com.github.hon454.copyselectioncontext
 
 import io.mockk.every
 import io.mockk.mockk
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.SelectionModel
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.editor.CaretModel
 import com.intellij.openapi.editor.Document
-import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.editor.SelectionModel
 import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -17,6 +25,20 @@ import kotlin.test.assertNotNull
  * This test class demonstrates the test infrastructure setup for the plugin.
  */
 class CopySelectionActionTest {
+
+    private lateinit var settings: CopySelectionSettings
+
+    @BeforeTest
+    fun setUp() {
+        settings = mockk()
+        mockkObject(CopySelectionSettings.Companion)
+        every { CopySelectionSettings.getInstance() } returns settings
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkObject(CopySelectionSettings.Companion)
+    }
 
     @Test
     fun testResolveLineRangeWithMockEditor() {
@@ -60,5 +82,60 @@ class CopySelectionActionTest {
         assertTrue(result.contains("@src/App.kt#L10-15"))
         assertTrue(result.contains("```kotlin"))
         assertTrue(result.contains("fun main() {"))
+    }
+
+    @Test
+    fun `custom template includes filename for single caret output`() {
+        useFilenameTemplate()
+        val file = mockk<VirtualFile>()
+        every { file.name } returns "Example.kt"
+
+        val result = TestCopySelectionAction().buildSingleCaretContent(file, mockSingleCaretEditor())
+
+        assertEquals("File: Example.kt", result)
+    }
+
+    @Test
+    fun `custom template includes filename for multi caret output`() {
+        useFilenameTemplate()
+        val file = mockk<VirtualFile>()
+        val caret = mockk<Caret>()
+        every { file.name } returns "Example.kt"
+
+        val result = TestCopySelectionAction().buildMultiCaretContent(file, mockSingleCaretEditor(), caret)
+
+        assertEquals("File: Example.kt", result)
+    }
+
+    private fun useFilenameTemplate() {
+        every { settings.state } returns CopySelectionSettings.State(
+            outputFormat = "template",
+            customFormatTemplate = "File: {filename}"
+        )
+    }
+
+    private fun mockSingleCaretEditor(): Editor {
+        val editor = mockk<Editor>()
+        val selectionModel = mockk<SelectionModel>()
+        val caretModel = mockk<CaretModel>()
+        val document = mockk<Document>()
+        every { editor.selectionModel } returns selectionModel
+        every { editor.caretModel } returns caretModel
+        every { editor.document } returns document
+        every { selectionModel.hasSelection() } returns false
+        every { caretModel.logicalPosition } returns LogicalPosition(4, 0)
+        return editor
+    }
+
+    private class TestCopySelectionAction : CopySelectionBaseAction() {
+        override fun getPath(project: Project, file: VirtualFile): String = file.path
+
+        fun buildSingleCaretContent(file: VirtualFile, editor: Editor): String {
+            return buildContent("src/Example.kt", "5", file, editor)
+        }
+
+        fun buildMultiCaretContent(file: VirtualFile, editor: Editor, caret: Caret): String {
+            return buildContentForCaret("src/Example.kt", "5", 5, 5, file, editor, caret)
+        }
     }
 }


### PR DESCRIPTION
## Rationale

The settings preview populates `{filename}`, but runtime actions omitted the active file name when constructing `FormatContext`. As a result, copied output rendered the variable as an empty string even though the preview showed a value.

## Implementation

- Pass the active `VirtualFile` through the shared runtime formatting path and populate `FormatContext.filename` from `VirtualFile.name`.
- Update the unified and code-content actions to use the same filename-aware formatting path.
- Add focused action-level regression tests for single-caret and multi-caret custom-template output.

## Verification

- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew test` — passed, 156 tests with 0 failures.
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew buildPlugin` — passed.
- Plugin Verifier 1.410 against IntelliJ IDEA IC-243.28141.41 — compatible.
- Full `verifyPlugin` was also attempted for all recommended IDEs; Plugin Verifier 1.410 stopped on its own extracted JAR with `NoSuchFileException` for the 2025.x checks. The minimum supported 2024.3 verification completed successfully when run separately.

Closes #7
