### PR TITLE
fix: remove placeholder GitHub formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Prevent legacy GitHub output format settings from copying placeholder URLs while preserving the dedicated GitHub/GitLab permalink action
+
 ## [1.0.4] - 2026-08-21
 
 ### Changed
@@ -30,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Copy History browser — browse and re-copy recent entries (`Ctrl+Alt+H`)
 - GitHub/GitLab permalink generation for selected lines
-- Template-based output formatting with presets (Claude Code, Path:Line, GitHub Permalink, Custom)
+- Template-based output formatting with presets (Claude Code, Path:Line, Custom)
 - Live template preview and variable validation in settings
 - Status bar widget — shows last copied text, click to re-copy
 

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionSettings.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionSettings.kt
@@ -30,10 +30,16 @@ class CopySelectionSettings : PersistentStateComponent<CopySelectionSettings.Sta
 
     override fun loadState(state: State) {
         state.copyHistorySize = state.copyHistorySize.coerceIn(0, 100)
+        if (state.outputFormat == LEGACY_GITHUB_FORMAT) {
+            state.outputFormat = DEFAULT_OUTPUT_FORMAT
+        }
         myState = state
     }
 
     companion object {
+        private const val LEGACY_GITHUB_FORMAT = "github"
+        private const val DEFAULT_OUTPUT_FORMAT = "claude"
+
         fun getInstance(): CopySelectionSettings {
             return ApplicationManager.getApplication().getService(CopySelectionSettings::class.java)
         }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/OutputFormatter.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/OutputFormatter.kt
@@ -59,26 +59,10 @@ class PathLineFormatter : OutputFormatter {
     }
 }
 
-class GitHubPermalinkTemplateFormatter : OutputFormatter {
-    override val key = "github"
-    override val displayName = "GitHub Permalink"
-
-    override fun format(context: FormatContext): String {
-        val normalizedPath = context.path.replace("\\", "/")
-        val lineFragment = if (context.startLine == context.endLine) {
-            "L${context.startLine}"
-        } else {
-            "L${context.startLine}-L${context.endLine}"
-        }
-        return "https://github.com/{owner}/{repo}/blob/{sha}/$normalizedPath#$lineFragment"
-    }
-}
-
 object OutputFormatterFactory {
     private val formatters: Map<String, OutputFormatter> = listOf(
         ClaudeCodeFormatter(),
         PathLineFormatter(),
-        GitHubPermalinkTemplateFormatter(),
         TemplateFormatter(TemplateFormatter.PRESET_PATH_AND_RANGE)
     ).associateBy { it.key }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,7 +17,7 @@ One shortcut (<code>Ctrl+Alt+C</code> / <code>Cmd+Alt+C</code>) copies your curr
     <li><strong>Code content as markdown</strong> — include the selected code as a fenced markdown code block with language tag</li>
     <li><strong>Private copy history</strong> — <code>Ctrl+Alt+H</code> opens locally stored history with clear-all and disable controls</li>
     <li><strong>GitHub/GitLab permalink</strong> — generate a permanent link to the exact lines in your remote repository</li>
-    <li><strong>Template-based output formatting</strong> — choose from built-in presets (Claude Code, Path:Line, GitHub Permalink, Custom) or define your own template with variable placeholders</li>
+    <li><strong>Template-based output formatting</strong> — choose from built-in presets (Claude Code, Path:Line, Custom) or define your own template with variable placeholders</li>
     <li><strong>Live template preview</strong> — settings UI shows a real-time preview and validates template variables before you save</li>
     <li><strong>Smart line handling</strong> — copies the current line number when no text is selected, so the shortcut always produces useful output</li>
     <li><strong>Status bar widget</strong> — displays the last copied text in the IDE status bar; click it to copy again</li>

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionSettingsTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionSettingsTest.kt
@@ -115,4 +115,22 @@ class CopySelectionSettingsTest {
         settings.loadState(CopySelectionSettings.State(copyHistorySize = 101))
         assertEquals(100, settings.state.copyHistorySize)
     }
+
+    @Test
+    fun `loadState migrates legacy github format to claude`() {
+        val settings = CopySelectionSettings()
+
+        settings.loadState(CopySelectionSettings.State(outputFormat = "github"))
+
+        assertEquals("claude", settings.state.outputFormat)
+    }
+
+    @Test
+    fun `loadState preserves supported output format`() {
+        val settings = CopySelectionSettings()
+
+        settings.loadState(CopySelectionSettings.State(outputFormat = "pathline"))
+
+        assertEquals("pathline", settings.state.outputFormat)
+    }
 }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/OutputFormatterTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/OutputFormatterTest.kt
@@ -2,6 +2,7 @@ package com.github.hon454.copyselectioncontext
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -291,5 +292,25 @@ class OutputFormatterTest {
         val result = formatter.format(context)
 
         assertEquals(" @src/App.kt#L5 ", result)
+    }
+
+    @Test
+    fun `legacy github format falls back without placeholder url`() {
+        val formatter = OutputFormatterFactory.getFormatter("github")
+        val context = FormatContext(path = "src/App.kt", startLine = 5, endLine = 5)
+
+        val result = formatter.format(context)
+
+        assertEquals(" @src/App.kt#L5 ", result)
+        assertFalse(result.contains("{owner}"))
+        assertFalse(result.contains("{repo}"))
+        assertFalse(result.contains("{sha}"))
+    }
+
+    @Test
+    fun `available formatters exclude github placeholder format`() {
+        val keys = OutputFormatterFactory.getAvailableFormatters().map { it.key }
+
+        assertEquals(listOf("claude", "pathline", "template"), keys)
     }
 }


### PR DESCRIPTION
## Rationale

The generic formatter registry exposed a GitHub formatter that had no repository context and could therefore copy unresolved `{owner}`, `{repo}`, and `{sha}` placeholders as if they were a valid permalink. Real GitHub/GitLab links already belong to the dedicated permalink action, which resolves the remote and commit SHA.

## Implementation

- Remove the placeholder GitHub formatter from the generic formatter registry and available formatter list.
- Migrate legacy persisted `outputFormat = "github"` settings to the safe Claude formatter during state loading; direct legacy factory lookups also fall back safely.
- Add focused factory and settings migration regression tests.
- Align the changelog and plugin-facing formatter documentation with the actual settings options.
- Keep `CopyGitPermalinkAction` and `GitPermalinkGenerator` unchanged for real repository-aware permalinks.

## Verification

- `JAVA_HOME=<IntelliJ-2024.3-JBR> ./gradlew test buildPlugin` — `BUILD SUCCESSFUL`; all 158 tests passed and `build/distributions/copy-selection-context-1.0.4.zip` was produced.
- Focused `OutputFormatterTest`, `CopySelectionSettingsTest`, and `GitPermalinkGeneratorTest` run — `BUILD SUCCESSFUL`.
- `unzip -t build/distributions/copy-selection-context-1.0.4.zip` — no compressed-data errors.
- IntelliJ Plugin Verifier 1.410, run with an isolated `plugin.verifier.home.dir` after the shared default verifier directory produced a transient missing-extraction-file error:
  - IC-243.28141.41 (IntelliJ IDEA 2024.3.7.1) — `Compatible`.
  - IC-251.29188.72 (IntelliJ IDEA 2025.1.7.2) — `Compatible`.
  - IC-252.28539.97 (IntelliJ IDEA 2025.2.6.3) — `Compatible`.

Closes #16
