### PR TITLE
fix: preserve context for every caret

### DIFF
--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyGitPermalinkAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyGitPermalinkAction.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.vcs.ProjectLevelVcsManager
 import java.awt.datatransfer.StringSelection
@@ -19,7 +20,7 @@ class CopyGitPermalinkAction : AnAction() {
         val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
         val requestId = requests.begin()
 
-        val (startLine, endLine) = CopySelectionUtils.resolveLineNumbers(editor)
+        val lineRanges = resolveLineRanges(editor)
         val vcsManager = ProjectLevelVcsManager.getInstance(project)
         if (vcsManager.getVcsFor(file) == null) {
             CopySelectionNotifier.notifyPermalinkFailure(project)
@@ -34,7 +35,7 @@ class CopyGitPermalinkAction : AnAction() {
         val application = ApplicationManager.getApplication()
 
         application.executeOnPooledThread {
-            val permalink = tryBuildPermalink(rootPath, filePath, startLine, endLine)
+            val permalink = tryBuildPermalink(rootPath, filePath, lineRanges)
             application.invokeLater {
                 if (project.isDisposed) return@invokeLater
                 requests.runIfCurrent(requestId) {
@@ -54,11 +55,30 @@ class CopyGitPermalinkAction : AnAction() {
             e.getData(CommonDataKeys.EDITOR) != null
     }
 
+    internal fun resolveLineRanges(editor: Editor): List<Pair<Int, Int>> {
+        if (editor.caretModel.caretCount <= 1) {
+            return listOf(CopySelectionUtils.resolveLineNumbers(editor))
+        }
+
+        return editor.caretModel.allCarets
+            .sortedBy { it.selectionStart }
+            .map { caret -> CopySelectionUtils.resolveLineNumbers(editor, caret) }
+    }
+
+    internal fun buildPermalinkContent(
+        lineRanges: List<Pair<Int, Int>>,
+        buildBlock: (startLine: Int, endLine: Int) -> String?,
+    ): String? {
+        val blocks = lineRanges.map { (startLine, endLine) ->
+            buildBlock(startLine, endLine) ?: return null
+        }
+        return CopySelectionUtils.joinCaretBlocks(blocks)
+    }
+
     private fun tryBuildPermalink(
         rootPath: String,
         filePath: String,
-        startLine: Int,
-        endLine: Int
+        lineRanges: List<Pair<Int, Int>>
     ): String? {
         return try {
             val root = Path.of(rootPath).toAbsolutePath().normalize()
@@ -66,13 +86,15 @@ class CopyGitPermalinkAction : AnAction() {
             if (!file.startsWith(root)) return null
             val relativePath = root.relativize(file).toString().replace('\\', '/')
             val metadata = GitRepositoryMetadataResolver.resolve(root) ?: return null
-            GitPermalinkGenerator.buildPermalinkFromRemote(
-                metadata.remoteUrl,
-                metadata.commitSha,
-                relativePath,
-                startLine,
-                endLine
-            )
+            buildPermalinkContent(lineRanges) { startLine, endLine ->
+                GitPermalinkGenerator.buildPermalinkFromRemote(
+                    metadata.remoteUrl,
+                    metadata.commitSha,
+                    relativePath,
+                    startLine,
+                    endLine
+                )
+            }
         } catch (_: Exception) {
             null
         }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
@@ -21,7 +21,7 @@ abstract class CopySelectionBaseAction : AnAction() {
         val caretCount = editor.caretModel.caretCount
 
         val copyResult = if (caretCount > 1) {
-            buildMultiCaretContent(path, file, editor)
+            buildMultiCaretContent(path, file, editor, project)
         } else {
             val (startLine, endLine) = resolveLineNumbers(editor)
             val lineRange = CopySelectionUtils.toLineRange(startLine, endLine)
@@ -63,24 +63,32 @@ abstract class CopySelectionBaseAction : AnAction() {
         return formatWithSettings(path, startLine, endLine, file)
     }
 
-    internal open fun buildContentForCaret(
+    protected open fun buildContentForCaret(
         path: String,
+        lineRange: String,
         startLine: Int,
         endLine: Int,
         file: VirtualFile,
         editor: Editor,
         caret: Caret,
+        project: Project? = null,
     ): String {
-        return formatWithSettings(path, startLine, endLine)
+        return formatWithSettings(path, startLine, endLine, file)
     }
 
-    internal fun buildMultiCaretContent(path: String, file: VirtualFile, editor: Editor): CaretCopyResult {
+    internal fun buildMultiCaretContent(
+        path: String,
+        file: VirtualFile,
+        editor: Editor,
+        project: Project? = null,
+    ): CaretCopyResult {
         val blocks = mutableListOf<String>()
         val lineRanges = mutableListOf<Pair<Int, Int>>()
         editor.caretModel.runForEachCaret { caret ->
             val (startLine, endLine) = CopySelectionUtils.resolveLineNumbers(editor, caret)
+            val lineRange = CopySelectionUtils.toLineRange(startLine, endLine)
             lineRanges.add(Pair(startLine, endLine))
-            blocks.add(buildContentForCaret(path, startLine, endLine, file, editor, caret))
+            blocks.add(buildContentForCaret(path, lineRange, startLine, endLine, file, editor, caret, project))
         }
         return CaretCopyResult(CopySelectionUtils.joinCaretBlocks(blocks), lineRanges)
     }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
@@ -20,19 +20,17 @@ abstract class CopySelectionBaseAction : AnAction() {
         val path = getPath(project, file)
         val caretCount = editor.caretModel.caretCount
 
-        val result = if (caretCount > 1) {
-            val blocks = mutableListOf<String>()
-            editor.caretModel.runForEachCaret { caret ->
-                val (startLine, endLine) = CopySelectionUtils.resolveLineNumbers(editor, caret)
-                val lineRange = CopySelectionUtils.toLineRange(startLine, endLine)
-                val block = buildContentForCaret(path, lineRange, startLine, endLine, file, editor, caret, project)
-                blocks.add(block)
-            }
-            CopySelectionUtils.joinCaretBlocks(blocks)
+        val copyResult = if (caretCount > 1) {
+            buildMultiCaretContent(path, file, editor)
         } else {
-            val lineRange = CopySelectionUtils.resolveLineRange(editor)
-            buildContent(path, lineRange, file, editor, project)
+            val (startLine, endLine) = resolveLineNumbers(editor)
+            val lineRange = CopySelectionUtils.toLineRange(startLine, endLine)
+            CaretCopyResult(
+                content = buildContent(path, lineRange, file, editor, project),
+                lineRanges = listOf(Pair(startLine, endLine)),
+            )
         }
+        val result = copyResult.content
 
         copyToClipboard(result)
 
@@ -41,8 +39,7 @@ abstract class CopySelectionBaseAction : AnAction() {
             CopySelectionAnalytics.getInstance()?.recordCopy(appSettings.outputFormat)
         }
 
-        val (gutterStartLine, gutterEndLine) = resolveLineNumbers(editor)
-        CopySelectionHighlighter.update(editor, gutterStartLine, gutterEndLine)
+        CopySelectionHighlighter.update(editor, copyResult.lineRanges)
 
         val historyService = project.getService(CopyHistoryService::class.java)
         val maxSize = CopySelectionSettings.getInstance().state.copyHistorySize
@@ -66,17 +63,26 @@ abstract class CopySelectionBaseAction : AnAction() {
         return formatWithSettings(path, startLine, endLine, file)
     }
 
-    protected open fun buildContentForCaret(
+    internal open fun buildContentForCaret(
         path: String,
-        lineRange: String,
         startLine: Int,
         endLine: Int,
         file: VirtualFile,
         editor: Editor,
         caret: Caret,
-        project: Project? = null
     ): String {
-        return buildContent(path, lineRange, file, editor, project)
+        return formatWithSettings(path, startLine, endLine)
+    }
+
+    internal fun buildMultiCaretContent(path: String, file: VirtualFile, editor: Editor): CaretCopyResult {
+        val blocks = mutableListOf<String>()
+        val lineRanges = mutableListOf<Pair<Int, Int>>()
+        editor.caretModel.runForEachCaret { caret ->
+            val (startLine, endLine) = CopySelectionUtils.resolveLineNumbers(editor, caret)
+            lineRanges.add(Pair(startLine, endLine))
+            blocks.add(buildContentForCaret(path, startLine, endLine, file, editor, caret))
+        }
+        return CaretCopyResult(CopySelectionUtils.joinCaretBlocks(blocks), lineRanges)
     }
 
     protected fun resolveLineNumbers(editor: Editor): Pair<Int, Int> {
@@ -108,6 +114,10 @@ abstract class CopySelectionBaseAction : AnAction() {
         return CopySelectionUtils.getCodeContent(editor)
     }
 
+    protected fun getCodeContent(editor: Editor, caret: Caret): String {
+        return CopySelectionUtils.getCodeContent(editor, caret)
+    }
+
     protected fun detectLanguage(file: VirtualFile): String {
         return CopySelectionUtils.detectLanguage(file)
     }
@@ -121,3 +131,8 @@ abstract class CopySelectionBaseAction : AnAction() {
         CopyPasteManager.getInstance().setContents(StringSelection(content))
     }
 }
+
+internal data class CaretCopyResult(
+    val content: String,
+    val lineRanges: List<Pair<Int, Int>>,
+)

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionContextAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionContextAction.kt
@@ -1,5 +1,6 @@
 package com.github.hon454.copyselectioncontext
 
+import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -19,6 +20,25 @@ class CopySelectionContextAction : CopySelectionBaseAction() {
             formatWithSettings(path, startLine, endLine, file, code, language)
         } else {
             formatWithSettings(path, startLine, endLine, file)
+        }
+    }
+
+    internal override fun buildContentForCaret(
+        path: String,
+        startLine: Int,
+        endLine: Int,
+        file: VirtualFile,
+        editor: Editor,
+        caret: Caret,
+    ): String {
+        val settings = CopySelectionSettings.getInstance().state
+        return if (settings.includeCodeContent) {
+            var code = getCodeContent(editor, caret)
+            code = applyCodeTrimming(code)
+            val language = detectLanguage(file)
+            formatWithSettings(path, startLine, endLine, code, language)
+        } else {
+            formatWithSettings(path, startLine, endLine)
         }
     }
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionContextAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionContextAction.kt
@@ -23,22 +23,24 @@ class CopySelectionContextAction : CopySelectionBaseAction() {
         }
     }
 
-    internal override fun buildContentForCaret(
+    protected override fun buildContentForCaret(
         path: String,
+        lineRange: String,
         startLine: Int,
         endLine: Int,
         file: VirtualFile,
         editor: Editor,
         caret: Caret,
+        project: Project?,
     ): String {
         val settings = CopySelectionSettings.getInstance().state
         return if (settings.includeCodeContent) {
             var code = getCodeContent(editor, caret)
             code = applyCodeTrimming(code)
             val language = detectLanguage(file)
-            formatWithSettings(path, startLine, endLine, code, language)
+            formatWithSettings(path, startLine, endLine, file, code, language)
         } else {
-            formatWithSettings(path, startLine, endLine)
+            formatWithSettings(path, startLine, endLine, file)
         }
     }
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionHighlighter.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionHighlighter.kt
@@ -7,27 +7,34 @@ import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.util.Key
 
 internal object CopySelectionHighlighter {
-    private val lastHighlighterKey = Key.create<RangeHighlighter>(
-        "CopySelectionContext.lastHighlighter"
+    private val lastHighlightersKey = Key.create<List<RangeHighlighter>>(
+        "CopySelectionContext.lastHighlighters"
     )
 
     fun update(editor: Editor, startLine: Int, endLine: Int) {
+        update(editor, listOf(Pair(startLine, endLine)))
+    }
+
+    fun update(editor: Editor, lineRanges: List<Pair<Int, Int>>) {
         val markupModel = editor.markupModel
-        editor.getUserData(lastHighlighterKey)
-            ?.takeIf { it.isValid }
-            ?.let(markupModel::removeHighlighter)
+        editor.getUserData(lastHighlightersKey)
+            .orEmpty()
+            .filter { it.isValid }
+            .forEach(markupModel::removeHighlighter)
 
         val document = editor.document
-        val startOffset = document.getLineStartOffset(startLine - 1)
-        val endOffset = document.getLineEndOffset(endLine - 1)
-        val highlighter = markupModel.addRangeHighlighter(
-            startOffset,
-            endOffset,
-            HighlighterLayer.ADDITIONAL_SYNTAX,
-            null,
-            HighlighterTargetArea.LINES_IN_RANGE,
-        ).also { it.gutterIconRenderer = CopySelectionGutterIconRenderer() }
+        val highlighters = lineRanges.map { (startLine, endLine) ->
+            val startOffset = document.getLineStartOffset(startLine - 1)
+            val endOffset = document.getLineEndOffset(endLine - 1)
+            markupModel.addRangeHighlighter(
+                startOffset,
+                endOffset,
+                HighlighterLayer.ADDITIONAL_SYNTAX,
+                null,
+                HighlighterTargetArea.LINES_IN_RANGE,
+            ).also { it.gutterIconRenderer = CopySelectionGutterIconRenderer() }
+        }
 
-        editor.putUserData(lastHighlighterKey, highlighter)
+        editor.putUserData(lastHighlightersKey, highlighters)
     }
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionUtils.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionUtils.kt
@@ -132,6 +132,18 @@ object CopySelectionUtils {
         }
     }
 
+    fun getCodeContent(editor: Editor, caret: Caret): String {
+        return if (caret.hasSelection()) {
+            caret.selectedText ?: ""
+        } else {
+            val document = editor.document
+            val caretLine = caret.logicalPosition.line
+            val lineStart = document.getLineStartOffset(caretLine)
+            val lineEnd = document.getLineEndOffset(caretLine)
+            document.getText(TextRange(lineStart, lineEnd))
+        }
+    }
+
     fun detectLanguage(file: VirtualFile): String {
         val fileTypeName = file.fileType.name.lowercase()
         return LANGUAGE_MAP[fileTypeName] ?: file.extension?.lowercase().orEmpty()

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyWithCodeContentAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyWithCodeContentAction.kt
@@ -19,17 +19,19 @@ class CopyWithCodeContentAction : CopySelectionBaseAction() {
         return formatWithSettings(path, startLine, endLine, file, code, language)
     }
 
-    internal override fun buildContentForCaret(
+    protected override fun buildContentForCaret(
         path: String,
+        lineRange: String,
         startLine: Int,
         endLine: Int,
         file: VirtualFile,
         editor: Editor,
         caret: Caret,
+        project: Project?,
     ): String {
         var code = getCodeContent(editor, caret)
         code = applyCodeTrimming(code)
         val language = detectLanguage(file)
-        return formatWithSettings(path, startLine, endLine, code, language)
+        return formatWithSettings(path, startLine, endLine, file, code, language)
     }
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyWithCodeContentAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyWithCodeContentAction.kt
@@ -1,5 +1,6 @@
 package com.github.hon454.copyselectioncontext
 
+import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -16,5 +17,19 @@ class CopyWithCodeContentAction : CopySelectionBaseAction() {
         code = applyCodeTrimming(code)
         val language = detectLanguage(file)
         return formatWithSettings(path, startLine, endLine, file, code, language)
+    }
+
+    internal override fun buildContentForCaret(
+        path: String,
+        startLine: Int,
+        endLine: Int,
+        file: VirtualFile,
+        editor: Editor,
+        caret: Caret,
+    ): String {
+        var code = getCodeContent(editor, caret)
+        code = applyCodeTrimming(code)
+        val language = detectLanguage(file)
+        return formatWithSettings(path, startLine, endLine, code, language)
     }
 }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopyGitPermalinkActionTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopyGitPermalinkActionTest.kt
@@ -1,0 +1,103 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.editor.CaretModel
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.editor.SelectionModel
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CopyGitPermalinkActionTest {
+    private val action = CopyGitPermalinkAction()
+
+    @Test
+    fun `single caret keeps the editor selection range contract`() {
+        val editor = mockk<Editor>()
+        val caretModel = mockk<CaretModel>()
+        val selectionModel = mockk<SelectionModel>()
+        val document = mockk<Document>()
+
+        every { editor.caretModel } returns caretModel
+        every { editor.selectionModel } returns selectionModel
+        every { editor.document } returns document
+        every { caretModel.caretCount } returns 1
+        every { selectionModel.hasSelection() } returns true
+        every { selectionModel.selectionStart } returns 10
+        every { selectionModel.selectionEnd } returns 30
+        every { document.getLineNumber(10) } returns 1
+        every { document.getLineNumber(29) } returns 2
+
+        val result = action.resolveLineRanges(editor)
+
+        assertEquals(listOf(Pair(2, 3)), result)
+    }
+
+    @Test
+    fun `multi-caret ranges are copied in document order with current-line fallback`() {
+        val editor = mockk<Editor>()
+        val caretModel = mockk<CaretModel>()
+        val document = mockk<Document>()
+        val earlySelection = selectedCaret(selectionStart = 10, selectionEnd = 30)
+        val currentLineCaret = mockk<Caret>()
+        val lateSelection = selectedCaret(selectionStart = 80, selectionEnd = 110)
+
+        every { editor.caretModel } returns caretModel
+        every { editor.document } returns document
+        every { caretModel.caretCount } returns 3
+        every { caretModel.allCarets } returns listOf(lateSelection, currentLineCaret, earlySelection)
+        every { currentLineCaret.selectionStart } returns 50
+        every { currentLineCaret.hasSelection() } returns false
+        every { currentLineCaret.logicalPosition } returns LogicalPosition(4, 0)
+        every { document.getLineNumber(10) } returns 1
+        every { document.getLineNumber(29) } returns 2
+        every { document.getLineNumber(80) } returns 7
+        every { document.getLineNumber(109) } returns 9
+
+        val result = action.resolveLineRanges(editor)
+
+        assertEquals(listOf(Pair(2, 3), Pair(5, 5), Pair(8, 10)), result)
+    }
+
+    @Test
+    fun `multi-caret permalinks preserve line fragments and block separator`() {
+        val lineRanges = listOf(Pair(2, 3), Pair(5, 5), Pair(8, 10))
+
+        val result = action.buildPermalinkContent(lineRanges) { startLine, endLine ->
+            GitPermalinkGenerator.buildPermalink(
+                repoUrl = "https://github.com/owner/repo",
+                host = "github.com",
+                sha = "abc123",
+                filePath = "src/Main.kt",
+                startLine = startLine,
+                endLine = endLine,
+            )
+        }
+
+        assertEquals(
+            "https://github.com/owner/repo/blob/abc123/src/Main.kt#L2-L3\n\n" +
+                "https://github.com/owner/repo/blob/abc123/src/Main.kt#L5\n\n" +
+                "https://github.com/owner/repo/blob/abc123/src/Main.kt#L8-L10",
+            result,
+        )
+    }
+
+    @Test
+    fun `multi-caret permalink content fails when any range cannot be resolved`() {
+        val result = action.buildPermalinkContent(listOf(Pair(2, 3), Pair(5, 5))) { startLine, _ ->
+            if (startLine == 2) "first-permalink" else null
+        }
+
+        assertNull(result)
+    }
+
+    private fun selectedCaret(selectionStart: Int, selectionEnd: Int): Caret = mockk<Caret>().also { caret ->
+        every { caret.selectionStart } returns selectionStart
+        every { caret.selectionEnd } returns selectionEnd
+        every { caret.hasSelection() } returns true
+    }
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionHighlighterTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionHighlighterTest.kt
@@ -32,16 +32,44 @@ class CopySelectionHighlighterTest {
     }
 
     @Test
-    fun `previous highlighter is replaced within the same editor`() {
-        val previousHighlighter = mockHighlighter()
-        val replacementHighlighter = mockHighlighter()
-        val editor = mockEditor(previousHighlighter, replacementHighlighter)
+    fun `multi-caret update adds a gutter marker for every copied range`() {
+        val firstHighlighter = mockHighlighter()
+        val secondHighlighter = mockHighlighter()
+        val editor = mockEditor(firstHighlighter, secondHighlighter)
 
-        CopySelectionHighlighter.update(editor.editor, 1, 1)
+        CopySelectionHighlighter.update(editor.editor, listOf(Pair(1, 1), Pair(3, 4)))
+
+        verify(exactly = 1) {
+            editor.markupModel.addRangeHighlighter(
+                0,
+                9,
+                HighlighterLayer.ADDITIONAL_SYNTAX,
+                null,
+                HighlighterTargetArea.LINES_IN_RANGE,
+            )
+            editor.markupModel.addRangeHighlighter(
+                20,
+                39,
+                HighlighterLayer.ADDITIONAL_SYNTAX,
+                null,
+                HighlighterTargetArea.LINES_IN_RANGE,
+            )
+        }
+    }
+
+    @Test
+    fun `previous multi-caret highlighters are replaced within the same editor`() {
+        val firstPreviousHighlighter = mockHighlighter()
+        val secondPreviousHighlighter = mockHighlighter()
+        val replacementHighlighter = mockHighlighter()
+        val editor = mockEditor(firstPreviousHighlighter, secondPreviousHighlighter, replacementHighlighter)
+
+        CopySelectionHighlighter.update(editor.editor, listOf(Pair(1, 1), Pair(3, 4)))
         CopySelectionHighlighter.update(editor.editor, 1, 1)
 
         verify(exactly = 1) {
-            editor.markupModel.removeHighlighter(previousHighlighter)
+            editor.markupModel.removeHighlighter(firstPreviousHighlighter)
+            editor.markupModel.removeHighlighter(secondPreviousHighlighter)
         }
     }
 
@@ -49,26 +77,26 @@ class CopySelectionHighlighterTest {
         val editor = mockk<Editor>()
         val document = mockk<Document>()
         val markupModel = mockk<MarkupModel>()
-        var storedHighlighter: RangeHighlighter? = null
+        var storedHighlighters: List<RangeHighlighter>? = null
 
         every { editor.document } returns document
         every { editor.markupModel } returns markupModel
-        every { document.getLineStartOffset(0) } returns 0
-        every { document.getLineEndOffset(0) } returns 10
+        every { document.getLineStartOffset(any()) } answers { firstArg<Int>() * 10 }
+        every { document.getLineEndOffset(any()) } answers { firstArg<Int>() * 10 + 9 }
         every { markupModel.addRangeHighlighter(
-            0,
-            10,
+            any(),
+            any(),
             HighlighterLayer.ADDITIONAL_SYNTAX,
             null,
             HighlighterTargetArea.LINES_IN_RANGE,
         ) } returnsMany highlighters.toList()
-        every { editor.getUserData(any<Key<RangeHighlighter>>()) } answers {
-            storedHighlighter
+        every { editor.getUserData(any<Key<List<RangeHighlighter>>>()) } answers {
+            storedHighlighters
         }
         every {
-            editor.putUserData(any<Key<RangeHighlighter>>(), any<RangeHighlighter>())
+            editor.putUserData(any<Key<List<RangeHighlighter>>>(), any<List<RangeHighlighter>>())
         } answers {
-            storedHighlighter = secondArg()
+            storedHighlighters = secondArg()
         }
         every { markupModel.removeHighlighter(any()) } just Runs
 

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionMultiCaretTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionMultiCaretTest.kt
@@ -1,0 +1,125 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.editor.CaretAction
+import com.intellij.openapi.editor.CaretModel
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CopySelectionMultiCaretTest {
+    @Test
+    fun `settings action formats each caret with its own range and code`() = withSettings(
+        CopySelectionSettings.State(includeCodeContent = true),
+    ) {
+        val fixture = multiCaretFixture()
+        val action = CopySelectionContextAction()
+
+        val result = action.buildMultiCaretContent("src/App.kt", fixture.file, fixture.editor)
+
+        assertEquals(
+            " @src/App.kt#L1-2 \n```kotlin\nfirst()\n```\n\n" +
+                " @src/App.kt#L5 \n```kotlin\nsecond()\n```",
+            result.content,
+        )
+        assertEquals(listOf(Pair(1, 2), Pair(5, 5)), result.lineRanges)
+    }
+
+    @Test
+    fun `explicit code action formats each caret with its own range and code`() = withSettings(
+        CopySelectionSettings.State(),
+    ) {
+        val fixture = multiCaretFixture()
+        val action = CopyWithCodeContentAction()
+
+        val result = action.buildMultiCaretContent("src/App.kt", fixture.file, fixture.editor)
+
+        assertEquals(
+            " @src/App.kt#L1-2 \n```kotlin\nfirst()\n```\n\n" +
+                " @src/App.kt#L5 \n```kotlin\nsecond()\n```",
+            result.content,
+        )
+        assertEquals(listOf(Pair(1, 2), Pair(5, 5)), result.lineRanges)
+    }
+
+    @Test
+    fun `explicit path actions format each caret with its own range`() = withSettings(
+        CopySelectionSettings.State(),
+    ) {
+        val fixture = multiCaretFixture()
+        val actions = listOf(CopyAbsolutePathAction(), CopyRelativePathAction())
+
+        actions.forEach { action ->
+            val result = action.buildMultiCaretContent("src/App.kt", fixture.file, fixture.editor)
+
+            assertEquals(
+                " @src/App.kt#L1-2 \n\n @src/App.kt#L5 ",
+                result.content,
+            )
+            assertEquals(listOf(Pair(1, 2), Pair(5, 5)), result.lineRanges)
+        }
+    }
+
+    private fun multiCaretFixture(): MultiCaretFixture {
+        val editor = mockk<Editor>()
+        val caretModel = mockk<CaretModel>()
+        val document = mockk<Document>()
+        val selectedCaret = mockk<Caret>()
+        val currentLineCaret = mockk<Caret>()
+        val file = mockk<VirtualFile>()
+        val fileType = mockk<FileType>()
+
+        every { editor.document } returns document
+        every { editor.caretModel } returns caretModel
+        every { selectedCaret.hasSelection() } returns true
+        every { selectedCaret.selectionStart } returns 0
+        every { selectedCaret.selectionEnd } returns 12
+        every { selectedCaret.selectedText } returns "first()"
+        every { currentLineCaret.hasSelection() } returns false
+        every { currentLineCaret.logicalPosition } returns LogicalPosition(4, 0)
+        every { document.getLineNumber(0) } returns 0
+        every { document.getLineNumber(12) } returns 1
+        every { document.getLineStartOffset(4) } returns 40
+        every { document.getLineEndOffset(4) } returns 48
+        every { document.getText(TextRange(40, 48)) } returns "second()"
+        every { caretModel.runForEachCaret(any<CaretAction>()) } answers {
+            val action = firstArg<CaretAction>()
+            action.perform(selectedCaret)
+            action.perform(currentLineCaret)
+        }
+        every { file.fileType } returns fileType
+        every { fileType.name } returns "Kotlin"
+        every { file.extension } returns "kt"
+
+        return MultiCaretFixture(editor, selectedCaret, currentLineCaret, file)
+    }
+
+    private fun withSettings(state: CopySelectionSettings.State, test: () -> Unit) {
+        val settings = mockk<CopySelectionSettings>()
+        mockkObject(CopySelectionSettings.Companion)
+        every { CopySelectionSettings.getInstance() } returns settings
+        every { settings.state } returns state
+
+        try {
+            test()
+        } finally {
+            unmockkObject(CopySelectionSettings.Companion)
+        }
+    }
+
+    private data class MultiCaretFixture(
+        val editor: Editor,
+        val selectedCaret: Caret,
+        val currentLineCaret: Caret,
+        val file: VirtualFile,
+    )
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionMultiCaretTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionMultiCaretTest.kt
@@ -87,7 +87,7 @@ class CopySelectionMultiCaretTest {
         every { currentLineCaret.hasSelection() } returns false
         every { currentLineCaret.logicalPosition } returns LogicalPosition(4, 0)
         every { document.getLineNumber(0) } returns 0
-        every { document.getLineNumber(12) } returns 1
+        every { document.getLineNumber(11) } returns 1
         every { document.getLineStartOffset(4) } returns 40
         every { document.getLineEndOffset(4) } returns 48
         every { document.getText(TextRange(40, 48)) } returns "second()"
@@ -99,6 +99,7 @@ class CopySelectionMultiCaretTest {
         every { file.fileType } returns fileType
         every { fileType.name } returns "Kotlin"
         every { file.extension } returns "kt"
+        every { file.name } returns "App.kt"
 
         return MultiCaretFixture(editor, selectedCaret, currentLineCaret, file)
     }


### PR DESCRIPTION
## Rationale

Multi-caret copy calculated a range for each caret, but delegated block creation back to the editor-wide primary selection. That could repeat the same range and code instead of preserving each caret's context.

The explicit Git permalink action also read only the primary editor selection, so it omitted the remaining carets entirely.

## Implementation

- build multi-caret output from each `Caret`'s own range, selected text, or current-line fallback
- preserve the settings-driven action and all explicit path/code action behavior
- include every Git permalink range in document order, using the established blank-line block separator and preserving existing single-caret URL/fallback formats
- show gutter feedback for every copied caret range and replace all prior markers on the next copy
- add focused regression tests for distinct caret ranges/code, Git permalink ordering and fallback, and the multi-caret gutter policy

## Verification

- Gradle 9.7.1 with JDK 21: `test buildPlugin --rerun-tasks` — passed all 162 tests with 0 failures, 0 errors, and 0 skipped; plugin ZIP built successfully
- Plugin Verifier 1.410 `check-plugin`, each run with an isolated temporary `user.home` — Compatible with IC-243.28141.41 (2024.3.7.1)
- Plugin Verifier 1.410 `check-plugin`, each run with an isolated temporary `user.home` — Compatible with IC-251.29188.72 (2025.1.7.2)
- Plugin Verifier 1.410 `check-plugin`, each run with an isolated temporary `user.home` — Compatible with IC-252.28539.97 (2025.2.6.3)
- `unzip -t build/distributions/copy-selection-context-1.0.4.zip` — no errors detected
- GitHub Actions `Build` run 33484267016 — passed plugin build, ZIP existence check, and artifact upload

## Integration note

PR #29 also rewrites `CopyGitPermalinkAction.kt` for worktree-aware asynchronous metadata resolution. This PR intentionally does not import that implementation; when both changes land, its action rewrite will need to retain this PR's document-ordered multi-caret range collection and block joining.

Closes #5
