### PR TITLE
test(actions): cover actionPerformed with fixtures

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,9 @@ tasks {
 
     test {
         useJUnitPlatform()
+        // IntelliJ's JUnit 3 fixtures and JUnit 5 TestApplication fixtures retain
+        // engine-scoped application state, so keep each test class in its own JVM.
+        forkEvery = 1
     }
 
     buildSearchableOptions {

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyGitPermalinkAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyGitPermalinkAction.kt
@@ -6,12 +6,14 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.ProjectLevelVcsManager
+import com.intellij.openapi.vfs.VirtualFile
 import java.awt.datatransfer.StringSelection
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicLong
 
-class CopyGitPermalinkAction : AnAction() {
+open class CopyGitPermalinkAction : AnAction() {
     private val requests = LatestPermalinkRequestTracker()
 
     override fun actionPerformed(e: AnActionEvent) {
@@ -21,29 +23,23 @@ class CopyGitPermalinkAction : AnAction() {
         val requestId = requests.begin()
 
         val lineRanges = resolveLineRanges(editor)
-        val vcsManager = ProjectLevelVcsManager.getInstance(project)
-        if (vcsManager.getVcsFor(file) == null) {
-            CopySelectionNotifier.notifyPermalinkFailure(project)
-            return
-        }
-        val rootPath = vcsManager.getVcsRootFor(file)?.path
+        val rootPath = resolveGitRootPath(project, file)
         if (rootPath == null) {
-            CopySelectionNotifier.notifyPermalinkFailure(project)
+            showPermalinkFailure(project)
             return
         }
         val filePath = file.path
-        val application = ApplicationManager.getApplication()
 
-        application.executeOnPooledThread {
+        executeInBackground {
             val permalink = tryBuildPermalink(rootPath, filePath, lineRanges)
-            application.invokeLater {
-                if (project.isDisposed) return@invokeLater
+            invokeOnUiThread {
+                if (project.isDisposed) return@invokeOnUiThread
                 requests.runIfCurrent(requestId) {
                     if (permalink == null) {
-                        CopySelectionNotifier.notifyPermalinkFailure(project)
+                        showPermalinkFailure(project)
                     } else {
                         CopyPasteManager.getInstance().setContents(StringSelection(permalink))
-                        CopySelectionNotifier.notify(project, permalink)
+                        showPermalinkSuccess(project, permalink)
                     }
                 }
             }
@@ -53,6 +49,28 @@ class CopyGitPermalinkAction : AnAction() {
     override fun update(e: AnActionEvent) {
         e.presentation.isEnabledAndVisible = e.getData(CommonDataKeys.PROJECT) != null &&
             e.getData(CommonDataKeys.EDITOR) != null
+    }
+
+    protected open fun resolveGitRootPath(project: Project, file: VirtualFile): String? {
+        val vcsManager = ProjectLevelVcsManager.getInstance(project)
+        if (vcsManager.getVcsFor(file) == null) return null
+        return vcsManager.getVcsRootFor(file)?.path
+    }
+
+    protected open fun executeInBackground(action: () -> Unit) {
+        ApplicationManager.getApplication().executeOnPooledThread(action)
+    }
+
+    protected open fun invokeOnUiThread(action: () -> Unit) {
+        ApplicationManager.getApplication().invokeLater(action)
+    }
+
+    protected open fun showPermalinkFailure(project: Project) {
+        CopySelectionNotifier.notifyPermalinkFailure(project)
+    }
+
+    protected open fun showPermalinkSuccess(project: Project, permalink: String) {
+        CopySelectionNotifier.notify(project, permalink)
     }
 
     internal fun resolveLineRanges(editor: Editor): List<Pair<Int, Int>> {
@@ -75,7 +93,7 @@ class CopyGitPermalinkAction : AnAction() {
         return CopySelectionUtils.joinCaretBlocks(blocks)
     }
 
-    private fun tryBuildPermalink(
+    protected open fun tryBuildPermalink(
         rootPath: String,
         filePath: String,
         lineRanges: List<Pair<Int, Int>>

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
@@ -45,9 +45,17 @@ abstract class CopySelectionBaseAction : AnAction() {
         val maxSize = CopySelectionSettings.getInstance().state.copyHistorySize
         historyService?.addEntry(result, maxSize)
 
-        CopySelectionNotifier.notify(project, result)
+        showNotification(project, result)
+        updateStatusBar(project, result)
+    }
+
+    protected open fun showNotification(project: Project, content: String) {
+        CopySelectionNotifier.notify(project, content)
+    }
+
+    protected open fun updateStatusBar(project: Project, content: String) {
         val statusBar = WindowManager.getInstance().getStatusBar(project)
-        (statusBar?.getWidget(CopySelectionStatusBarWidget.ID) as? CopySelectionStatusBarWidget)?.update(result)
+        (statusBar?.getWidget(CopySelectionStatusBarWidget.ID) as? CopySelectionStatusBarWidget)?.update(content)
     }
     
     override fun update(e: AnActionEvent) {

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionContextAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionContextAction.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 
-class CopySelectionContextAction : CopySelectionBaseAction() {
+open class CopySelectionContextAction : CopySelectionBaseAction() {
     override fun getPath(project: Project, file: VirtualFile): String {
         return CopySelectionUtils.resolvePath(project, file, CopySelectionSettings.getInstance().state.defaultPathType)
     }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionActionFixtureTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionActionFixtureTest.kt
@@ -1,0 +1,180 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.testFramework.TestActionEvent
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+
+class CopySelectionActionFixtureTest : BasePlatformTestCase() {
+    private lateinit var originalSettings: CopySelectionSettings.State
+    private var originalClipboard: Transferable? = null
+
+    override fun setUp() {
+        super.setUp()
+        originalSettings = CopySelectionSettings.getInstance().state.copy()
+        originalClipboard = CopyPasteManager.getInstance().contents
+        resetActionState()
+    }
+
+    override fun tearDown() {
+        try {
+            CopySelectionSettings.getInstance().loadState(originalSettings)
+            CopyPasteManager.getInstance().setContents(originalClipboard ?: StringSelection(""))
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testMainActionCopiesSingleSelectionAndUpdatesLocalSideEffects() {
+        myFixture.configureByText(
+            "single.txt",
+            "<selection>first line\nsecond</selection> line\nthird line",
+        )
+
+        perform(CopySelectionContextAction())
+
+        val expected = "${relativePath()}:1-2"
+        assertEquals(expected, clipboardText())
+        assertEquals(listOf(expected), historyContents())
+        assertEquals(1, myFixture.editor.markupModel.allHighlighters.size)
+        assertTrue(
+            myFixture.editor.markupModel.allHighlighters.single().gutterIconRenderer is
+                CopySelectionGutterIconRenderer,
+        )
+    }
+
+    fun testMainActionFallsBackToCurrentLineWithoutSelection() {
+        myFixture.configureByText("fallback.txt", "first line\nsecond<caret> line\nthird line")
+
+        perform(CopySelectionContextAction())
+
+        assertEquals("${relativePath()}:2", clipboardText())
+    }
+
+    fun testMainActionFormatsEveryCaretIndependently() {
+        myFixture.configureByText("multiple.txt", "first line\nsecond line\nthird line\nfourth line")
+        val document = myFixture.editor.document
+        val primaryCaret = myFixture.editor.caretModel.primaryCaret
+        primaryCaret.moveToLogicalPosition(LogicalPosition(0, 0))
+        primaryCaret.setSelection(document.getLineStartOffset(0), document.getLineEndOffset(0))
+        val secondCaret = requireNotNull(
+            myFixture.editor.caretModel.addCaret(
+                myFixture.editor.logicalToVisualPosition(LogicalPosition(2, 0)),
+            ),
+        )
+        secondCaret.setSelection(document.getLineStartOffset(2), document.getLineEndOffset(2))
+
+        perform(CopySelectionContextAction())
+
+        val path = relativePath()
+        assertEquals("$path:1\n\n$path:3", clipboardText())
+        assertEquals(listOf("$path:1\n\n$path:3"), historyContents())
+    }
+
+    fun testMainActionIncludesTrimmedCodeWithCustomTemplate() {
+        myFixture.configureByText("custom.txt", "<selection>  selected code  </selection>\nignored")
+        settings().apply {
+            includeCodeContent = true
+            codeTrimming = true
+            outputFormat = "template"
+            customFormatTemplate =
+                "[{path}] file={filename}; lines={range}; lang={lang}; code={code}"
+        }
+
+        perform(CopySelectionContextAction())
+
+        assertEquals(
+            "[${relativePath()}] file=custom.txt; lines=1; lang=txt; code=selected code",
+            clipboardText(),
+        )
+    }
+
+    fun testExplicitActionsExecuteAgainstFixtureEditor() {
+        myFixture.configureByText("explicit.txt", "alpha\n<selection>beta\ngamma</selection>\ndelta")
+        val relativePath = relativePath()
+        val absolutePath = myFixture.file.virtualFile.path
+
+        perform(CopyRelativePathAction())
+        assertEquals("$relativePath:2-3", clipboardText())
+
+        perform(CopyAbsolutePathAction())
+        assertEquals("$absolutePath:2-3", clipboardText())
+
+        perform(CopyWithCodeContentAction())
+        assertEquals(
+            "$relativePath:2-3\n```txt\nbeta\ngamma\n```",
+            clipboardText(),
+        )
+    }
+
+    fun testActionReturnsWithoutSideEffectsWhenRequiredDataKeysAreUnavailable() {
+        myFixture.configureByText("missing.txt", "content<caret>")
+        val contexts = listOf(
+            actionContext(includeProject = false),
+            actionContext(includeEditor = false),
+            actionContext(includeFile = false),
+        )
+
+        contexts.forEachIndexed { index, context ->
+            val sentinel = "unchanged-$index"
+            CopyPasteManager.getInstance().setContents(StringSelection(sentinel))
+            CopyHistoryService.getInstance(project).clear()
+
+            perform(CopySelectionContextAction(), context)
+
+            assertEquals(sentinel, clipboardText())
+            assertTrue(historyContents().isEmpty())
+        }
+    }
+
+    private fun resetActionState() {
+        CopySelectionSettings.getInstance().loadState(
+            CopySelectionSettings.State(
+                defaultPathType = PathType.RELATIVE,
+                includeCodeContent = false,
+                enableNotification = false,
+                outputFormat = "pathline",
+                codeTrimming = false,
+                copyHistorySize = 10,
+                customFormatTemplate = "",
+                analyticsEnabled = false,
+            ),
+        )
+        CopyHistoryService.getInstance(project).clear()
+        CopyPasteManager.getInstance().setContents(StringSelection("fixture-initial"))
+    }
+
+    private fun settings(): CopySelectionSettings.State = CopySelectionSettings.getInstance().state
+
+    private fun relativePath(): String =
+        CopySelectionUtils.resolvePath(project, myFixture.file.virtualFile, PathType.RELATIVE)
+
+    private fun historyContents(): List<String> =
+        CopyHistoryService.getInstance(project).getEntries().map { it.content }
+
+    private fun clipboardText(): String? =
+        CopyPasteManager.getInstance().getContents(DataFlavor.stringFlavor)
+
+    private fun perform(action: AnAction, context: DataContext = actionContext()) {
+        action.actionPerformed(TestActionEvent.createTestEvent(action, context))
+    }
+
+    private fun actionContext(
+        includeProject: Boolean = true,
+        includeEditor: Boolean = true,
+        includeFile: Boolean = true,
+    ): DataContext = DataContext { dataId ->
+        when (dataId) {
+            CommonDataKeys.PROJECT.name -> project.takeIf { includeProject }
+            CommonDataKeys.EDITOR.name -> myFixture.editor.takeIf { includeEditor }
+            CommonDataKeys.VIRTUAL_FILE.name -> myFixture.file.virtualFile.takeIf { includeFile }
+            else -> null
+        }
+    }
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionActionFixtureTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionActionFixtureTest.kt
@@ -5,6 +5,8 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.TestActionEvent
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import java.awt.datatransfer.DataFlavor
@@ -36,12 +38,16 @@ class CopySelectionActionFixtureTest : BasePlatformTestCase() {
             "single.txt",
             "<selection>first line\nsecond</selection> line\nthird line",
         )
+        settings().enableNotification = true
 
-        perform(CopySelectionContextAction())
+        val action = RecordingCopySelectionContextAction()
+        perform(action)
 
         val expected = "${relativePath()}:1-2"
         assertEquals(expected, clipboardText())
         assertEquals(listOf(expected), historyContents())
+        assertEquals(listOf(expected), action.notificationMessages)
+        assertEquals(listOf(expected), action.statusBarMessages)
         assertEquals(1, myFixture.editor.markupModel.allHighlighters.size)
         assertTrue(
             myFixture.editor.markupModel.allHighlighters.single().gutterIconRenderer is
@@ -113,8 +119,65 @@ class CopySelectionActionFixtureTest : BasePlatformTestCase() {
         )
     }
 
+    fun testGitPermalinkActionCoversAsyncMultiCaretSuccessAndFailure() {
+        myFixture.configureByText(
+            "permalink.txt",
+            "first line\nsecond line\nthird line\nfourth line",
+        )
+        val document = myFixture.editor.document
+        val primaryCaret = myFixture.editor.caretModel.primaryCaret
+        primaryCaret.moveToLogicalPosition(LogicalPosition(1, 0))
+        primaryCaret.setSelection(document.getLineStartOffset(1), document.getLineEndOffset(1))
+        val secondCaret = requireNotNull(
+            myFixture.editor.caretModel.addCaret(
+                myFixture.editor.logicalToVisualPosition(LogicalPosition(3, 0)),
+            ),
+        )
+        secondCaret.setSelection(document.getLineStartOffset(3), document.getLineEndOffset(3))
+        val clipboardSentinel = "clipboard-before-permalink"
+        CopyPasteManager.getInstance().setContents(StringSelection(clipboardSentinel))
+        val resolvedPermalink =
+            "https://github.com/owner/repo/blob/abc123/src/permalink.txt#L2\n\n" +
+                "https://github.com/owner/repo/blob/abc123/src/permalink.txt#L4"
+
+        val resolvedAction = StubCopyGitPermalinkAction(resolvedPermalink)
+        perform(resolvedAction)
+
+        assertEquals(clipboardSentinel, clipboardText())
+        assertEquals(1, resolvedAction.backgroundActions.size)
+        assertTrue(resolvedAction.uiActions.isEmpty())
+
+        resolvedAction.runBackgroundAction()
+
+        assertEquals(clipboardSentinel, clipboardText())
+        assertEquals(1, resolvedAction.uiActions.size)
+        assertEquals(myFixture.file.virtualFile.path, resolvedAction.requestedFilePath)
+        assertEquals(listOf(Pair(2, 2), Pair(4, 4)), resolvedAction.requestedLineRanges)
+
+        resolvedAction.runUiAction()
+
+        assertEquals(resolvedPermalink, clipboardText())
+        assertEquals(listOf(resolvedPermalink), resolvedAction.successMessages)
+        assertEquals(0, resolvedAction.failureCount)
+
+        myFixture.configureByText("failed-permalink.txt", "first line\nsecond<caret> line")
+        val failureSentinel = "clipboard-before-failure"
+        CopyPasteManager.getInstance().setContents(StringSelection(failureSentinel))
+        val failedAction = StubCopyGitPermalinkAction(null)
+
+        perform(failedAction)
+        failedAction.runBackgroundAction()
+        failedAction.runUiAction()
+
+        assertEquals(failureSentinel, clipboardText())
+        assertEquals(1, failedAction.failureCount)
+        assertTrue(failedAction.successMessages.isEmpty())
+    }
+
     fun testActionReturnsWithoutSideEffectsWhenRequiredDataKeysAreUnavailable() {
         myFixture.configureByText("missing.txt", "content<caret>")
+        settings().enableNotification = true
+        val action = RecordingCopySelectionContextAction()
         val contexts = listOf(
             actionContext(includeProject = false),
             actionContext(includeEditor = false),
@@ -126,10 +189,12 @@ class CopySelectionActionFixtureTest : BasePlatformTestCase() {
             CopyPasteManager.getInstance().setContents(StringSelection(sentinel))
             CopyHistoryService.getInstance(project).clear()
 
-            perform(CopySelectionContextAction(), context)
+            perform(action, context)
 
             assertEquals(sentinel, clipboardText())
             assertTrue(historyContents().isEmpty())
+            assertTrue(action.notificationMessages.isEmpty())
+            assertTrue(action.statusBarMessages.isEmpty())
         }
     }
 
@@ -175,6 +240,66 @@ class CopySelectionActionFixtureTest : BasePlatformTestCase() {
             CommonDataKeys.EDITOR.name -> myFixture.editor.takeIf { includeEditor }
             CommonDataKeys.VIRTUAL_FILE.name -> myFixture.file.virtualFile.takeIf { includeFile }
             else -> null
+        }
+    }
+
+    private class RecordingCopySelectionContextAction : CopySelectionContextAction() {
+        val notificationMessages = mutableListOf<String>()
+        val statusBarMessages = mutableListOf<String>()
+
+        override fun showNotification(project: Project, content: String) {
+            notificationMessages.add(content)
+        }
+
+        override fun updateStatusBar(project: Project, content: String) {
+            statusBarMessages.add(content)
+        }
+    }
+
+    private class StubCopyGitPermalinkAction(
+        private val permalink: String?,
+    ) : CopyGitPermalinkAction() {
+        val backgroundActions = mutableListOf<() -> Unit>()
+        val uiActions = mutableListOf<() -> Unit>()
+        val successMessages = mutableListOf<String>()
+        var failureCount = 0
+        var requestedFilePath: String? = null
+        var requestedLineRanges: List<Pair<Int, Int>>? = null
+
+        override fun resolveGitRootPath(project: Project, file: VirtualFile): String = "/fixture-repo"
+
+        override fun executeInBackground(action: () -> Unit) {
+            backgroundActions.add(action)
+        }
+
+        override fun invokeOnUiThread(action: () -> Unit) {
+            uiActions.add(action)
+        }
+
+        override fun tryBuildPermalink(
+            rootPath: String,
+            filePath: String,
+            lineRanges: List<Pair<Int, Int>>,
+        ): String? {
+            requestedFilePath = filePath
+            requestedLineRanges = lineRanges
+            return permalink
+        }
+
+        override fun showPermalinkFailure(project: Project) {
+            failureCount += 1
+        }
+
+        override fun showPermalinkSuccess(project: Project, permalink: String) {
+            successMessages.add(permalink)
+        }
+
+        fun runBackgroundAction() {
+            backgroundActions.removeAt(0).invoke()
+        }
+
+        fun runUiAction() {
+            uiActions.removeAt(0).invoke()
         }
     }
 }


### PR DESCRIPTION
## Rationale

The existing action test mocked editor primitives and never executed `actionPerformed`, so integration failures across data-key extraction, formatting, clipboard writes, history, notifications, and status-bar feedback could escape the suite.

## Implementation

- replace the mock-only action test with IntelliJ `BasePlatformTestCase` fixture coverage for the main and explicit actions
- cover single and multiple carets, current-line fallback, code inclusion, custom templates, missing data keys, clipboard output, history, and highlighting
- add narrow action seams so fixture spies verify notification and status-bar dispatch on success and suppression on missing-data early returns
- exercise Git permalink completion across its background and UI phases, including multi-caret output
- verify failed permalink resolution reports failure without replacing existing clipboard contents
- isolate IntelliJ fixture classes in separate test JVMs to prevent retained application state from leaking between test engines

## Conflict resolution note

- `CopyGitPermalinkAction.kt` and `CopySelectionActionFixtureTest.kt`: the approved integration decision keeps `main` as authoritative for asynchronous execution, multi-caret ranges, latest-request-wins behavior, worktree-aware Git metadata, and failure notification with clipboard preservation. The fixture now queues and advances background/UI callbacks explicitly, asserts two ordered permalink blocks on success, and replaces the obsolete synchronous single-caret fallback expectation with a failure-notification/clipboard-preservation assertion.

## Verification

- `mise exec java@21 -- ./gradlew test --tests com.github.hon454.copyselectioncontext.CopySelectionActionFixtureTest --rerun-tasks --stacktrace --console=plain` — `BUILD SUCCESSFUL`
- `mise exec java@21 -- ./gradlew test buildPlugin verifyPluginProjectConfiguration verifyPluginStructure --rerun-tasks --stacktrace --console=plain` — `BUILD SUCCESSFUL`; 223 tests
- `unzip -t build/distributions/copy-selection-context-1.0.4.zip` — no errors
- isolated Plugin Verifier 1.410 with `JAVA_TOOL_OPTIONS=-Dplugin.verifier.home.dir=/private/tmp/copy-selection-context-pr35-verifier.dxZ9lh` — Compatible with IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97
- conflict preflight against `origin/main` and `git diff --check` — clean
- GitHub Actions [build job](https://github.com/hon454/copy-selection-context/actions/runs/33532843023/job/99939951762) on rebased head `fd80cc71fe6c73f2d9f70be7143649350744f48e` — SUCCESS

## Manual test plan

1. Invoke the main action with a selection, multiple carets, and no selection to confirm copied ranges and visible feedback.
2. Enable code inclusion and a custom template containing `{filename}` to confirm the active file name and selected code are copied.
3. Invoke each explicit path/code action and the Git permalink action from the editor context menu.
4. Confirm successful multi-caret permalink output is ordered and failed resolution leaves the clipboard unchanged while showing an error notification.

Closes #19
