### PR TITLE
chore(release): prepare v1.1.0 release candidate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,7 @@ jobs:
           echo "tag=v$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Verify version matches build.gradle.kts
-        run: |
-          GRADLE_VERSION=$(grep -oP 'version\s*=\s*"\K[^"]+' build.gradle.kts)
-          TAG_VERSION="${{ steps.version.outputs.version }}"
-          if [ "$GRADLE_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::Version mismatch: tag=$TAG_VERSION, build.gradle.kts=$GRADLE_VERSION"
-            exit 1
-          fi
-          echo "Version verified: $TAG_VERSION"
+        run: bash scripts/verify-release-version.sh "${{ steps.version.outputs.tag }}"
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -62,6 +55,7 @@ jobs:
       - name: Generate release notes from changelog
         run: |
           ./gradlew getChangelog \
+            --project-version "${{ steps.version.outputs.version }}" \
             --console=plain \
             -q \
             --no-header \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0]
+
+> **v1.1.0 release candidate scope:** All component pull requests are integrated.
+> The changes below remain unreleased until this release-candidate pull request
+> passes every release gate and v1.1.0 is tagged.
+
+### Added
+- Add local-only copy-history privacy controls, including disable, clear-all, deterministic trimming, and legacy cleanup behavior (#10)
+- Add accessible multiline custom-template editing with bounded preview and apply-time variable validation (#15)
+
+### Changed
+- Gate packaging and publication on tests, plugin structure checks, and supported-IDE compatibility verification (#12)
+- Show localized output-format names while preserving stable settings keys (#13)
+- Keep the English and Korean resource bundles on the same active key set (#14)
+- Synchronize architecture and user guides with the integrated settings, output, history, notification, analytics, and status behavior (#17)
+- Align contributor release instructions with the changelog-driven workflow (#18)
+- Exercise complete action flows with IntelliJ Platform fixtures, including clipboard and feedback side effects (#19)
+
 ### Fixed
-- Prevent legacy GitHub output format settings from copying placeholder URLs while preserving the dedicated GitHub/GitLab permalink action
+- Preserve each caret's own range and code when copying multi-caret selections (#5)
+- Honor exclusive selection end offsets without adding the following line (#6)
+- Populate `{filename}` consistently in runtime custom-template output (#7)
+- Resolve project-relative paths by path boundaries instead of string prefixes (#8)
+- Generate reliable GitHub and GitLab permalinks for worktrees, packed refs, detached HEADs, remote variants, and encoded paths (#9)
+- Keep notification and status previews concise, single-line, Unicode-safe, and markup-safe without truncating clipboard history (#11)
+- Prevent generic formatter settings from emitting unresolved GitHub permalink placeholders (#16)
 
 ## [1.0.4] - 2026-08-21
 
@@ -79,7 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toast notifications
 - IntelliJ Platform 2024.3+ compatibility
 
-[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.0.4...HEAD
+[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/hon454/copy-selection-context/compare/v1.0.4...v1.1.0
 [1.0.4]: https://github.com/hon454/copy-selection-context/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/hon454/copy-selection-context/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/hon454/copy-selection-context/compare/v1.0.1...v1.0.2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.github.hon454"
-version = "1.0.4"
+version = "1.1.0"
 
 repositories {
     mavenCentral()

--- a/docs/releases/1.1.0-rc.md
+++ b/docs/releases/1.1.0-rc.md
@@ -1,0 +1,77 @@
+# v1.1.0 Release Candidate Integration Record
+
+This document records the completed component integration for v1.1.0 without
+publishing it. Pull requests #20-#29 and #31-#35 were merged in the required
+order, and release-candidate PR #37 (issue #36) was rebased onto the integrated
+`main`. The release remains unpublished until every final gate passes and the
+release-candidate pull request is merged.
+
+## Component Scope
+
+| Issue | Pull request | Release-candidate change | Primary overlap |
+|---|---:|---|---|
+| [#5](https://github.com/hon454/copy-selection-context/issues/5) | [#33](https://github.com/hon454/copy-selection-context/pull/33) | Preserve every caret's range and code | Shared actions, permalink action, line utilities |
+| [#6](https://github.com/hon454/copy-selection-context/issues/6) | [#25](https://github.com/hon454/copy-selection-context/pull/25) | Honor exclusive selection end offsets | Shared actions, permalink action, line utilities |
+| [#7](https://github.com/hon454/copy-selection-context/issues/7) | [#31](https://github.com/hon454/copy-selection-context/pull/31) | Populate `{filename}` at runtime | Shared actions and action tests |
+| [#8](https://github.com/hon454/copy-selection-context/issues/8) | [#34](https://github.com/hon454/copy-selection-context/pull/34) | Resolve relative paths by VFS ancestry | Line/path utilities and tests |
+| [#9](https://github.com/hon454/copy-selection-context/issues/9) | [#29](https://github.com/hon454/copy-selection-context/pull/29) | Make Git permalinks work across repository layouts | Permalink action, bundles, architecture docs |
+| [#10](https://github.com/hon454/copy-selection-context/issues/10) | [#22](https://github.com/hon454/copy-selection-context/pull/22) | Add local-only history privacy controls | Settings, bundles, plugin metadata, guides |
+| [#11](https://github.com/hon454/copy-selection-context/issues/11) | [#28](https://github.com/hon454/copy-selection-context/pull/28) | Bound and escape visible copy previews | Notification, status widget, history tests |
+| [#12](https://github.com/hon454/copy-selection-context/issues/12) | [#21](https://github.com/hon454/copy-selection-context/pull/21) | Gate CI and releases on verification | Build and release workflows |
+| [#13](https://github.com/hon454/copy-selection-context/issues/13) | [#23](https://github.com/hon454/copy-selection-context/pull/23) | Localize output-format names | Settings UI/state and bundles |
+| [#14](https://github.com/hon454/copy-selection-context/issues/14) | [#26](https://github.com/hon454/copy-selection-context/pull/26) | Keep Korean bundle keys in parity | Korean bundle and bundle tests |
+| [#15](https://github.com/hon454/copy-selection-context/issues/15) | [#20](https://github.com/hon454/copy-selection-context/pull/20) | Improve multiline template editing and validation | Settings UI, bundles, UI tests |
+| [#16](https://github.com/hon454/copy-selection-context/issues/16) | [#32](https://github.com/hon454/copy-selection-context/pull/32) | Remove placeholder GitHub formatter output | Settings state, formatter registry, changelog |
+| [#17](https://github.com/hon454/copy-selection-context/issues/17) | [#27](https://github.com/hon454/copy-selection-context/pull/27) | Synchronize architecture and feature guides | AGENTS, architecture docs, all READMEs |
+| [#18](https://github.com/hon454/copy-selection-context/issues/18) | [#24](https://github.com/hon454/copy-selection-context/pull/24) | Align release guidance with the workflow | AGENTS, CONTRIBUTING, release contract tests |
+| [#19](https://github.com/hon454/copy-selection-context/issues/19) | [#35](https://github.com/hon454/copy-selection-context/pull/35) | Cover complete action flows with fixtures | Actions, action tests, build workflow, Gradle test setup |
+
+## Integrated Merge Order
+
+Each checked item was rebased as needed, resolved without dropping the listed
+contracts, verified with its focused checks, and merged into `main`.
+
+- [x] Merged #25 (#6), establishing the shared exclusive-end line resolver.
+- [x] Merged #34 (#8), preserving #25 while adding VFS-aware relative paths.
+- [x] Merged #31 (#7), threading the active file through every formatter call.
+- [x] Merged #29 (#9), preserving #25's line semantics in the asynchronous permalink implementation.
+- [x] Rebased and merged #33 (#5), adapting multi-caret permalink collection to #29's asynchronous request and failure model while preserving #31's filename context.
+- [x] Merged #22 (#10), including local-only persistence, immediate trimming, disable, clear, and legacy cleanup behavior.
+- [x] Rebased and merged #28 (#11), preserving full history values from #22 while bounding only visible previews.
+- [x] Rebased and merged #26 (#14), making bundle parity the guardrail for later settings and permalink message changes.
+- [x] Merged #32 (#16), retaining the dedicated repository-aware permalink action while removing the generic placeholder formatter.
+- [x] Rebased and merged #23 (#13), preserving #32's legacy `github` fallback while centralizing stable-key normalization and localized labels.
+- [x] Rebased and merged #20 (#15), adapting its multiline editor to #23's typed output-format options and keeping the bundle parity test green.
+- [x] Merged #21 (#12), establishing the complete CI and release validation gates.
+- [x] Rebased and merged #35 (#19) after all production changes, retaining its fixture contracts, dropping its duplicate filename fix from #31, and deduplicating the build-workflow test step already owned by #21.
+- [x] Rebased and merged #27 (#17) after behavior was final, reconciling #22's privacy text and synchronizing the English, Korean, Simplified Chinese, Traditional Chinese, and Japanese READMEs.
+- [x] Rebased and merged #24 (#18) after #21 and #27 so release guidance and AGENTS describe the final workflow and architecture.
+- [x] Rebased PR #37 (issue #36) onto the integrated `main`, preserving #35's Gradle test setup, #32's changelog correction, and #21's release gates.
+
+## Conflict Hotspots
+
+| Hotspot | Component PRs | Resolution contract |
+|---|---|---|
+| `CopySelectionBaseAction.kt` and concrete copy actions | #25, #31, #33, #35 | Keep exclusive-end ranges, per-caret code, active filename, and fixture seams together. |
+| `CopyGitPermalinkAction.kt` | #25, #29, #33, #35 | Keep async/stale-request protection and explicit failure handling while producing every caret's ordered permalink block. |
+| `CopySelectionUtils.kt` and its tests | #25, #33, #34 | Combine exclusive-end line handling, caret-specific code extraction, and VFS-boundary path resolution. |
+| Settings UI/state | #20, #22, #23, #32 | Preserve local history controls, typed localized format options, multiline validation, and legacy `github` fallback. |
+| Message bundles and bundle tests | #20, #22, #26, #29 | Retain every active English/Korean key; the parity test must pass after each resolution. |
+| Notification, status, and history tests | #22, #28 | Transform only visible previews; clipboard, history, and widget re-copy retain the full value. |
+| `.github/workflows/build.yml` | #21, #35 | Run the complete suite exactly once before packaging and keep failure diagnostics from #21. |
+| `.github/workflows/release.yml` | #21, #37 | Keep #21's full gates and #37's deterministic tag/version verifier before publication. |
+| `build.gradle.kts` | #35, #37 | Preserve fixture dependencies and the canonical `1.1.0` version. |
+| `CHANGELOG.md` | #32, #37 | Preserve the placeholder-formatter correction inside the unreleased v1.1.0 scope; do not add a release date before publication. |
+| AGENTS, architecture docs, and READMEs | #22, #24, #27, #29 | Describe only integrated behavior and keep all five README variants structurally and semantically synchronized. |
+
+## Final Release Gates
+
+- [x] Every component issue #5 through #19 is closed by its merged PR.
+- [x] No v1.1.0 release-note entry describes a component that was dropped during integration.
+- [x] `bash scripts/verify-release-version.sh v1.1.0` passes, while mismatched and malformed tags fail.
+- [x] The complete test suite passes on JDK 21.
+- [x] `buildPlugin` produces `build/distributions/copy-selection-context-1.1.0.zip`, and the ZIP integrity check passes.
+- [x] Plugin structure and project-configuration verification pass.
+- [x] Isolated Plugin Verifier runs report Compatible for every supported/recommended IDE baseline.
+- [x] The release workflow keeps GitHub Release creation and conditional Marketplace publication behind all validation gates.
+- [x] No `v1.1.0` tag, GitHub Release, or Marketplace publication was created by this release-candidate work; those remain post-merge actions.

--- a/scripts/verify-release-version.sh
+++ b/scripts/verify-release-version.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_tag="${1:-${GITHUB_REF_NAME:-}}"
+build_file="${2:-build.gradle.kts}"
+
+if [[ -z "$release_tag" ]]; then
+  echo "::error::Release tag is required (argument 1 or GITHUB_REF_NAME)." >&2
+  exit 1
+fi
+
+if [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "::error::Release tag must use v<major>.<minor>.<patch>: $release_tag" >&2
+  exit 1
+fi
+
+if [[ ! -f "$build_file" ]]; then
+  echo "::error::Canonical Gradle build file not found: $build_file" >&2
+  exit 1
+fi
+
+version_lines="$(grep -E '^[[:space:]]*version[[:space:]]*=[[:space:]]*"[^"]+"' "$build_file" || true)"
+version_count="$(printf '%s\n' "$version_lines" | awk 'NF { count++ } END { print count + 0 }')"
+
+if [[ "$version_count" -ne 1 ]]; then
+  echo "::error::Expected exactly one canonical version declaration in $build_file; found $version_count." >&2
+  exit 1
+fi
+
+canonical_version="$(printf '%s\n' "$version_lines" | sed -E 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/')"
+tag_version="${release_tag#v}"
+
+if [[ "$canonical_version" != "$tag_version" ]]; then
+  echo "::error::Version mismatch: tag=$tag_version, $build_file=$canonical_version" >&2
+  exit 1
+fi
+
+echo "Version verified: $release_tag"

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -1,0 +1,101 @@
+package com.github.hon454.copyselectioncontext
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ReleaseVersionParityTest {
+    private val projectRoot: Path = Path.of(System.getProperty("user.dir"))
+    private val verifier = projectRoot.resolve("scripts/verify-release-version.sh")
+
+    @Test
+    fun `canonical project version is 1_1_0`() {
+        assertEquals("1.1.0", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
+    }
+
+    @Test
+    fun `verifier accepts the tag matching the canonical version`() {
+        val result = runVerifier("v${canonicalVersion(projectRoot.resolve("build.gradle.kts"))}")
+
+        assertEquals(0, result.exitCode, result.output)
+        assertTrue(result.output.contains("Version verified: v1.1.0"), result.output)
+    }
+
+    @Test
+    fun `verifier rejects mismatched and malformed tags`() {
+        val mismatch = runVerifier("v9.9.9")
+        val malformed = runVerifier("1.1.0")
+
+        assertEquals(1, mismatch.exitCode, mismatch.output)
+        assertTrue(mismatch.output.contains("Version mismatch"), mismatch.output)
+        assertEquals(1, malformed.exitCode, malformed.output)
+        assertTrue(malformed.output.contains("must use v<major>.<minor>.<patch>"), malformed.output)
+    }
+
+    @Test
+    fun `verifier rejects ambiguous canonical declarations`(@TempDir tempDir: Path) {
+        val ambiguousBuildFile = tempDir.resolve("build.gradle.kts")
+        Files.writeString(
+            ambiguousBuildFile,
+            """
+            version = "1.1.0"
+            version = "1.1.0"
+            """.trimIndent()
+        )
+
+        val result = runVerifier("v1.1.0", ambiguousBuildFile)
+
+        assertEquals(1, result.exitCode, result.output)
+        assertTrue(result.output.contains("exactly one canonical version declaration"), result.output)
+    }
+
+    @Test
+    fun `release workflow uses the deterministic verifier`() {
+        val workflow = Files.readString(projectRoot.resolve(".github/workflows/release.yml"))
+
+        assertTrue(
+            workflow.contains("bash scripts/verify-release-version.sh \"${'$'}{{ steps.version.outputs.tag }}\""),
+            workflow
+        )
+        assertFalse(workflow.contains("grep -oP"), workflow)
+        assertTrue(
+            workflow.contains("--project-version \"${'$'}{{ steps.version.outputs.version }}\""),
+            workflow
+        )
+    }
+
+    @Test
+    fun `versioned release candidate notes remain explicitly unreleased`() {
+        val changelog = Files.readString(projectRoot.resolve("CHANGELOG.md"))
+        val releaseCandidateNotes = changelog
+            .substringAfter("## [1.1.0]")
+            .substringBefore("## [1.0.4]")
+
+        assertTrue(releaseCandidateNotes.contains("remain unreleased until"), releaseCandidateNotes)
+        (5..19).forEach { issue ->
+            assertTrue(releaseCandidateNotes.contains("(#$issue)"), "Missing issue #$issue from v1.1.0 notes")
+        }
+    }
+
+    private fun canonicalVersion(buildFile: Path): String {
+        val match = Regex("(?m)^\\s*version\\s*=\\s*\"([^\"]+)\"").find(Files.readString(buildFile))
+        return requireNotNull(match) { "Canonical version declaration not found in $buildFile" }.groupValues[1]
+    }
+
+    private fun runVerifier(tag: String, buildFile: Path? = null): CommandResult {
+        val command = mutableListOf("bash", verifier.toString(), tag)
+        buildFile?.let { command.add(it.toString()) }
+        val process = ProcessBuilder(command)
+            .directory(projectRoot.toFile())
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        return CommandResult(process.waitFor(), output)
+    }
+
+    private data class CommandResult(val exitCode: Int, val output: String)
+}


### PR DESCRIPTION
## Rationale

The v1.1.0 component changes are being reviewed independently, but the repository still needs a canonical candidate version, accurate staged release notes, an explicit integration plan, and a deterministic tag/version gate before any release operation is allowed.

## Implementation

- set the canonical Gradle version to `1.1.0`, producing v1.1.0 plugin metadata and package names
- add a versioned CHANGELOG entry covering every issue from #5 through #19 while explicitly marking the scope as unreleased until all component PRs and release gates are complete
- document the issue-to-PR map, required merge order, overlapping files, conflict-resolution contracts, five-language README requirement, and final release checklist in `docs/releases/1.1.0-rc.md`
- replace the GNU `grep -P` workflow check with a portable deterministic verifier that rejects malformed, mismatched, missing, and ambiguous versions
- make the release workflow select the changelog entry matching the pushed tag instead of implicitly returning the previous release notes
- add regression coverage for the canonical version, verifier behavior, workflow wiring, explicit unreleased status, and complete #5-#19 note coverage

## Release status

This PR does not merge any component PR and does not claim those features are published. It must be rebased and merged only after the component PRs are integrated in the documented order. No tag, GitHub Release, Marketplace publication, or merge was performed here.

## Verification

- `bash scripts/verify-release-version.sh v1.1.0` — passed; `v1.1.1` was rejected with a version mismatch
- `mise exec java@21 -- ./gradlew test --tests com.github.hon454.copyselectioncontext.ReleaseVersionParityTest --rerun-tasks --console=plain` — passed all 6 focused tests
- `mise exec java@21 -- ./gradlew test --rerun-tasks --stacktrace --console=plain` — `BUILD SUCCESSFUL`; 160 tests, 0 failures, 0 errors, 0 skipped
- `mise exec java@21 -- ./gradlew test verifyPluginProjectConfiguration verifyPluginStructure buildPlugin --rerun-tasks --stacktrace --console=plain` — `BUILD SUCCESSFUL`
- `build/distributions/copy-selection-context-1.1.0.zip` — produced; `unzip -t` reported no errors
- `mise exec java@21 -- ./gradlew getChangelog --project-version 1.1.0 --console=plain -q --no-header --no-links --no-summary` — selected the v1.1.0 notes and included every issue #5-#19
- isolated Plugin Verifier 1.410 with `plugin.verifier.home.dir=/private/tmp/copy-selection-context-issue-36-verifier.8uuZNf` — Compatible with IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97
- `actionlint -color` — passed with no findings
- `git diff --check` — clean

## Remaining integration prerequisites

- merge and reconcile component PRs #20-#35 according to `docs/releases/1.1.0-rc.md`
- rebase this PR onto the integrated `main`, preserving #35's Gradle fixture setup, #32's changelog correction, and #21's release gates
- synchronize all five README variants when #22 and #27 are rebased
- rerun the complete test, packaging, ZIP integrity, and isolated three-IDE Plugin Verifier gates on the final integrated tree
- remove or rewrite any release-note entry for a component that does not land

Closes #36
