### PR TITLE
docs: clarify cross-ide product scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ JetBrains IDE plugin for copying code context (file path, line numbers, optional
 
 - **Core Value**: One shortcut copies file path + line numbers + optional code, formatted for AI
 - **Target Users**: Developers using AI coding assistants (Claude, ChatGPT, etc.)
-- **Primary IDE**: Rider (compatible with all IntelliJ Platform IDEs 2024.3+)
+- **IDE Scope**: Cross-IDE IntelliJ Platform plugin for 2024.3+; IntelliJ IDEA is the largest observed user base, while Rider is the original use case
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary
- describe the plugin as cross-IDE across IntelliJ Platform 2024.3+
- reflect IntelliJ IDEA as the largest observed user base
- retain Rider as the original use case without treating it as the primary product target

## Testing
- not run (documentation-only change)
- verified the diff and whitespace with `git diff --check`