### PR TITLE
docs: add marketplace install call to action

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -12,6 +12,8 @@
 
 ClaudeやChatGPTなどのAIコーディングアシスタントにコードのコンテキストを共有するとき、ファイルパスや行番号を手入力していませんか？ **Copy Selection Context**なら、1つのショートカットで`@path#Lline`形式のコンテキストをクリップボードにコピーできます。
 
+[![Get from JetBrains Marketplace](https://img.shields.io/badge/Get%20from-JetBrains%20Marketplace-000000?style=for-the-badge&logo=jetbrains&logoColor=white)](https://plugins.jetbrains.com/plugin/30262-copy-selection-context)
+
 ## 機能
 
 - **ショートカットでコピー** — `Ctrl+Alt+C`でファイルパスと行番号をすぐにコピー

--- a/README.ko.md
+++ b/README.ko.md
@@ -12,6 +12,8 @@
 
 AI 코딩 어시스턴트(Claude, ChatGPT 등)에게 코드 컨텍스트를 전달할 때, 파일 경로와 라인 번호를 일일이 타이핑하고 계신가요? **Copy Selection Context**는 한 번의 단축키로 `@path#Lline` 형식의 컨텍스트를 클립보드에 복사합니다.
 
+[![Get from JetBrains Marketplace](https://img.shields.io/badge/Get%20from-JetBrains%20Marketplace-000000?style=for-the-badge&logo=jetbrains&logoColor=white)](https://plugins.jetbrains.com/plugin/30262-copy-selection-context)
+
 ## 기능
 
 - **원클릭 복사** — `Ctrl+Alt+C` 하나로 파일 경로 + 라인 번호 복사

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 Tired of manually typing file paths and line numbers when sharing code context with AI coding assistants like Claude or ChatGPT? **Copy Selection Context** copies `@path#Lline` formatted context to your clipboard with a single shortcut.
 
+[![Get from JetBrains Marketplace](https://img.shields.io/badge/Get%20from-JetBrains%20Marketplace-000000?style=for-the-badge&logo=jetbrains&logoColor=white)](https://plugins.jetbrains.com/plugin/30262-copy-selection-context)
+
 ## Features
 
 - **One-shortcut copy** — `Ctrl+Alt+C` copies file path + line numbers instantly

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,6 +12,8 @@
 
 向 Claude、ChatGPT 等 AI 编程助手提供代码上下文时，还在手动输入文件路径和行号吗？**Copy Selection Context** 只需一个快捷键，即可将 `@path#Lline` 格式的上下文复制到剪贴板。
 
+[![Get from JetBrains Marketplace](https://img.shields.io/badge/Get%20from-JetBrains%20Marketplace-000000?style=for-the-badge&logo=jetbrains&logoColor=white)](https://plugins.jetbrains.com/plugin/30262-copy-selection-context)
+
 ## 功能
 
 - **快捷键复制** — 按下 `Ctrl+Alt+C`，立即复制文件路径和行号

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -12,6 +12,8 @@
 
 向 Claude、ChatGPT 等 AI 程式設計助理提供程式碼上下文時，還在手動輸入檔案路徑和行號嗎？**Copy Selection Context** 只需一個快速鍵，即可將 `@path#Lline` 格式的上下文複製到剪貼簿。
 
+[![Get from JetBrains Marketplace](https://img.shields.io/badge/Get%20from-JetBrains%20Marketplace-000000?style=for-the-badge&logo=jetbrains&logoColor=white)](https://plugins.jetbrains.com/plugin/30262-copy-selection-context)
+
 ## 功能
 
 - **快速鍵複製** — 按下 `Ctrl+Alt+C`，立即複製檔案路徑和行號


### PR DESCRIPTION
## Summary

- add a prominent GitHub-compatible JetBrains Marketplace install CTA near the README introduction
- keep the CTA placement and content synchronized across all five localized README files

## Verification

- `git diff --check`
- confirmed exactly one CTA in each localized README
- runtime tests not run because this is a documentation-only change
