### PR TITLE
build: harden Java and Gradle bootstrap for v1.1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v7
       
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: '21'
           distribution: 'zulu'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: bash scripts/verify-release-version.sh "${{ steps.version.outputs.tag }}"
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: '21'
           distribution: 'zulu'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
@@ -61,6 +61,12 @@ class CiWorkflowTest {
             workflow.contains("uses: gradle/actions/setup-gradle@v6"),
             "$workflowName must cache Gradle dependencies used by plugin verification",
         )
+        assertTrue(
+            workflow.contains(
+                "uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0",
+            ),
+            "$workflowName must pin the verified setup-java v6.0.0 commit",
+        )
     }
 
     private fun readWorkflow(workflowName: String): String {

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/DocumentationSyncTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/DocumentationSyncTest.kt
@@ -86,8 +86,15 @@ class DocumentationSyncTest {
         val junitVersion = capture(buildScript, "junit-jupiter-api:([^\"]+)\"")
         val mockkVersion = capture(buildScript, "io\\.mockk:mockk:([^\"]+)\"")
         val gradleVersion = capture(wrapperProperties, "gradle-([0-9.]+)-bin\\.zip")
+        val distributionChecksum = capture(wrapperProperties, "distributionSha256Sum=([0-9a-f]{64})")
         val useBundledKotlinStdlib = gradleProperties.getProperty("kotlin.stdlib.default.dependency")
             ?: error("gradle.properties must declare kotlin.stdlib.default.dependency")
+
+        assertEquals(
+            "acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a",
+            distributionChecksum,
+            "Gradle 9.7.1 bin distribution must use the official SHA-256 checksum",
+        )
 
         val knowledgeBase = repositoryRoot.resolve("AGENTS.md").readText()
         assertTableValue(knowledgeBase, "Kotlin", kotlinVersion)


### PR DESCRIPTION
## Summary

- pin `actions/setup-java` v6.0.0 to verified commit `dd06d9cba3e5552c54d9f8ea23572deb30010f7c` in build and release workflows
- add the official Gradle 9.7.1 `-bin` SHA-256 checksum to the wrapper configuration
- add regression coverage for both bootstrap integrity pins

## Verification

- `./gradlew test verifyPluginProjectConfiguration verifyPluginStructure verifyPlugin buildPlugin --stacktrace --console=plain`
- Plugin Verifier: compatible with IC 2024.3.7.1, 2025.1.7.2, and 2025.2.6.3
- YAML parsing: `build.yml` and `release.yml`
- action tag verification: `v6` and `v6.0.0` both resolve to `dd06d9cba3e5552c54d9f8ea23572deb30010f7c`
- Gradle checksum verification: official 9.7.1 `-bin` checksum matches `acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a`

Closes #47
