### PR TITLE
fix: make custom template substitution non-recursive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Prevent custom-template replacement values from recursively expanding placeholder-like text and align blank previews with the runtime fallback (#40)
+
 ## [1.1.0]
 
 > **v1.1.0 release candidate scope:** All component pull requests are integrated.

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionConfigurable.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionConfigurable.kt
@@ -234,7 +234,7 @@ class CopySelectionConfigurable internal constructor(
         )
 
         internal fun renderTemplatePreview(template: String): String =
-            if (template.isBlank()) "" else TemplateFormatter(template).format(SAMPLE_CONTEXT)
+            OutputFormatterFactory.getTemplateFormatter(template).format(SAMPLE_CONTEXT)
 
         internal fun templateValidationMessage(template: String): String? {
             val unknownVariables = TemplateFormatter.findUnknownVariables(template)

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/OutputFormatter.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/OutputFormatter.kt
@@ -63,18 +63,21 @@ object OutputFormatterFactory {
     private val formatters: Map<String, OutputFormatter> = listOf(
         ClaudeCodeFormatter(),
         PathLineFormatter(),
-        TemplateFormatter(TemplateFormatter.PRESET_PATH_AND_RANGE)
+        getTemplateFormatter("")
     ).associateBy { it.key }
 
     fun getFormatter(key: String): OutputFormatter = formatters[key] ?: ClaudeCodeFormatter()
 
     fun getFormatterForSettings(settings: CopySelectionSettings.State): OutputFormatter {
-        return if (settings.outputFormat == "template" && settings.customFormatTemplate.isNotBlank()) {
-            TemplateFormatter(settings.customFormatTemplate)
+        return if (settings.outputFormat == "template") {
+            getTemplateFormatter(settings.customFormatTemplate)
         } else {
             getFormatter(settings.outputFormat)
         }
     }
+
+    internal fun getTemplateFormatter(template: String): TemplateFormatter =
+        TemplateFormatter(template.ifBlank { TemplateFormatter.PRESET_PATH_AND_RANGE })
 
     fun getAvailableFormatters(): List<OutputFormatter> = formatters.values.toList()
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/TemplateFormatter.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/TemplateFormatter.kt
@@ -5,13 +5,17 @@ class TemplateFormatter(private val template: String) : OutputFormatter {
     override val displayName = "Custom Template"
 
     override fun format(context: FormatContext): String {
-        return template
-            .replace("{path}", context.path.replace("\\", "/"))
-            .replace("{line}", context.startLine.toString())
-            .replace("{range}", context.lineRange)
-            .replace("{code}", context.code ?: "")
-            .replace("{lang}", context.language)
-            .replace("{filename}", context.filename)
+        val replacements = mapOf(
+            "path" to context.path.replace("\\", "/"),
+            "line" to context.startLine.toString(),
+            "range" to context.lineRange,
+            "code" to (context.code ?: ""),
+            "lang" to context.language,
+            "filename" to context.filename,
+        )
+        return VARIABLE_REGEX.replace(template) { match ->
+            replacements[match.groupValues[1]] ?: match.value
+        }
     }
 
     companion object {
@@ -28,12 +32,13 @@ class TemplateFormatter(private val template: String) : OutputFormatter {
         val VALID_VARIABLES = setOf("path", "line", "range", "code", "lang", "filename")
 
         fun findUnknownVariables(template: String): List<String> {
-            val regex = Regex("""\{(\w+)\}""")
-            return regex.findAll(template)
+            return VARIABLE_REGEX.findAll(template)
                 .map { it.groupValues[1] }
                 .filter { it !in VALID_VARIABLES }
                 .distinct()
                 .toList()
         }
+
+        private val VARIABLE_REGEX = Regex("""\{(\w+)\}""")
     }
 }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionConfigurableTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionConfigurableTest.kt
@@ -62,6 +62,29 @@ class CopySelectionConfigurableTest {
     }
 
     @Test
+    fun `blank template preview matches runtime fallback`() = onEdt {
+        val context = FormatContext(
+            path = "src/main/kotlin/Example.kt",
+            startLine = 42,
+            endLine = 53,
+            code = "fun hello() = println(\"world\")",
+            language = "kotlin",
+            filename = "Example.kt"
+        )
+
+        listOf("", " \n\t").forEach { template ->
+            val settings = CopySelectionSettings.State(
+                outputFormat = "template",
+                customFormatTemplate = template
+            )
+            val runtimeOutput = OutputFormatterFactory.getFormatterForSettings(settings).format(context)
+
+            assertEquals(runtimeOutput, CopySelectionConfigurable.renderTemplatePreview(template))
+            assertEquals("src/main/kotlin/Example.kt:42-53", runtimeOutput)
+        }
+    }
+
+    @Test
     fun `template editor and preview are bounded and accessible`() = onEdt {
         val fixture = createFixture()
 

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/TemplateFormatterTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/TemplateFormatterTest.kt
@@ -71,6 +71,36 @@ class TemplateFormatterTest {
     }
 
     @Test
+    fun `TemplateFormatter preserves placeholder tokens in code`() {
+        val code = "{path} {line} {range} {code} {lang} {filename} {unknown}"
+        val formatter = TemplateFormatter("{code}")
+
+        assertEquals(code, formatter.format(context.copy(code = code)))
+    }
+
+    @Test
+    fun `TemplateFormatter preserves placeholder tokens in paths while normalizing separators`() {
+        val formatter = TemplateFormatter("{path}")
+        val path = "C:\\work\\{line}\\{filename}.kt"
+
+        assertEquals("C:/work/{line}/{filename}.kt", formatter.format(context.copy(path = path)))
+    }
+
+    @Test
+    fun `TemplateFormatter preserves placeholder tokens in language`() {
+        val formatter = TemplateFormatter("{lang}")
+
+        assertEquals("{code}-{path}", formatter.format(context.copy(language = "{code}-{path}")))
+    }
+
+    @Test
+    fun `TemplateFormatter preserves placeholder tokens in filename`() {
+        val formatter = TemplateFormatter("{filename}")
+
+        assertEquals("{lang}-{range}.kt", formatter.format(context.copy(filename = "{lang}-{range}.kt")))
+    }
+
+    @Test
     fun `TemplateFormatter returns empty string for empty template`() {
         val formatter = TemplateFormatter("")
 
@@ -122,6 +152,7 @@ class TemplateFormatterTest {
         val formatter = OutputFormatterFactory.getFormatterForSettings(settings)
 
         assertIs<TemplateFormatter>(formatter)
+        assertEquals("src/App.kt:15-23", formatter.format(context))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- replace custom-template placeholders in a single pass so replacement values remain verbatim
- preserve placeholder-like text in copied code, paths, filenames, and language tags while retaining Windows path normalization and unknown-variable validation
- share the blank-template fallback between the settings preview and runtime formatting
- document the v1.1.1 correctness fix in the unreleased changelog

## Testing

- `./gradlew test --tests com.github.hon454.copyselectioncontext.TemplateFormatterTest --tests com.github.hon454.copyselectioncontext.CopySelectionConfigurableTest`
- `./gradlew test verifyPluginProjectConfiguration verifyPluginStructure --stacktrace --console=plain`

Fixes #40
