### PR TITLE
chore(release): prepare version 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-09-02
+
+### Changed
+- Harden the Java and Gradle bootstrap path with a verified setup action and Gradle distribution checksum (#47)
+
 ### Fixed
 - Prevent custom-template replacement values from recursively expanding placeholder-like text and align blank previews with the runtime fallback (#40)
 - Add actionable, localized Git permalink failure diagnostics with credential-safe logging (#46)
@@ -107,7 +112,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toast notifications
 - IntelliJ Platform 2024.3+ compatibility
 
-[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/hon454/copy-selection-context/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/hon454/copy-selection-context/compare/v1.0.4...v1.1.0
 [1.0.4]: https://github.com/hon454/copy-selection-context/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/hon454/copy-selection-context/compare/v1.0.2...v1.0.3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.github.hon454"
-version = "1.1.0"
+version = "1.1.1"
 
 repositories {
     mavenCentral()

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -13,8 +13,8 @@ class ReleaseVersionParityTest {
     private val verifier = projectRoot.resolve("scripts/verify-release-version.sh")
 
     @Test
-    fun `canonical project version is 1_1_0`() {
-        assertEquals("1.1.0", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
+    fun `canonical project version is 1_1_1`() {
+        assertEquals("1.1.1", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
     }
 
     @Test
@@ -22,7 +22,7 @@ class ReleaseVersionParityTest {
         val result = runVerifier("v${canonicalVersion(projectRoot.resolve("build.gradle.kts"))}")
 
         assertEquals(0, result.exitCode, result.output)
-        assertTrue(result.output.contains("Version verified: v1.1.0"), result.output)
+        assertTrue(result.output.contains("Version verified: v1.1.1"), result.output)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- bump the canonical project and plugin version to 1.1.1
- publish the dated 1.1.1 changelog section with #47 under Changed and #40/#46 under Fixed
- restore an empty Unreleased section and keep the v1.1.0 historical notes unchanged
- align release-version parity tests with the new canonical version

## Verification

- `scripts/verify-release-version.sh v1.1.1`
- `./gradlew test verifyPluginProjectConfiguration verifyPluginStructure verifyPlugin buildPlugin --stacktrace`
- 249 tests passed with no failures, errors, or skips
- Plugin Verifier reported compatible for IntelliJ IDEA 2024.3, 2025.1, and 2025.2
- generated `build/distributions/copy-selection-context-1.1.1.zip`

## Release boundary

This PR does not create a tag, publish a GitHub release, publish to JetBrains Marketplace, or merge the release branch.

Fixes #51
