### PR TITLE
fix: keep Gradle output out of generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,17 +54,9 @@ jobs:
 
       - name: Generate release notes from changelog
         run: |
-          ./gradlew getChangelog \
-            --project-version "${{ steps.version.outputs.version }}" \
-            --console=plain \
-            -q \
-            --no-header \
-            --no-links \
-            --no-summary > release-notes.md
-
-          if [ ! -s release-notes.md ]; then
-            echo "Release ${{ steps.version.outputs.tag }}" > release-notes.md
-          fi
+          bash scripts/generate-release-notes.sh \
+            "${{ steps.version.outputs.version }}" \
+            "${{ steps.version.outputs.tag }}"
 
       - name: Run test suite
         run: ./gradlew test --stacktrace --console=plain

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ cmd //c "gradlew.bat publishPlugin"  # Publish to Marketplace (requires PUBLISH_
 1. Update the `[Unreleased]` entries in `CHANGELOG.md`
 2. Bump `version` in `build.gradle.kts`, then run `cmd //c "gradlew.bat patchChangelog"`
 3. Commit the version and changelog, tag (`v<major>.<minor>.<patch>`), and push
-4. `release.yml` generates GitHub Release notes from the matching `CHANGELOG.md` section with `getChangelog`
+4. `release.yml` uses `scripts/generate-release-notes.sh` to initialize Gradle separately, then captures only the matching `CHANGELOG.md` section from `getChangelog`
 5. JetBrains Marketplace publishing runs only when `PUBLISH_TOKEN`, `CERTIFICATE_CHAIN`, and `PRIVATE_KEY` are all non-empty
 
 **Version rule**: Tag version must match `build.gradle.kts` `version` — workflow fails on mismatch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Bound project copy history by documented per-entry and total UTF-8 content budgets while preserving oversized clipboard results (#42)
 
+### Fixed
+- Keep Gradle wrapper download and initialization output out of generated GitHub Release notes (#53)
+
 ## [1.1.1] - 2026-09-02
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Releases are automated by [`.github/workflows/release.yml`](.github/workflows/re
 
 ### Release Notes
 
-[`CHANGELOG.md`](CHANGELOG.md) is the single source of truth for release notes. The workflow runs `getChangelog` for the project version without the section header, comparison links, or summary and writes the result to `release-notes.md`. If that output is empty, it uses `Release v<version>` as a fallback.
+[`CHANGELOG.md`](CHANGELOG.md) is the single source of truth for release notes. The workflow invokes `scripts/generate-release-notes.sh`, which initializes the Gradle wrapper before separately capturing `getChangelog` output for the project version without the section header, comparison links, or summary. Only that captured output is written to `release-notes.md`; if it is empty, the script uses `Release v<version>` as a fallback.
 
 Keep `[Unreleased]` current as changes land, then run `patchChangelog` after setting the release version so the workflow can find the matching version section. Commit messages remain important for review and repository history, but they are not used to generate release notes.
 

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_version="${1:-}"
+release_tag="${2:-}"
+output_file="${3:-release-notes.md}"
+gradle_wrapper="${GRADLE_WRAPPER:-./gradlew}"
+
+if [[ -z "$release_version" || -z "$release_tag" ]]; then
+  echo "::error::Release version and tag are required." >&2
+  exit 1
+fi
+
+output_directory="$(dirname "$output_file")"
+if [[ ! -d "$output_directory" ]]; then
+  echo "::error::Release notes output directory not found: $output_directory" >&2
+  exit 1
+fi
+
+temporary_notes="$(mktemp "$output_directory/.release-notes.XXXXXX")"
+trap 'rm -f "$temporary_notes"' EXIT
+
+# Warm the wrapper before redirecting task output. On a cold cache, the wrapper
+# writes distribution download progress to stdout before Gradle starts.
+"$gradle_wrapper" --version --console=plain
+
+"$gradle_wrapper" getChangelog \
+  --project-version "$release_version" \
+  --console=plain \
+  -q \
+  --no-header \
+  --no-links \
+  --no-summary > "$temporary_notes"
+
+if [[ ! -s "$temporary_notes" ]]; then
+  printf 'Release %s\n' "$release_tag" > "$temporary_notes"
+fi
+
+mv "$temporary_notes" "$output_file"
+trap - EXIT

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
@@ -3,6 +3,7 @@ package com.github.hon454.copyselectioncontext
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class CiWorkflowTest {
@@ -19,6 +20,33 @@ class CiWorkflowTest {
         assertValidationPipeline(
             workflowName = "release.yml",
             publicationStep = "Create GitHub Release",
+        )
+    }
+
+    @Test
+    fun `release generates notes only after version and Gradle setup`() {
+        val workflow = readWorkflow("release.yml")
+
+        assertInOrder(
+            workflow,
+            "name: Verify version matches build.gradle.kts",
+            "name: Set up JDK 21",
+            "name: Setup Gradle",
+            "name: Ensure gradlew is executable",
+            "name: Generate release notes from changelog",
+            "name: Run test suite",
+        )
+        val generationCommand =
+            "bash scripts/generate-release-notes.sh \\\n" +
+                "            \"${'$'}{{ steps.version.outputs.version }}\" \\\n" +
+                "            \"${'$'}{{ steps.version.outputs.tag }}\""
+        assertTrue(
+            workflow.contains(generationCommand),
+            "release.yml must delegate deterministic note generation to the tested script",
+        )
+        assertFalse(
+            workflow.contains("--no-summary > release-notes.md"),
+            "release.yml must not redirect a cold Gradle wrapper invocation into the release body",
         )
     }
 

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseDocumentationTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseDocumentationTest.kt
@@ -12,11 +12,11 @@ class ReleaseDocumentationTest {
     private val contributing = readProjectFile("CONTRIBUTING.md")
     private val agents = readProjectFile("AGENTS.md")
     private val releaseWorkflow = readProjectFile(".github/workflows/release.yml")
+    private val releaseNotesGenerator = readProjectFile("scripts/generate-release-notes.sh")
 
     @Test
     fun `release guidance uses the changelog workflow commands`() {
-        val getChangelogArguments = listOf(
-            "./gradlew getChangelog",
+        val getChangelogOptions = listOf(
             "--console=plain",
             "-q",
             "--no-header",
@@ -26,10 +26,13 @@ class ReleaseDocumentationTest {
 
         assertContains(contributing, "CHANGELOG.md")
         assertContains(contributing, "./gradlew patchChangelog")
-        getChangelogArguments.forEach { argument ->
-            assertContains(contributing, argument)
-            assertContains(releaseWorkflow, argument)
+        assertContains(contributing, "./gradlew getChangelog")
+        assertContains(releaseNotesGenerator, "\"${'$'}gradle_wrapper\" getChangelog")
+        getChangelogOptions.forEach { option ->
+            assertContains(contributing, option)
+            assertContains(releaseNotesGenerator, option)
         }
+        assertContains(releaseWorkflow, "bash scripts/generate-release-notes.sh")
         assertFalse(contributing.contains("commit-based release notes"))
         assertFalse(agents.contains("commit-based release notes"))
     }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseNotesGenerationTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseNotesGenerationTest.kt
@@ -1,0 +1,102 @@
+package com.github.hon454.copyselectioncontext
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ReleaseNotesGenerationTest {
+    private val projectRoot: Path = Path.of(System.getProperty("user.dir"))
+    private val generator = projectRoot.resolve("scripts/generate-release-notes.sh")
+
+    @Test
+    fun `cold wrapper output stays out of requested version notes`(@TempDir tempDir: Path) {
+        val expectedNotes = """
+            ### Fixed
+            - Keep Gradle output out of release notes (#53)
+        """.trimIndent() + "\n"
+        val result = runGenerator(tempDir, expectedNotes)
+
+        assertEquals(0, result.exitCode, result.output)
+        assertTrue(
+            result.output.contains("Downloading https://services.gradle.org/distributions/gradle.zip"),
+            result.output,
+        )
+        assertEquals(expectedNotes, Files.readString(result.releaseNotes))
+        assertFalse(Files.readString(result.releaseNotes).contains("Downloading"))
+        assertEquals(
+            listOf(
+                "--version --console=plain",
+                "getChangelog --project-version 1.2.0 --console=plain -q --no-header --no-links --no-summary",
+            ),
+            Files.readAllLines(result.invocationLog),
+        )
+    }
+
+    @Test
+    fun `empty changelog output uses the release tag fallback`(@TempDir tempDir: Path) {
+        val result = runGenerator(tempDir, "")
+
+        assertEquals(0, result.exitCode, result.output)
+        assertEquals("Release v1.2.0\n", Files.readString(result.releaseNotes))
+    }
+
+    private fun runGenerator(tempDir: Path, changelogOutput: String): GenerationResult {
+        val fakeWrapper = tempDir.resolve("gradlew")
+        val invocationLog = tempDir.resolve("gradle-invocations.log")
+        val releaseNotes = tempDir.resolve("release-notes.md")
+        Files.writeString(
+            fakeWrapper,
+            """
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            printf '%s\n' "${'$'}*" >> "${'$'}FAKE_GRADLE_LOG"
+            case "${'$'}{1:-}" in
+              --version)
+                echo "Downloading https://services.gradle.org/distributions/gradle.zip"
+                echo "10%...100%"
+                echo "Welcome to Gradle"
+                ;;
+              getChangelog)
+                printf '%s' "${'$'}FAKE_CHANGELOG_OUTPUT"
+                ;;
+              *)
+                exit 2
+                ;;
+            esac
+            """.trimIndent(),
+        )
+        assertTrue(
+            fakeWrapper.toFile().setExecutable(true),
+            "Failed to make fake Gradle wrapper executable",
+        )
+
+        val process = ProcessBuilder(
+            "bash",
+            generator.toString(),
+            "1.2.0",
+            "v1.2.0",
+            releaseNotes.toString(),
+        )
+            .directory(projectRoot.toFile())
+            .redirectErrorStream(true)
+        process.environment()["GRADLE_WRAPPER"] = fakeWrapper.toString()
+        process.environment()["FAKE_GRADLE_LOG"] = invocationLog.toString()
+        process.environment()["FAKE_CHANGELOG_OUTPUT"] = changelogOutput
+
+        val startedProcess = process.start()
+        val output = startedProcess.inputStream.bufferedReader().use { it.readText() }
+        return GenerationResult(startedProcess.waitFor(), output, releaseNotes, invocationLog)
+    }
+
+    private data class GenerationResult(
+        val exitCode: Int,
+        val output: String,
+        val releaseNotes: Path,
+        val invocationLog: Path,
+    )
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -54,8 +54,9 @@ class ReleaseVersionParityTest {
     }
 
     @Test
-    fun `release workflow uses the deterministic verifier`() {
+    fun `release workflow preserves deterministic version and changelog inputs`() {
         val workflow = Files.readString(projectRoot.resolve(".github/workflows/release.yml"))
+        val releaseNotesGenerator = Files.readString(projectRoot.resolve("scripts/generate-release-notes.sh"))
 
         assertTrue(
             workflow.contains("bash scripts/verify-release-version.sh \"${'$'}{{ steps.version.outputs.tag }}\""),
@@ -63,8 +64,12 @@ class ReleaseVersionParityTest {
         )
         assertFalse(workflow.contains("grep -oP"), workflow)
         assertTrue(
-            workflow.contains("--project-version \"${'$'}{{ steps.version.outputs.version }}\""),
-            workflow
+            workflow.contains("bash scripts/generate-release-notes.sh"),
+            workflow,
+        )
+        assertTrue(
+            releaseNotesGenerator.contains("--project-version \"${'$'}release_version\""),
+            releaseNotesGenerator,
         )
     }
 


### PR DESCRIPTION
## Summary

- generate release notes through a small script that warms the Gradle wrapper before capturing changelog output
- write only the requested version's `getChangelog` result to `release-notes.md` while preserving the existing empty-result fallback and tag/version verifier
- add a cold-cache regression test plus workflow, documentation, and version-contract coverage for the v1.2.0 release path

## Automated verification

- `./gradlew test verifyPluginProjectConfiguration verifyPluginStructure verifyPlugin buildPlugin --stacktrace --console=plain`
  - 252 tests passed with no failures, errors, or skips
  - project configuration and plugin structure checks passed
  - Plugin Verifier reported compatible with IntelliJ IDEA 2024.3, 2025.1, and 2025.2
  - generated `build/distributions/copy-selection-context-1.1.1.zip`
- release-focused Gradle tests passed after the final diff was staged
- `actionlint .github/workflows/build.yml .github/workflows/release.yml`
- `shellcheck scripts/generate-release-notes.sh scripts/verify-release-version.sh`
- `bash -n scripts/generate-release-notes.sh scripts/verify-release-version.sh`
- `git diff --check`

## Manual verification

- ran `scripts/generate-release-notes.sh` against the real v1.1.1 changelog section
- confirmed Gradle initialization output remained in the command log while the generated file began directly with `### Changed` and contained only the requested changelog content
- the regression fixture simulates cold-wrapper download/progress/build preamble output for v1.2.0 and asserts exact, preamble-free release-note contents

## Release boundary

This change is recorded under `Unreleased` for v1.2.0. It does not create a tag, publish a GitHub Release, publish to JetBrains Marketplace, or merge the PR.

Closes #53
