### PR TITLE
ci: pin GitHub Actions to immutable revisions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ jobs:
     
     steps:
       - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           large-packages: false
 
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
       - name: Set up JDK 21
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
@@ -30,7 +30,7 @@ jobs:
           distribution: 'zulu'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - name: Ensure gradlew is executable
         run: chmod +x ./gradlew
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload validation reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: validation-reports
           path: |
@@ -75,7 +75,7 @@ jobs:
           retention-days: 14
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: plugin-artifact
           path: build/distributions/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           large-packages: false
 
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
           distribution: 'zulu'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - name: Ensure gradlew is executable
         run: chmod +x ./gradlew
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload validation reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: validation-reports
           path: |
@@ -98,7 +98,7 @@ jobs:
           retention-days: 14
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: ${{ steps.version.outputs.tag }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:6.1.3")
     testImplementation("junit:junit:4.13.2")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:6.1.3")
+    testImplementation("org.snakeyaml:snakeyaml-engine:3.1.1")
     testImplementation("io.mockk:mockk:1.14.11") {
         exclude(group = "org.jetbrains.kotlinx")
     }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
@@ -1,10 +1,17 @@
 package com.github.hon454.copyselectioncontext
 
+import org.snakeyaml.engine.v2.api.LoadSettings
+import org.snakeyaml.engine.v2.api.lowlevel.Compose
+import org.snakeyaml.engine.v2.nodes.MappingNode
+import org.snakeyaml.engine.v2.nodes.Node
+import org.snakeyaml.engine.v2.nodes.ScalarNode
+import org.snakeyaml.engine.v2.nodes.SequenceNode
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class CiWorkflowTest {
@@ -65,34 +72,108 @@ class CiWorkflowTest {
             }
         assertTrue(workflowPaths.isNotEmpty(), "No GitHub Actions workflows found")
 
-        val externalActionPattern = Regex("""^\s*(?:-\s*)?uses:\s*([^\s#]+)(?:\s+#\s*(\S+))?\s*${'$'}""")
-        val immutableReferencePattern = Regex("""^[^/@\s]+/[^@\s]+@[0-9a-f]{40}${'$'}""")
-        val versionCommentPattern = Regex("""^v\d+(?:\.\d+){0,2}(?:[-+][0-9A-Za-z.-]+)?${'$'}""")
-        var externalActionCount = 0
-
-        workflowPaths.forEach { path ->
-            Files.readAllLines(path).forEachIndexed { index, line ->
-                val match = externalActionPattern.matchEntire(line) ?: return@forEachIndexed
-                val reference = match.groupValues[1]
-                if (reference.startsWith("./") || reference.startsWith("docker://")) {
-                    return@forEachIndexed
-                }
-
-                externalActionCount += 1
-                val location = "${path}:${index + 1}"
-                assertTrue(
-                    immutableReferencePattern.matches(reference),
-                    "$location must pin external action '$reference' to a full 40-character commit SHA",
-                )
-                val versionComment = match.groupValues[2]
-                assertTrue(
-                    versionCommentPattern.matches(versionComment),
-                    "$location must include a readable version comment such as '# v1.2.3'",
+        val externalActionCount =
+            workflowPaths.sumOf { path ->
+                assertWorkflowActionReferencesAreImmutable(
+                    workflow = Files.readString(path),
+                    source = path.toString(),
                 )
             }
-        }
 
         assertTrue(externalActionCount > 0, "No external actions found to validate")
+    }
+
+    @Test
+    fun `mutable action references fail closed across YAML key styles`() {
+        val mutableWorkflows =
+            listOf(
+                workflowWithStep("- uses: actions/checkout@v7"),
+                workflowWithStep("- 'uses': actions/checkout@v7 # v7.0.1"),
+                workflowWithStep("- uses: actions/checkout@v7 # v7.0.1 upstream release"),
+                workflowWithStep("- { name: Checkout code, uses: actions/checkout@v7 } # v7.0.1"),
+                """
+                name: Reusable workflow pin check
+                on: push
+                jobs:
+                  reuse:
+                    'uses': owner/repository/.github/workflows/reusable.yml@main # v1.2.3
+                """.trimIndent(),
+            )
+
+        mutableWorkflows.forEachIndexed { index, workflow ->
+            assertFailsWith<AssertionError>("Mutable workflow variant ${index + 1} must fail") {
+                assertWorkflowActionReferencesAreImmutable(workflow, "inline-workflow-${index + 1}")
+            }
+        }
+    }
+
+    @Test
+    fun `pinned actions require readable version comments`() {
+        val pinnedReference = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+        val invalidComments =
+            listOf(
+                workflowWithStep("- uses: $pinnedReference"),
+                workflowWithStep("- uses: $pinnedReference # upstream release"),
+                workflowWithStep("- uses: $pinnedReference # v7.0.1upstream"),
+            )
+
+        invalidComments.forEachIndexed { index, workflow ->
+            assertFailsWith<AssertionError>("Missing or invalid version comment ${index + 1} must fail") {
+                assertWorkflowActionReferencesAreImmutable(workflow, "inline-workflow-${index + 1}")
+            }
+        }
+    }
+
+    @Test
+    fun `version comments may include descriptive text after the version`() {
+        val workflow =
+            workflowWithStep(
+                "- { 'uses': actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 } " +
+                    "# v7.0.1 upstream release",
+            )
+
+        assertEquals(1, assertWorkflowActionReferencesAreImmutable(workflow, "inline-workflow"))
+    }
+
+    @Test
+    fun `local and Docker uses values are not GitHub repository references`() {
+        val workflow =
+            """
+            name: Non-repository references
+            on: push
+            jobs:
+              test:
+                runs-on: ubuntu-latest
+                steps:
+                  - { uses: ./actions/local }
+                  - 'uses': docker://alpine:3.22
+            """.trimIndent()
+
+        assertEquals(0, assertWorkflowActionReferencesAreImmutable(workflow, "inline-workflow"))
+    }
+
+    @Test
+    fun `uses keys in workflow data are not action references`() {
+        val workflow =
+            """
+            name: Uses data keys
+            on: push
+            env:
+              uses: actions/checkout@v7
+            jobs:
+              test:
+                runs-on: ubuntu-latest
+                env: { uses: actions/checkout@v7 }
+                steps:
+                  - name: Environment data
+                    run: echo ok
+                    env:
+                      'uses': actions/checkout@v7
+                  - uses: ./actions/local
+                    with: { uses: actions/checkout@v7 }
+            """.trimIndent()
+
+        assertEquals(0, assertWorkflowActionReferencesAreImmutable(workflow, "inline-workflow"))
     }
 
     @Test
@@ -179,6 +260,98 @@ class CiWorkflowTest {
         assertTrue(Files.isRegularFile(path), "Workflow not found: $path")
         return Files.readString(path)
     }
+
+    private fun assertWorkflowActionReferencesAreImmutable(
+        workflow: String,
+        source: String,
+    ): Int {
+        val immutableReferencePattern = Regex("""^[^/@\s]+/[^@\s]+@[0-9a-f]{40}${'$'}""")
+        val versionCommentPattern = Regex("""^v\d+(?:\.\d+){0,2}(?:[-+][0-9A-Za-z.-]+)?${'$'}""")
+        val settings =
+            LoadSettings
+                .builder()
+                .setLabel(source)
+                .setAllowDuplicateKeys(false)
+                .setParseComments(true)
+                .setUseMarks(true)
+                .build()
+        val usesEntries =
+            Compose(settings)
+                .composeAllFromString(workflow)
+                .flatMap(::collectActionReferenceEntries)
+        var externalActionCount = 0
+
+        usesEntries.forEach { entry ->
+            val line = entry.key.startMark.map { it.line + 1 }.orElse(1)
+            val location = "$source:$line"
+            val scalarValue = entry.value as? ScalarNode
+            assertTrue(scalarValue != null, "$location must use a scalar action reference")
+            val reference = scalarValue.value.trim()
+            if (reference.startsWith("./") || reference.startsWith("docker://")) {
+                return@forEach
+            }
+
+            externalActionCount += 1
+            assertTrue(
+                immutableReferencePattern.matches(reference),
+                "$location must pin external action '$reference' to a full 40-character commit SHA",
+            )
+            val endIndex = scalarValue.endMark.map { it.index }.orElse(-1)
+            assertTrue(endIndex in 0..workflow.length, "$location must retain the action source location")
+            val sourceSuffix = workflow.substring(endIndex).lineSequence().firstOrNull().orEmpty()
+            val versionComment = sourceSuffix.substringAfter('#', missingDelimiterValue = "").trim()
+            val versionToken = versionComment.split(Regex("""\s+"""), limit = 2).firstOrNull().orEmpty()
+            assertTrue(
+                versionCommentPattern.matches(versionToken),
+                "$location must include a readable version comment such as '# v1.2.3'",
+            )
+        }
+
+        return externalActionCount
+    }
+
+    private fun collectActionReferenceEntries(document: Node): List<UsesEntry> {
+        val root = document as? MappingNode ?: return emptyList()
+        val jobs = root.valueForKey("jobs") as? MappingNode ?: return emptyList()
+
+        return jobs.value.flatMap { jobTuple ->
+            val job = jobTuple.valueNode as? MappingNode ?: return@flatMap emptyList()
+            val reusableWorkflow = job.entriesForKey("uses")
+            val stepActions =
+                (job.valueForKey("steps") as? SequenceNode)
+                    ?.value
+                    .orEmpty()
+                    .filterIsInstance<MappingNode>()
+                    .flatMap { step -> step.entriesForKey("uses") }
+            reusableWorkflow + stepActions
+        }
+    }
+
+    private fun MappingNode.entriesForKey(key: String): List<UsesEntry> =
+        value.mapNotNull { tuple ->
+            val scalarKey = tuple.keyNode as? ScalarNode
+            scalarKey
+                ?.takeIf { it.value == key }
+                ?.let { UsesEntry(it, tuple.valueNode) }
+        }
+
+    private fun MappingNode.valueForKey(key: String): Node? = entriesForKey(key).singleOrNull()?.value
+
+    private fun workflowWithStep(step: String): String =
+        """
+        name: Action pin check
+        on: push
+        jobs:
+          test:
+            runs-on: ubuntu-latest
+            steps:
+              $step
+        """.trimIndent()
+
+    private data class UsesEntry(
+        val key: ScalarNode,
+        val value: Node,
+    )
 
     private fun workflowPermissions(workflow: String): String {
         val lines = workflow.lines()

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
@@ -3,6 +3,7 @@ package com.github.hon454.copyselectioncontext
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -50,6 +51,88 @@ class CiWorkflowTest {
         )
     }
 
+    @Test
+    fun `external actions use immutable full SHA pins with version comments`() {
+        val workflowDirectory = Path.of(".github", "workflows")
+        val workflowPaths =
+            Files.list(workflowDirectory).use { paths ->
+                paths
+                    .filter { path ->
+                        val fileName = path.fileName.toString()
+                        fileName.endsWith(".yml") || fileName.endsWith(".yaml")
+                    }.sorted()
+                    .toList()
+            }
+        assertTrue(workflowPaths.isNotEmpty(), "No GitHub Actions workflows found")
+
+        val externalActionPattern = Regex("""^\s*(?:-\s*)?uses:\s*([^\s#]+)(?:\s+#\s*(\S+))?\s*${'$'}""")
+        val immutableReferencePattern = Regex("""^[^/@\s]+/[^@\s]+@[0-9a-f]{40}${'$'}""")
+        val versionCommentPattern = Regex("""^v\d+(?:\.\d+){0,2}(?:[-+][0-9A-Za-z.-]+)?${'$'}""")
+        var externalActionCount = 0
+
+        workflowPaths.forEach { path ->
+            Files.readAllLines(path).forEachIndexed { index, line ->
+                val match = externalActionPattern.matchEntire(line) ?: return@forEachIndexed
+                val reference = match.groupValues[1]
+                if (reference.startsWith("./") || reference.startsWith("docker://")) {
+                    return@forEachIndexed
+                }
+
+                externalActionCount += 1
+                val location = "${path}:${index + 1}"
+                assertTrue(
+                    immutableReferencePattern.matches(reference),
+                    "$location must pin external action '$reference' to a full 40-character commit SHA",
+                )
+                val versionComment = match.groupValues[2]
+                assertTrue(
+                    versionCommentPattern.matches(versionComment),
+                    "$location must include a readable version comment such as '# v1.2.3'",
+                )
+            }
+        }
+
+        assertTrue(externalActionCount > 0, "No external actions found to validate")
+    }
+
+    @Test
+    fun `workflows declare only required token permissions`() {
+        assertEquals(
+            "contents: read",
+            workflowPermissions(readWorkflow("build.yml")),
+            "build.yml must keep the default GITHUB_TOKEN read-only",
+        )
+        assertEquals(
+            "contents: write",
+            workflowPermissions(readWorkflow("release.yml")),
+            "release.yml needs only contents write access to create the GitHub release",
+        )
+    }
+
+    @Test
+    fun `Dependabot safely updates action pins through pull request validation`() {
+        val dependabotPath = Path.of(".github", "dependabot.yml")
+        assertTrue(Files.isRegularFile(dependabotPath), "Dependabot configuration is required")
+        val dependabot = Files.readString(dependabotPath)
+        val buildWorkflow = readWorkflow("build.yml")
+
+        assertTrue(
+            dependabot.contains("package-ecosystem: \"github-actions\"") &&
+                dependabot.contains("directory: \"/\"") &&
+                dependabot.contains("interval: \"weekly\""),
+            "Dependabot must check GitHub Actions pins at the repository root on a weekly schedule",
+        )
+        assertFalse(
+            dependabot.contains("automerge", ignoreCase = true),
+            "GitHub Actions updates must not be configured for automatic merging",
+        )
+        assertTrue(
+            Regex("""(?ms)^on:\s.*?^\s{2}pull_request:\s*\n\s{4}branches:\s*\[\s*main\s*]""")
+                .containsMatchIn(buildWorkflow),
+            "Dependabot pull requests targeting main must run the complete build workflow",
+        )
+    }
+
     private fun assertValidationPipeline(
         workflowName: String,
         publicationStep: String,
@@ -86,14 +169,8 @@ class CiWorkflowTest {
             "$workflowName must upload plugin verification and test diagnostics",
         )
         assertTrue(
-            workflow.contains("uses: gradle/actions/setup-gradle@v6"),
+            workflow.contains("uses: gradle/actions/setup-gradle@"),
             "$workflowName must cache Gradle dependencies used by plugin verification",
-        )
-        assertTrue(
-            workflow.contains(
-                "uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0",
-            ),
-            "$workflowName must pin the verified setup-java v6.0.0 commit",
         )
     }
 
@@ -101,6 +178,20 @@ class CiWorkflowTest {
         val path = Path.of(".github", "workflows", workflowName)
         assertTrue(Files.isRegularFile(path), "Workflow not found: $path")
         return Files.readString(path)
+    }
+
+    private fun workflowPermissions(workflow: String): String {
+        val lines = workflow.lines()
+        val permissionsIndex = lines.indexOfFirst { it == "permissions:" }
+        assertTrue(permissionsIndex >= 0, "Workflow must declare permissions explicitly")
+
+        val permissionLines =
+            lines
+                .drop(permissionsIndex + 1)
+                .takeWhile { it.startsWith("  ") && it.isNotBlank() }
+                .map { it.trim() }
+        assertEquals(1, permissionLines.size, "Workflow must grant exactly one explicit token permission")
+        return permissionLines.single()
     }
 
     private fun assertInOrder(


### PR DESCRIPTION
## Summary

- pin every external action in the build and release workflows to a reviewed 40-character commit SHA while retaining an adjacent release-version comment
- preserve the `actions/setup-java` v6.0.0 pin introduced by #47 and re-audit every action reference on the latest `main`
- configure weekly Dependabot updates for the `github-actions` ecosystem without automatic merging
- extend `CiWorkflowTest` so mutable refs, missing version comments, excessive token permissions, or a missing Dependabot validation path fail CI

## Verified action provenance

The existing moving major aliases were compared with the current official release tags. Pinning these commits therefore freezes the workflow behavior currently selected by those aliases; it does not introduce an action major-version migration.

| Action | Official release | Pinned commit |
| --- | --- | --- |
| `jlumbroso/free-disk-space` | [`v1.3.1`](https://github.com/jlumbroso/free-disk-space/releases/tag/v1.3.1) | [`54081f138730dfa15788a46383842cd2f914a1be`](https://github.com/jlumbroso/free-disk-space/commit/54081f138730dfa15788a46383842cd2f914a1be) |
| `actions/checkout` | [`v7.0.1`](https://github.com/actions/checkout/releases/tag/v7.0.1) | [`3d3c42e5aac5ba805825da76410c181273ba90b1`](https://github.com/actions/checkout/commit/3d3c42e5aac5ba805825da76410c181273ba90b1) |
| `actions/setup-java` | [`v6.0.0`](https://github.com/actions/setup-java/releases/tag/v6.0.0) | [`dd06d9cba3e5552c54d9f8ea23572deb30010f7c`](https://github.com/actions/setup-java/commit/dd06d9cba3e5552c54d9f8ea23572deb30010f7c) |
| `gradle/actions/setup-gradle` | [`v6.3.0`](https://github.com/gradle/actions/releases/tag/v6.3.0) | [`9c971963bec38e04b3d30dcc455b5382be2fdbfb`](https://github.com/gradle/actions/commit/9c971963bec38e04b3d30dcc455b5382be2fdbfb) |
| `actions/upload-artifact` | [`v7.0.1`](https://github.com/actions/upload-artifact/releases/tag/v7.0.1) | [`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`](https://github.com/actions/upload-artifact/commit/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a) |
| `softprops/action-gh-release` | [`v2.6.2`](https://github.com/softprops/action-gh-release/releases/tag/v2.6.2) | [`3bb12739c298aeb8a4eeaf626c5b8d85266b0e65`](https://github.com/softprops/action-gh-release/commit/3bb12739c298aeb8a4eeaf626c5b8d85266b0e65) |

## Permission analysis

- `build.yml` remains limited to `contents: read`, which is sufficient for checkout and all validation/upload steps.
- `release.yml` remains limited to `contents: write`, required by `softprops/action-gh-release` to create the GitHub release and upload its ZIP. Checkout only consumes the read subset of that permission.
- Marketplace publishing authenticates with its dedicated repository secrets and does not require additional `GITHUB_TOKEN` scopes. No `actions`, `checks`, `id-token`, `packages`, `pull-requests`, or other permissions are granted.

## Validation

Automated/local:

- `actionlint -color`
- `shellcheck scripts/*.sh`
- Dependabot YAML parse/shape check
- `./gradlew test --tests com.github.hon454.copyselectioncontext.CiWorkflowTest --stacktrace --console=plain`
- `./gradlew test verifyPluginProjectConfiguration verifyPluginStructure verifyPlugin buildPlugin --stacktrace --console=plain`
  - Plugin Verifier: compatible with IntelliJ IDEA 2024.3.7.1, 2025.1.7.2, and 2025.2.6.3

Manual release dry path:

- `scripts/verify-release-version.sh v1.1.1`
- generated non-empty v1.1.1 release notes through `scripts/generate-release-notes.sh` into a temporary path
- did not create a tag, GitHub release, Marketplace publication, or use publishing secrets

## Remaining risk

- SHA pinning prevents later tag movement but cannot prove that an upstream commit was uncompromised before review; every selected commit was resolved from its official repository release/tag on 2026-09-02.
- Dependabot will propose reviewed SHA/comment updates through pull requests. No automatic merge path is added, so upstream changes still require human review and the full build workflow.
- The token-protected GitHub release and Marketplace publication steps are intentionally not executed by the local dry path; the existing tag-triggered workflow remains their integration gate.

Closes #44
