### PR TITLE
chore(release): prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-09-02
+
 ### Added
 - Bound project copy history by documented per-entry and total UTF-8 content budgets while preserving oversized clipboard results (#42)
 - Show local-only copy totals, output-format usage, and language usage in Settings with a confirmed reset action (#41)
 - Publish SHA-256 checksums and GitHub build provenance for canonical release ZIPs (#45)
 - Offer a localized, non-modal Marketplace review path after 10 successful session copies, with version-aware and permanent suppression controls plus a passive Settings link (#56)
 
+### Changed
+- Pin GitHub Actions to reviewed immutable commit SHAs while preserving least-privilege workflow permissions (#44)
+
 ### Fixed
 - Localize action menus, Git permalink presentation, gutter feedback, and template preset labels without changing persisted settings or template contents (#43)
 - Record the detected file language exactly once per successful standard copy action, including multi-caret copies (#41)
-
-### Fixed
 - Keep Gradle wrapper download and initialization output out of generated GitHub Release notes (#53)
 
 ## [1.1.1] - 2026-09-02
@@ -125,7 +128,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toast notifications
 - IntelliJ Platform 2024.3+ compatibility
 
-[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/hon454/copy-selection-context/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/hon454/copy-selection-context/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/hon454/copy-selection-context/compare/v1.0.4...v1.1.0
 [1.0.4]: https://github.com/hon454/copy-selection-context/compare/v1.0.3...v1.0.4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.github.hon454"
-version = "1.1.1"
+version = "1.2.0"
 
 repositories {
     mavenCentral()

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -13,8 +13,8 @@ class ReleaseVersionParityTest {
     private val verifier = projectRoot.resolve("scripts/verify-release-version.sh")
 
     @Test
-    fun `canonical project version is 1_1_1`() {
-        assertEquals("1.1.1", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
+    fun `canonical project version is 1_2_0`() {
+        assertEquals("1.2.0", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
     }
 
     @Test
@@ -22,7 +22,7 @@ class ReleaseVersionParityTest {
         val result = runVerifier("v${canonicalVersion(projectRoot.resolve("build.gradle.kts"))}")
 
         assertEquals(0, result.exitCode, result.output)
-        assertTrue(result.output.contains("Version verified: v1.1.1"), result.output)
+        assertTrue(result.output.contains("Version verified: v1.2.0"), result.output)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- bump the canonical plugin version from `1.1.1` to `1.2.0`
- move the complete v1.2.0 changelog into `[1.2.0] - 2026-09-02` and leave `[Unreleased]` empty
- update the version-parity assertion for the planned `v1.2.0` tag

Closes #63

## Changelog issues

- #41 — local analytics recording and controls
- #42 — bounded copy-history storage
- #43 — localized action and template UI strings
- #44 — immutable GitHub Actions revisions and least-privilege permissions
- #45 — canonical release ZIP checksum and provenance
- #53 — deterministic release-note generation
- #56 — respectful Marketplace review prompt

All seven milestone issues were confirmed closed before preparing this PR.

## Verification

- `bash scripts/verify-release-version.sh v1.2.0`
- actual `scripts/generate-release-notes.sh 1.2.0 v1.2.0` output contains only the v1.2.0 changelog body
- release contract tests: version parity, release notes, signed/unsigned mode, canonical artifact selection, checksum, attestation workflow, and documentation
- `actionlint .github/workflows/build.yml .github/workflows/release.yml`
- `shellcheck scripts/*.sh`
- `./gradlew test verifyPluginProjectConfiguration verifyPluginStructure verifyPlugin buildPlugin --rerun-tasks --stacktrace --console=plain`
- Plugin Verifier: compatible with IC 2024.3.7.1, 2025.1.7.2, and 2025.2.6.3
- generated `build/distributions/copy-selection-context-1.2.0.zip`
- packaged `META-INF/plugin.xml` reports version `1.2.0`
- local checksum generation and verification passed (`SHA-256: 59fee8f6d6ef90ebc22519d3bd8c58d80f5605d81a75986d7ca32b82f83683dd`)

## Publication status

No tag was created. No GitHub Release was created. No Marketplace publication was attempted. Signing and unsigned-release paths were validated through the repository contract tests; the credential-backed release path remains release-time work.

## Release-time checklist

- [ ] Wait for this PR's independent review and required CI to pass
- [ ] Merge this PR into `main`
- [ ] Confirm `v1.2.0` does not already exist and tag the verified `main` merge commit
- [ ] Push only `v1.2.0` and monitor the tag-triggered Release workflow
- [ ] Confirm the GitHub Release contains the canonical ZIP and `SHA256SUMS`
- [ ] Verify the published ZIP digest against `SHA256SUMS`
- [ ] Run `gh attestation verify` for the release asset and repository
- [ ] Record whether Marketplace publication succeeded or was explicitly skipped because credentials were absent
