### PR TITLE
chore(release): prepare v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-09-02
+
+### Changed
+- Upgrade the GitHub release action from v2.6.2 to v3.0.3, adopting its Node 24 runtime and release reliability fixes (#59)
+
 ## [1.2.0] - 2026-09-02
 
 ### Added
@@ -128,7 +133,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toast notifications
 - IntelliJ Platform 2024.3+ compatibility
 
-[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/hon454/copy-selection-context/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/hon454/copy-selection-context/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/hon454/copy-selection-context/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/hon454/copy-selection-context/compare/v1.0.4...v1.1.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.github.hon454"
-version = "1.2.0"
+version = "1.2.1"
 
 repositories {
     mavenCentral()

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -13,8 +13,8 @@ class ReleaseVersionParityTest {
     private val verifier = projectRoot.resolve("scripts/verify-release-version.sh")
 
     @Test
-    fun `canonical project version is 1_2_0`() {
-        assertEquals("1.2.0", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
+    fun `canonical project version is 1_2_1`() {
+        assertEquals("1.2.1", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
     }
 
     @Test
@@ -22,7 +22,7 @@ class ReleaseVersionParityTest {
         val result = runVerifier("v${canonicalVersion(projectRoot.resolve("build.gradle.kts"))}")
 
         assertEquals(0, result.exitCode, result.output)
-        assertTrue(result.output.contains("Version verified: v1.2.0"), result.output)
+        assertTrue(result.output.contains("Version verified: v1.2.1"), result.output)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- bump the plugin version from 1.2.0 to 1.2.1
- promote the action-gh-release v3 upgrade into the 1.2.1 changelog
- refresh changelog comparison links for the new tag

## Validation
- `bash scripts/verify-release-version.sh v1.2.1`
- `git diff --check`
- Full Gradle validation delegated to GitHub Actions because this host has no JDK runtime.