### PR TITLE
refactor: consolidate selection context

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -18,8 +18,8 @@
 ## Standard Copy Flow
 
 1. The user invokes `CopySelectionContextAction` with `Ctrl+Alt+C` / `Cmd+Alt+C`, or chooses an explicit path/code action from the editor context menu.
-2. `CopySelectionBaseAction` resolves the project, editor, and virtual file. `CopySelectionUtils` derives the configured path, selected text or current line, 1-based inclusive line range, and Markdown language tag.
-3. A non-empty selection uses `selectionEnd - 1` as its last included offset, so a selection ending at the next line's start does not include that line. With multiple carets, each caret is formatted independently and the blocks are joined with a blank line.
+2. `CopySelectionBaseAction` resolves the project, editor, and virtual file. `CopySelectionUtils` reads each caret exactly once into an immutable `SelectionContext` containing the captured path, file, filename, selected text or current line, 1-based inclusive line range, and Markdown language tag.
+3. A non-empty selection uses `selectionEnd - 1` as its last included offset, so a selection ending at the next line's start does not include that line. With multiple carets, each captured context is formatted independently and the blocks are joined with a blank line; formatting and post-copy highlighting never re-read mutable editor selection state.
 4. `OutputFormatterFactory` selects the configured Claude Code, Path:Line, or custom template formatter. `CopySelectionContextAction` includes code only when enabled; `CopyWithCodeContentAction` always includes it.
 5. `CopyPasteManager` writes the complete formatted result to the clipboard.
 6. When analytics are enabled, `CopySelectionAnalytics` increments total, selected-format, and detected-language counters exactly once per standard copy action, including multi-caret copies.
@@ -93,7 +93,7 @@ The implementation uses the flat package `com.github.hon454.copyselectioncontext
 | `CopySelectionSettings.kt` | Persistent application settings and path enum |
 | `CopySelectionStatusBarWidget.kt` | Safe last-copy preview and click-to-copy interaction |
 | `CopySelectionStatusBarWidgetFactory.kt` | Status-bar widget registration lifecycle |
-| `CopySelectionUtils.kt` | VFS path, exclusive-end range, code, multi-caret, and language helpers |
+| `CopySelectionUtils.kt` | VFS paths, language detection, exclusive-end ranges, and single-pass caret context capture |
 | `CopySelectionWebHelpProvider.kt` | README help-topic URLs |
 | `CopyWithCodeContentAction.kt` | Context-menu action that always includes code |
 | `GitPermalinkGenerator.kt` | GitHub/GitLab remote parsing and encoded URL construction |
@@ -101,6 +101,7 @@ The implementation uses the flat package `com.github.hon454.copyselectioncontext
 | `GitRepositoryMetadataResolver.kt` | Standard and linked-worktree metadata/ref resolution |
 | `OutputFormatOption.kt` | Localized output-format setting options |
 | `OutputFormatter.kt` | Format context, built-in formatters, and formatter factory |
+| `SelectionContext.kt` | Immutable single source of truth for per-caret path, file, range, code, language, and filename inputs |
 | `ShowCopyHistoryAction.kt` | Direct action that opens project copy history |
 | `TemplateFormatter.kt` | Custom variable substitution, presets, and validation |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,8 @@ Single flat package: `com.github.hon454.copyselectioncontext/`
 | `CopySelectionContextAction.kt` | Main unified action (`Ctrl+Alt+C` shortcut) |
 | `CopySelectionBaseAction.kt` | Shared copy pipeline: formatting, clipboard, analytics, highlighting, history, notifications, status, and review-prompt accounting |
 | `OutputFormatter.kt` / `TemplateFormatter.kt` | Built-in Claude Code and Path:Line formats plus custom templates |
-| `CopySelectionUtils.kt` | Path, line range, selected code, multi-caret, and language helpers |
+| `SelectionContext.kt` | Immutable per-caret snapshot of path, file, range, code, language, and filename inputs |
+| `CopySelectionUtils.kt` | Path/language helpers and single-pass selection context capture |
 | `CopySelectionHighlighter.kt` | Editor-scoped gutter highlighter lifecycle |
 | `CopyRelativePathAction.kt` | Relative path (context menu only) |
 | `CopyAbsolutePathAction.kt` | Absolute path (context menu only) |
@@ -75,7 +76,7 @@ Single flat package: `com.github.hon454.copyselectioncontext/`
 | `CopySelectionSettings.kt` | Settings persistence (`@Service` + `@State`) |
 | `CopySelectionConfigurable.kt` | Settings UI with multiline template editor, preview, validation, passive review link, and analytics view/reset controls |
 
-**Flow**: User trigger -> Action reads settings -> Extract editor context -> Format output -> CopyPasteManager -> optional local analytics -> gutter marker -> project history -> optional notification -> status bar update -> session-only review eligibility
+**Flow**: User trigger -> Action reads settings -> Capture one immutable `SelectionContext` per caret -> Format captured contexts -> CopyPasteManager -> optional local analytics -> gutter marker from captured ranges -> project history -> optional notification -> status bar update -> session-only review eligibility
 
 ## Conventions
 

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBaseAction.kt
@@ -3,7 +3,6 @@ package com.github.hon454.copyselectioncontext
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
@@ -18,18 +17,9 @@ abstract class CopySelectionBaseAction : AnAction() {
         val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
 
         val path = getPath(project, file)
-        val caretCount = editor.caretModel.caretCount
-
-        val copyResult = if (caretCount > 1) {
-            buildMultiCaretContent(path, file, editor, project)
-        } else {
-            val (startLine, endLine) = resolveLineNumbers(editor)
-            val lineRange = CopySelectionUtils.toLineRange(startLine, endLine)
-            CaretCopyResult(
-                content = buildContent(path, lineRange, file, editor, project),
-                lineRanges = listOf(Pair(startLine, endLine)),
-            )
-        }
+        val contexts = CopySelectionUtils.captureSelectionContexts(path, file, editor)
+        if (contexts.isEmpty()) return
+        val copyResult = buildCapturedContent(contexts)
         val result = copyResult.content
 
         copyToClipboard(result)
@@ -38,7 +28,7 @@ abstract class CopySelectionBaseAction : AnAction() {
         if (appSettings.analyticsEnabled) {
             CopySelectionAnalytics.getInstance().recordCopy(
                 format = appSettings.outputFormat,
-                language = detectLanguage(file),
+                language = contexts.first().language,
             )
         }
 
@@ -74,81 +64,25 @@ abstract class CopySelectionBaseAction : AnAction() {
 
     protected abstract fun getPath(project: Project, file: VirtualFile): String
 
-    protected open fun buildContent(path: String, lineRange: String, file: VirtualFile, editor: Editor, project: Project? = null): String {
-        val (startLine, endLine) = resolveLineNumbers(editor)
-        return formatWithSettings(path, startLine, endLine, file)
-    }
+    protected open fun buildContent(context: SelectionContext): String = formatWithSettings(context)
 
-    protected open fun buildContentForCaret(
-        path: String,
-        lineRange: String,
-        startLine: Int,
-        endLine: Int,
-        file: VirtualFile,
-        editor: Editor,
-        caret: Caret,
-        project: Project? = null,
-    ): String {
-        return formatWithSettings(path, startLine, endLine, file)
-    }
-
-    internal fun buildMultiCaretContent(
-        path: String,
-        file: VirtualFile,
-        editor: Editor,
-        project: Project? = null,
-    ): CaretCopyResult {
-        val blocks = mutableListOf<String>()
-        val lineRanges = mutableListOf<Pair<Int, Int>>()
-        editor.caretModel.runForEachCaret { caret ->
-            val (startLine, endLine) = CopySelectionUtils.resolveLineNumbers(editor, caret)
-            val lineRange = CopySelectionUtils.toLineRange(startLine, endLine)
-            lineRanges.add(Pair(startLine, endLine))
-            blocks.add(buildContentForCaret(path, lineRange, startLine, endLine, file, editor, caret, project))
-        }
-        return CaretCopyResult(CopySelectionUtils.joinCaretBlocks(blocks), lineRanges)
-    }
-
-    protected fun resolveLineNumbers(editor: Editor): Pair<Int, Int> {
-        return CopySelectionUtils.resolveLineNumbers(editor)
-    }
+    internal fun buildCapturedContent(contexts: List<SelectionContext>): CaretCopyResult = CaretCopyResult(
+        content = CopySelectionUtils.joinCaretBlocks(contexts.map(::buildContent)),
+        lineRanges = contexts.map(SelectionContext::lineNumbers),
+    )
 
     protected fun formatWithSettings(
-        path: String,
-        startLine: Int,
-        endLine: Int,
-        file: VirtualFile,
-        code: String? = null,
-        language: String = ""
+        context: SelectionContext,
+        includeCode: Boolean = false,
     ): String {
         val settings = CopySelectionSettings.getInstance().state
         val formatter = OutputFormatterFactory.getFormatterForSettings(settings)
-        val context = FormatContext(
-            path = path,
-            startLine = startLine,
-            endLine = endLine,
-            code = code,
-            language = language,
-            filename = file.name
-        )
-        return formatter.format(context)
-    }
-
-    protected fun getCodeContent(editor: Editor): String {
-        return CopySelectionUtils.getCodeContent(editor)
-    }
-
-    protected fun getCodeContent(editor: Editor, caret: Caret): String {
-        return CopySelectionUtils.getCodeContent(editor, caret)
-    }
-
-    protected fun detectLanguage(file: VirtualFile): String {
-        return CopySelectionUtils.detectLanguage(file)
-    }
-
-    protected fun applyCodeTrimming(code: String): String {
-        val settings = CopySelectionSettings.getInstance().state
-        return if (settings.codeTrimming) code.trim() else code
+        val code = if (includeCode) {
+            if (settings.codeTrimming) context.code.trim() else context.code
+        } else {
+            null
+        }
+        return formatter.format(context.toFormatContext(code))
     }
     
     private fun copyToClipboard(content: String) {

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionContextAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionContextAction.kt
@@ -1,7 +1,5 @@
 package com.github.hon454.copyselectioncontext
 
-import com.intellij.openapi.editor.Caret
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 
@@ -10,37 +8,8 @@ open class CopySelectionContextAction : CopySelectionBaseAction() {
         return CopySelectionUtils.resolvePath(project, file, CopySelectionSettings.getInstance().state.defaultPathType)
     }
 
-    override fun buildContent(path: String, lineRange: String, file: VirtualFile, editor: Editor, project: Project?): String {
+    override fun buildContent(context: SelectionContext): String {
         val settings = CopySelectionSettings.getInstance().state
-        val (startLine, endLine) = resolveLineNumbers(editor)
-        return if (settings.includeCodeContent) {
-            var code = getCodeContent(editor)
-            code = applyCodeTrimming(code)
-            val language = detectLanguage(file)
-            formatWithSettings(path, startLine, endLine, file, code, language)
-        } else {
-            formatWithSettings(path, startLine, endLine, file)
-        }
-    }
-
-    protected override fun buildContentForCaret(
-        path: String,
-        lineRange: String,
-        startLine: Int,
-        endLine: Int,
-        file: VirtualFile,
-        editor: Editor,
-        caret: Caret,
-        project: Project?,
-    ): String {
-        val settings = CopySelectionSettings.getInstance().state
-        return if (settings.includeCodeContent) {
-            var code = getCodeContent(editor, caret)
-            code = applyCodeTrimming(code)
-            val language = detectLanguage(file)
-            formatWithSettings(path, startLine, endLine, file, code, language)
-        } else {
-            formatWithSettings(path, startLine, endLine, file)
-        }
+        return formatWithSettings(context, includeCode = settings.includeCodeContent)
     }
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionUtils.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionUtils.kt
@@ -61,11 +61,6 @@ object CopySelectionUtils {
         }
     }
 
-    fun resolveLineRange(editor: Editor): String {
-        val (startLine, endLine) = resolveLineNumbers(editor)
-        return toLineRange(startLine, endLine)
-    }
-
     fun resolveLineNumbers(editor: Editor): Pair<Int, Int> {
         val selectionModel = editor.selectionModel
         return if (selectionModel.hasSelection()) {
@@ -85,30 +80,8 @@ object CopySelectionUtils {
         }
     }
 
-    fun resolveLineRange(editor: Editor, caret: Caret): String {
-        val (startLine, endLine) = resolveLineNumbers(editor, caret)
-        return toLineRange(startLine, endLine)
-    }
-
-    fun resolveLineRanges(editor: Editor): List<String> {
-        val caretModel = editor.caretModel
-        if (caretModel.caretCount <= 1) {
-            return listOf(resolveLineRange(editor))
-        }
-
-        val ranges = mutableListOf<String>()
-        caretModel.runForEachCaret { caret ->
-            ranges.add(resolveLineRange(editor, caret))
-        }
-        return ranges
-    }
-
     fun joinCaretBlocks(blocks: List<String>): String {
         return blocks.joinToString("\n\n")
-    }
-
-    fun toLineRange(startLine: Int, endLine: Int): String {
-        return if (startLine == endLine) "$startLine" else "$startLine-$endLine"
     }
 
     private fun resolveSelectedLineNumbers(editor: Editor, selectionStart: Int, selectionEnd: Int): Pair<Int, Int> {
@@ -119,29 +92,14 @@ object CopySelectionUtils {
         return Pair(startLine, endLine)
     }
 
-    fun getCodeContent(editor: Editor): String {
-        val selectionModel = editor.selectionModel
-        return if (selectionModel.hasSelection()) {
-            selectionModel.selectedText ?: ""
-        } else {
-            val document = editor.document
-            val caretLine = editor.caretModel.logicalPosition.line
-            val lineStart = document.getLineStartOffset(caretLine)
-            val lineEnd = document.getLineEndOffset(caretLine)
-            document.getText(TextRange(lineStart, lineEnd))
+    internal fun captureSelectionContexts(path: String, file: VirtualFile, editor: Editor): List<SelectionContext> {
+        val contexts = mutableListOf<SelectionContext>()
+        val language = detectLanguage(file)
+        val filename = file.name
+        editor.caretModel.runForEachCaret { caret ->
+            contexts.add(captureSelectionContext(path, file, language, filename, editor, caret))
         }
-    }
-
-    fun getCodeContent(editor: Editor, caret: Caret): String {
-        return if (caret.hasSelection()) {
-            caret.selectedText ?: ""
-        } else {
-            val document = editor.document
-            val caretLine = caret.logicalPosition.line
-            val lineStart = document.getLineStartOffset(caretLine)
-            val lineEnd = document.getLineEndOffset(caretLine)
-            document.getText(TextRange(lineStart, lineEnd))
-        }
+        return contexts
     }
 
     fun detectLanguage(file: VirtualFile): String {
@@ -149,16 +107,42 @@ object CopySelectionUtils {
         return LANGUAGE_MAP[fileTypeName] ?: file.extension?.lowercase().orEmpty()
     }
 
-    fun formatOutput(path: String, lineRange: String, code: String? = null, language: String? = null): String {
-        val startLine = lineRange.substringBefore("-").toIntOrNull() ?: 0
-        val endLine = lineRange.substringAfter("-", lineRange).toIntOrNull() ?: startLine
-        val context = FormatContext(
+    private fun captureSelectionContext(
+        path: String,
+        file: VirtualFile,
+        language: String,
+        filename: String,
+        editor: Editor,
+        caret: Caret,
+    ): SelectionContext {
+        val document = editor.document
+        val hasSelection = caret.hasSelection()
+        val (startLine, endLine, code) = if (hasSelection) {
+            val selectionStart = caret.selectionStart
+            val selectionEnd = caret.selectionEnd
+            Triple(
+                document.getLineNumber(selectionStart) + 1,
+                document.getLineNumber(selectionEnd - 1) + 1,
+                caret.selectedText ?: "",
+            )
+        } else {
+            val caretLine = caret.logicalPosition.line
+            val lineStart = document.getLineStartOffset(caretLine)
+            val lineEnd = document.getLineEndOffset(caretLine)
+            Triple(
+                caretLine + 1,
+                caretLine + 1,
+                document.getText(TextRange(lineStart, lineEnd)),
+            )
+        }
+        return SelectionContext(
             path = path,
+            file = file,
             startLine = startLine,
             endLine = endLine,
             code = code,
-            language = language ?: "null"
+            language = language,
+            filename = filename,
         )
-        return ClaudeCodeFormatter().format(context)
     }
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyWithCodeContentAction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopyWithCodeContentAction.kt
@@ -1,7 +1,5 @@
 package com.github.hon454.copyselectioncontext
 
-import com.intellij.openapi.editor.Caret
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 
@@ -11,27 +9,6 @@ class CopyWithCodeContentAction : CopySelectionBaseAction() {
         return CopySelectionUtils.resolvePath(project, file, settings.defaultPathType)
     }
 
-    override fun buildContent(path: String, lineRange: String, file: VirtualFile, editor: Editor, project: Project?): String {
-        val (startLine, endLine) = resolveLineNumbers(editor)
-        var code = getCodeContent(editor)
-        code = applyCodeTrimming(code)
-        val language = detectLanguage(file)
-        return formatWithSettings(path, startLine, endLine, file, code, language)
-    }
-
-    protected override fun buildContentForCaret(
-        path: String,
-        lineRange: String,
-        startLine: Int,
-        endLine: Int,
-        file: VirtualFile,
-        editor: Editor,
-        caret: Caret,
-        project: Project?,
-    ): String {
-        var code = getCodeContent(editor, caret)
-        code = applyCodeTrimming(code)
-        val language = detectLanguage(file)
-        return formatWithSettings(path, startLine, endLine, file, code, language)
-    }
+    override fun buildContent(context: SelectionContext): String =
+        formatWithSettings(context, includeCode = true)
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/OutputFormatter.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/OutputFormatter.kt
@@ -26,16 +26,9 @@ class ClaudeCodeFormatter : OutputFormatter {
         return if (context.code.isNullOrBlank()) {
             " @$normalizedPath#L${context.lineRange} "
         } else {
-            val fence = buildFence(context.code)
+            val fence = MarkdownCodeFence.forCode(context.code)
             " @$normalizedPath#L${context.lineRange} \n$fence${context.language}\n${context.code}\n$fence"
         }
-    }
-
-    private fun buildFence(code: String): String {
-        val maxBackticks = code.lines().maxOfOrNull { line ->
-            line.takeWhile { it == '`' }.length
-        } ?: 0
-        return "`".repeat(maxOf(3, maxBackticks + 1))
     }
 }
 
@@ -48,12 +41,14 @@ class PathLineFormatter : OutputFormatter {
         return if (context.code.isNullOrBlank()) {
             "$normalizedPath:${context.lineRange}"
         } else {
-            val fence = buildFence(context.code)
+            val fence = MarkdownCodeFence.forCode(context.code)
             "$normalizedPath:${context.lineRange}\n$fence${context.language}\n${context.code}\n$fence"
         }
     }
+}
 
-    private fun buildFence(code: String): String {
+internal object MarkdownCodeFence {
+    fun forCode(code: String): String {
         val maxBackticks = code.lines().maxOfOrNull { line ->
             line.takeWhile { it == '`' }.length
         } ?: 0

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/SelectionContext.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/SelectionContext.kt
@@ -11,9 +11,6 @@ data class SelectionContext(
     val language: String,
     val filename: String,
 ) {
-    val lineRange: String
-        get() = if (startLine == endLine) "$startLine" else "$startLine-$endLine"
-
     val lineNumbers: Pair<Int, Int>
         get() = Pair(startLine, endLine)
 

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/SelectionContext.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/SelectionContext.kt
@@ -1,0 +1,28 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.vfs.VirtualFile
+
+data class SelectionContext(
+    val path: String,
+    val file: VirtualFile,
+    val startLine: Int,
+    val endLine: Int,
+    val code: String,
+    val language: String,
+    val filename: String,
+) {
+    val lineRange: String
+        get() = if (startLine == endLine) "$startLine" else "$startLine-$endLine"
+
+    val lineNumbers: Pair<Int, Int>
+        get() = Pair(startLine, endLine)
+
+    fun toFormatContext(code: String? = null): FormatContext = FormatContext(
+        path = path,
+        startLine = startLine,
+        endLine = endLine,
+        code = code,
+        language = language,
+        filename = filename,
+    )
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionActionTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionActionTest.kt
@@ -1,31 +1,18 @@
 package com.github.hon454.copyselectioncontext
 
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
-import com.intellij.openapi.editor.Caret
-import com.intellij.openapi.editor.CaretModel
-import com.intellij.openapi.editor.Document
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.LogicalPosition
-import com.intellij.openapi.editor.SelectionModel
-import com.intellij.openapi.fileTypes.FileType
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.VirtualFile
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
-import kotlin.test.assertNotNull
 
-/**
- * Integration tests for CopySelectionAction using mock fixtures.
- * This test class demonstrates the test infrastructure setup for the plugin.
- */
 class CopySelectionActionTest {
-
     private lateinit var settings: CopySelectionSettings
 
     @BeforeTest
@@ -41,101 +28,55 @@ class CopySelectionActionTest {
     }
 
     @Test
-    fun testResolveLineRangeWithMockEditor() {
-        val editor = mockk<Editor>()
-        val selectionModel = mockk<SelectionModel>()
-        val document = mockk<Document>()
-
-        every { editor.selectionModel } returns selectionModel
-        every { editor.document } returns document
-        every { selectionModel.hasSelection() } returns true
-        every { selectionModel.selectionStart } returns 0
-        every { selectionModel.selectionEnd } returns 20
-        every { document.getLineNumber(0) } returns 0
-        every { document.getLineNumber(19) } returns 2
-
-        val result = CopySelectionUtils.resolveLineRange(editor)
-
-        assertNotNull(result)
-        assertTrue(result.contains("-"))
-        assertEquals("1-3", result)
-    }
-
-    @Test
-    fun testDetectLanguageForKotlinFile() {
+    fun `detectLanguage returns Kotlin language tag`() {
         val file = mockk<VirtualFile>()
         val fileType = mockk<FileType>()
         every { file.fileType } returns fileType
         every { fileType.name } returns "Kotlin"
         every { file.extension } returns "kt"
 
-        val language = CopySelectionUtils.detectLanguage(file)
-
-        assertEquals("kotlin", language)
+        assertEquals("kotlin", CopySelectionUtils.detectLanguage(file))
     }
 
     @Test
-    fun testFormatOutputWithCode() {
-        val result = CopySelectionUtils.formatOutput("src/App.kt", "10-15", "fun main() {}", "kotlin")
+    fun `Claude output with code remains byte-for-byte stable`() {
+        val result = ClaudeCodeFormatter().format(
+            FormatContext(
+                path = "src/App.kt",
+                startLine = 10,
+                endLine = 15,
+                code = "fun main() {}",
+                language = "kotlin",
+            ),
+        )
 
-        assertNotNull(result)
-        assertTrue(result.contains("@src/App.kt#L10-15"))
-        assertTrue(result.contains("```kotlin"))
-        assertTrue(result.contains("fun main() {"))
+        assertEquals(" @src/App.kt#L10-15 \n```kotlin\nfun main() {}\n```", result)
     }
 
     @Test
-    fun `custom template includes filename for single caret output`() {
-        useFilenameTemplate()
-        val file = mockk<VirtualFile>()
-        every { file.name } returns "Example.kt"
-
-        val result = TestCopySelectionAction().buildSingleCaretContent(file, mockSingleCaretEditor())
-
-        assertEquals("File: Example.kt", result)
-    }
-
-    @Test
-    fun `custom template includes filename for multi caret output`() {
-        useFilenameTemplate()
-        val file = mockk<VirtualFile>()
-        val caret = mockk<Caret>()
-        every { file.name } returns "Example.kt"
-
-        val result = TestCopySelectionAction().buildMultiCaretContent(file, mockSingleCaretEditor(), caret)
-
-        assertEquals("File: Example.kt", result)
-    }
-
-    private fun useFilenameTemplate() {
+    fun `custom template uses filename from captured context`() {
         every { settings.state } returns CopySelectionSettings.State(
             outputFormat = "template",
-            customFormatTemplate = "File: {filename}"
+            customFormatTemplate = "File: {filename}",
         )
-    }
+        val file = mockk<VirtualFile>()
+        val context = SelectionContext(
+            path = "src/Example.kt",
+            file = file,
+            startLine = 5,
+            endLine = 5,
+            code = "example()",
+            language = "kotlin",
+            filename = "Example.kt",
+        )
 
-    private fun mockSingleCaretEditor(): Editor {
-        val editor = mockk<Editor>()
-        val selectionModel = mockk<SelectionModel>()
-        val caretModel = mockk<CaretModel>()
-        val document = mockk<Document>()
-        every { editor.selectionModel } returns selectionModel
-        every { editor.caretModel } returns caretModel
-        every { editor.document } returns document
-        every { selectionModel.hasSelection() } returns false
-        every { caretModel.logicalPosition } returns LogicalPosition(4, 0)
-        return editor
+        val result = TestCopySelectionAction().buildCapturedContent(listOf(context, context))
+
+        assertEquals("File: Example.kt\n\nFile: Example.kt", result.content)
+        assertEquals(listOf(Pair(5, 5), Pair(5, 5)), result.lineRanges)
     }
 
     private class TestCopySelectionAction : CopySelectionBaseAction() {
         override fun getPath(project: Project, file: VirtualFile): String = file.path
-
-        fun buildSingleCaretContent(file: VirtualFile, editor: Editor): String {
-            return buildContent("src/Example.kt", "5", file, editor)
-        }
-
-        fun buildMultiCaretContent(file: VirtualFile, editor: Editor, caret: Caret): String {
-            return buildContentForCaret("src/Example.kt", "5", 5, 5, file, editor, caret)
-        }
     }
 }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionMultiCaretTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionMultiCaretTest.kt
@@ -13,6 +13,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -24,7 +25,8 @@ class CopySelectionMultiCaretTest {
         val fixture = multiCaretFixture()
         val action = CopySelectionContextAction()
 
-        val result = action.buildMultiCaretContent("src/App.kt", fixture.file, fixture.editor)
+        val contexts = CopySelectionUtils.captureSelectionContexts("src/App.kt", fixture.file, fixture.editor)
+        val result = action.buildCapturedContent(contexts)
 
         assertEquals(
             " @src/App.kt#L1-2 \n```kotlin\nfirst()\n```\n\n" +
@@ -41,7 +43,8 @@ class CopySelectionMultiCaretTest {
         val fixture = multiCaretFixture()
         val action = CopyWithCodeContentAction()
 
-        val result = action.buildMultiCaretContent("src/App.kt", fixture.file, fixture.editor)
+        val contexts = CopySelectionUtils.captureSelectionContexts("src/App.kt", fixture.file, fixture.editor)
+        val result = action.buildCapturedContent(contexts)
 
         assertEquals(
             " @src/App.kt#L1-2 \n```kotlin\nfirst()\n```\n\n" +
@@ -57,9 +60,10 @@ class CopySelectionMultiCaretTest {
     ) {
         val fixture = multiCaretFixture()
         val actions = listOf(CopyAbsolutePathAction(), CopyRelativePathAction())
+        val contexts = CopySelectionUtils.captureSelectionContexts("src/App.kt", fixture.file, fixture.editor)
 
         actions.forEach { action ->
-            val result = action.buildMultiCaretContent("src/App.kt", fixture.file, fixture.editor)
+            val result = action.buildCapturedContent(contexts)
 
             assertEquals(
                 " @src/App.kt#L1-2 \n\n @src/App.kt#L5 ",
@@ -67,6 +71,27 @@ class CopySelectionMultiCaretTest {
             )
             assertEquals(listOf(Pair(1, 2), Pair(5, 5)), result.lineRanges)
         }
+        verify(exactly = 1) { fixture.document.getLineNumber(0) }
+        verify(exactly = 1) { fixture.document.getLineNumber(11) }
+    }
+
+    @Test
+    fun `captured contexts remain deterministic after selections change`() = withSettings(
+        CopySelectionSettings.State(includeCodeContent = true),
+    ) {
+        val fixture = multiCaretFixture()
+        val contexts = CopySelectionUtils.captureSelectionContexts("src/App.kt", fixture.file, fixture.editor)
+        every { fixture.selectedCaret.selectionStart } returns 40
+        every { fixture.selectedCaret.selectionEnd } returns 48
+        every { fixture.selectedCaret.selectedText } returns "changed()"
+
+        val result = CopySelectionContextAction().buildCapturedContent(contexts)
+
+        assertEquals(
+            " @src/App.kt#L1-2 \n```kotlin\nfirst()\n```\n\n" +
+                " @src/App.kt#L5 \n```kotlin\nsecond()\n```",
+            result.content,
+        )
     }
 
     private fun multiCaretFixture(): MultiCaretFixture {
@@ -101,7 +126,7 @@ class CopySelectionMultiCaretTest {
         every { file.extension } returns "kt"
         every { file.name } returns "App.kt"
 
-        return MultiCaretFixture(editor, selectedCaret, currentLineCaret, file)
+        return MultiCaretFixture(editor, document, selectedCaret, currentLineCaret, file)
     }
 
     private fun withSettings(state: CopySelectionSettings.State, test: () -> Unit) {
@@ -119,6 +144,7 @@ class CopySelectionMultiCaretTest {
 
     private data class MultiCaretFixture(
         val editor: Editor,
+        val document: Document,
         val selectedCaret: Caret,
         val currentLineCaret: Caret,
         val file: VirtualFile,

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionMultiCaretTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionMultiCaretTest.kt
@@ -92,6 +92,7 @@ class CopySelectionMultiCaretTest {
                 " @src/App.kt#L5 \n```kotlin\nsecond()\n```",
             result.content,
         )
+        assertEquals(listOf(Pair(1, 2), Pair(5, 5)), result.lineRanges)
     }
 
     private fun multiCaretFixture(): MultiCaretFixture {

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionUtilsTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionUtilsTest.kt
@@ -1,15 +1,12 @@
 package com.github.hon454.copyselectioncontext
 
 import com.intellij.openapi.editor.CaretModel
-import com.intellij.openapi.editor.Caret
-import com.intellij.openapi.editor.CaretAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.SelectionModel
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileSystem
 import io.mockk.every
@@ -21,58 +18,6 @@ import kotlin.test.assertTrue
 
 class CopySelectionUtilsTest {
     private val virtualFileSystem = mockk<VirtualFileSystem>()
-
-    @Test
-    fun `resolveLineRanges returns single block for single caret`() {
-        val editor = mockk<Editor>()
-        val selectionModel = mockk<SelectionModel>()
-        val caretModel = mockk<CaretModel>()
-        val document = mockk<Document>()
-
-        every { editor.selectionModel } returns selectionModel
-        every { editor.caretModel } returns caretModel
-        every { editor.document } returns document
-        every { caretModel.caretCount } returns 1
-        every { selectionModel.hasSelection() } returns false
-        every { caretModel.logicalPosition } returns LogicalPosition(9, 0)
-
-        val result = CopySelectionUtils.resolveLineRanges(editor)
-
-        assertEquals(listOf("10"), result)
-    }
-
-    @Test
-    fun `resolveLineRanges returns multiple blocks joined by double newlines for two carets`() {
-        val editor = mockk<Editor>()
-        val caretModel = mockk<CaretModel>()
-        val document = mockk<Document>()
-        val caret1 = mockk<Caret>()
-        val caret2 = mockk<Caret>()
-
-        every { editor.caretModel } returns caretModel
-        every { editor.document } returns document
-        every { caretModel.caretCount } returns 2
-
-        every { caret1.hasSelection() } returns true
-        every { caret1.selectionStart } returns 0
-        every { caret1.selectionEnd } returns 10
-        every { document.getLineNumber(0) } returns 0
-        every { document.getLineNumber(9) } returns 1
-
-        every { caret2.hasSelection() } returns false
-        every { caret2.logicalPosition } returns LogicalPosition(3, 0)
-
-        every { caretModel.runForEachCaret(any<CaretAction>()) } answers {
-            val action = firstArg<CaretAction>()
-            action.perform(caret1)
-            action.perform(caret2)
-        }
-
-        val result = CopySelectionUtils.resolveLineRanges(editor)
-
-        assertEquals(listOf("1-2", "4"), result)
-        assertEquals("1-2\n\n4", CopySelectionUtils.joinCaretBlocks(result))
-    }
 
     @Test
     fun `joinCaretBlocks joins blocks with double newlines`() {
@@ -118,7 +63,7 @@ class CopySelectionUtilsTest {
     }
 
     @Test
-    fun `resolveLineRange returns selection range`() {
+    fun `resolveLineNumbers returns selection range`() {
         val editor = mockk<Editor>()
         val selectionModel = mockk<SelectionModel>()
         val document = mockk<Document>()
@@ -131,9 +76,9 @@ class CopySelectionUtilsTest {
         every { document.getLineNumber(10) } returns 1
         every { document.getLineNumber(19) } returns 3
 
-        val result = CopySelectionUtils.resolveLineRange(editor)
+        val result = CopySelectionUtils.resolveLineNumbers(editor)
 
-        assertEquals("2-4", result)
+        assertEquals(Pair(2, 4), result)
     }
 
     @Test
@@ -213,7 +158,7 @@ class CopySelectionUtilsTest {
     }
 
     @Test
-    fun `resolveLineRange returns current line when no selection`() {
+    fun `resolveLineNumbers returns current line when no selection`() {
         val editor = mockk<Editor>()
         val selectionModel = mockk<SelectionModel>()
         val caretModel = mockk<CaretModel>()
@@ -225,47 +170,9 @@ class CopySelectionUtilsTest {
         every { selectionModel.hasSelection() } returns false
         every { caretModel.logicalPosition } returns LogicalPosition(9, 0)
 
-        val result = CopySelectionUtils.resolveLineRange(editor)
+        val result = CopySelectionUtils.resolveLineNumbers(editor)
 
-        assertEquals("10", result)
-    }
-
-    @Test
-    fun `getCodeContent returns selected text`() {
-        val editor = mockk<Editor>()
-        val selectionModel = mockk<SelectionModel>()
-
-        every { editor.selectionModel } returns selectionModel
-        every { selectionModel.hasSelection() } returns true
-        every { selectionModel.selectedText } returns "val x = 1"
-
-        val result = CopySelectionUtils.getCodeContent(editor)
-
-        assertEquals("val x = 1", result)
-    }
-
-    @Test
-    fun `getCodeContent returns current line text when no selection`() {
-        val editor = mockk<Editor>()
-        val selectionModel = mockk<SelectionModel>()
-        val caretModel = mockk<CaretModel>()
-        val document = mockk<Document>()
-
-        every { editor.selectionModel } returns selectionModel
-        every { editor.caretModel } returns caretModel
-        every { editor.document } returns document
-        every { selectionModel.hasSelection() } returns false
-        every { caretModel.logicalPosition } returns LogicalPosition(2, 0)
-        every { document.getLineStartOffset(2) } returns 5
-        every { document.getLineEndOffset(2) } returns 12
-        every { document.getText(any()) } answers {
-            val range = firstArg<TextRange>()
-            if (range.startOffset == 5 && range.endOffset == 12) "line text" else ""
-        }
-
-        val result = CopySelectionUtils.getCodeContent(editor)
-
-        assertEquals("line text", result)
+        assertEquals(Pair(10, 10), result)
     }
 
     @Test
@@ -288,14 +195,14 @@ class CopySelectionUtilsTest {
 
     @Test
     fun `formatOutput renders plain output`() {
-        val result = CopySelectionUtils.formatOutput("C:\\repo\\src\\App.kt", "3-5")
+        val result = ClaudeCodeFormatter().format(FormatContext("C:\\repo\\src\\App.kt", 3, 5))
 
         assertEquals(" @C:/repo/src/App.kt#L3-5 ", result)
     }
 
     @Test
     fun `formatOutput renders markdown output`() {
-        val result = CopySelectionUtils.formatOutput("src/App.kt", "7", "println(1)", "kotlin")
+        val result = ClaudeCodeFormatter().format(FormatContext("src/App.kt", 7, 7, "println(1)", "kotlin"))
 
         assertEquals(" @src/App.kt#L7 \n```kotlin\nprintln(1)\n```", result)
     }
@@ -368,7 +275,7 @@ class CopySelectionUtilsTest {
     }
 
     @Test
-    fun `resolveLineRange returns single line number when startLine equals endLine`() {
+    fun `resolveLineNumbers returns equal line numbers for one selected line`() {
         val editor = mockk<Editor>()
         val selectionModel = mockk<SelectionModel>()
         val document = mockk<Document>()
@@ -381,23 +288,9 @@ class CopySelectionUtilsTest {
         every { document.getLineNumber(10) } returns 5
         every { document.getLineNumber(14) } returns 5
 
-        val result = CopySelectionUtils.resolveLineRange(editor)
+        val result = CopySelectionUtils.resolveLineNumbers(editor)
 
-        assertEquals("6", result)
-    }
-
-    @Test
-    fun `getCodeContent returns empty string when selectedText is null`() {
-        val editor = mockk<Editor>()
-        val selectionModel = mockk<SelectionModel>()
-
-        every { editor.selectionModel } returns selectionModel
-        every { selectionModel.hasSelection() } returns true
-        every { selectionModel.selectedText } returns null
-
-        val result = CopySelectionUtils.getCodeContent(editor)
-
-        assertEquals("", result)
+        assertEquals(Pair(6, 6), result)
     }
 
     @Test
@@ -412,7 +305,7 @@ class CopySelectionUtilsTest {
     @Test
     fun `formatOutput handles code with triple backticks`() {
         val code = "val markdown = \"\"\"\n```\ncode block\n```\n\"\"\""
-        val result = CopySelectionUtils.formatOutput("src/App.kt", "10-15", code, "kotlin")
+        val result = ClaudeCodeFormatter().format(FormatContext("src/App.kt", 10, 15, code, "kotlin"))
 
         // Should use 4+ backticks to avoid breaking markdown
         assertTrue(result.contains("````kotlin"))
@@ -421,14 +314,14 @@ class CopySelectionUtilsTest {
 
     @Test
     fun `formatOutput handles path with hash character`() {
-        val result = CopySelectionUtils.formatOutput("src/App#v2.kt", "5", null, null)
+        val result = ClaudeCodeFormatter().format(FormatContext("src/App#v2.kt", 5, 5))
 
         assertEquals(" @src/App#v2.kt#L5 ", result)
     }
 
     @Test
     fun `formatOutput does not render code block with empty code string`() {
-        val result = CopySelectionUtils.formatOutput("src/App.kt", "3", "", "kotlin")
+        val result = ClaudeCodeFormatter().format(FormatContext("src/App.kt", 3, 3, "", "kotlin"))
 
         // Empty code should not produce code block
         assertEquals(" @src/App.kt#L3 ", result)
@@ -441,21 +334,6 @@ class CopySelectionUtilsTest {
         val result = CopySelectionUtils.detectLanguage(file)
 
         assertEquals("kotlin", result)
-    }
-
-    @Test
-    fun `getCodeContent handles multiline selected text with special characters`() {
-        val editor = mockk<Editor>()
-        val selectionModel = mockk<SelectionModel>()
-        val multilineText = "fun test() {\n    println(\"한글\")\n}"
-
-        every { editor.selectionModel } returns selectionModel
-        every { selectionModel.hasSelection() } returns true
-        every { selectionModel.selectedText } returns multilineText
-
-        val result = CopySelectionUtils.getCodeContent(editor)
-
-        assertEquals(multilineText, result)
     }
 
     @Test
@@ -603,41 +481,9 @@ class CopySelectionUtilsTest {
     }
 
     @Test
-    fun `getCodeContent with trimming enabled removes leading and trailing whitespace`() {
-        val editor = mockk<Editor>()
-        val selectionModel = mockk<SelectionModel>()
-        val settings = mockk<CopySelectionSettings>()
-        val state = mockk<CopySelectionSettings.State>()
-
-        every { editor.selectionModel } returns selectionModel
-        every { selectionModel.hasSelection() } returns true
-        every { selectionModel.selectedText } returns "  val x = 1  "
-
-        val code = CopySelectionUtils.getCodeContent(editor)
-        val trimmed = if (true) code.trim() else code  // Simulate trimming=true
-
-        assertEquals("val x = 1", trimmed)
-    }
-
-    @Test
-    fun `getCodeContent with trimming disabled preserves whitespace`() {
-        val editor = mockk<Editor>()
-        val selectionModel = mockk<SelectionModel>()
-
-        every { editor.selectionModel } returns selectionModel
-        every { selectionModel.hasSelection() } returns true
-        every { selectionModel.selectedText } returns "  val x = 1  "
-
-        val code = CopySelectionUtils.getCodeContent(editor)
-        val notTrimmed = if (false) code.trim() else code  // Simulate trimming=false
-
-        assertEquals("  val x = 1  ", notTrimmed)
-    }
-
-    @Test
     fun `formatOutput with trimmed code removes whitespace from code block`() {
         val trimmedCode = "val x = 1"
-        val result = CopySelectionUtils.formatOutput("src/App.kt", "5", trimmedCode, "kotlin")
+        val result = ClaudeCodeFormatter().format(FormatContext("src/App.kt", 5, 5, trimmedCode, "kotlin"))
 
         assertEquals(" @src/App.kt#L5 \n```kotlin\nval x = 1\n```", result)
     }
@@ -645,25 +491,17 @@ class CopySelectionUtilsTest {
     @Test
     fun `formatOutput with untrimmed code preserves whitespace in code block`() {
         val untrimmedCode = "  val x = 1  "
-        val result = CopySelectionUtils.formatOutput("src/App.kt", "5", untrimmedCode, "kotlin")
+        val result = ClaudeCodeFormatter().format(FormatContext("src/App.kt", 5, 5, untrimmedCode, "kotlin"))
 
         assertEquals(" @src/App.kt#L5 \n```kotlin\n  val x = 1  \n```", result)
     }
 
     @Test
     fun `trimming only affects code content, not path or line range`() {
-        val editor = mockk<Editor>()
-        val selectionModel = mockk<SelectionModel>()
-
-        every { editor.selectionModel } returns selectionModel
-        every { selectionModel.hasSelection() } returns true
-        every { selectionModel.selectedText } returns "  code  "
-
-        val code = CopySelectionUtils.getCodeContent(editor)
-        val trimmedCode = code.trim()
+        val trimmedCode = "  code  ".trim()
 
         // Path and line range should not be affected
-        val result = CopySelectionUtils.formatOutput("src/  App  .kt", "5", trimmedCode, "kotlin")
+        val result = ClaudeCodeFormatter().format(FormatContext("src/  App  .kt", 5, 5, trimmedCode, "kotlin"))
 
         // Path should preserve its whitespace, only code is trimmed
         assertTrue(result.contains("src/  App  .kt"))

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/OutputFormatterTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/OutputFormatterTest.kt
@@ -8,6 +8,32 @@ import kotlin.test.assertTrue
 
 class OutputFormatterTest {
     @Test
+    fun `shared fence builder lengthens only for leading backtick runs`() {
+        assertEquals("```", MarkdownCodeFence.forCode("val ticks = ```"))
+        assertEquals("`````", MarkdownCodeFence.forCode("````\ncontent"))
+    }
+
+    @Test
+    fun `built-in formatter outputs remain byte-for-byte stable`() {
+        val context = FormatContext(
+            path = "src\\App.kt",
+            startLine = 10,
+            endLine = 12,
+            code = "val x = 1",
+            language = "kotlin",
+        )
+
+        assertEquals(
+            " @src/App.kt#L10-12 \n```kotlin\nval x = 1\n```",
+            ClaudeCodeFormatter().format(context),
+        )
+        assertEquals(
+            "src/App.kt:10-12\n```kotlin\nval x = 1\n```",
+            PathLineFormatter().format(context),
+        )
+    }
+
+    @Test
     fun `ClaudeCodeFormatter formats single line`() {
         val formatter = ClaudeCodeFormatter()
         val context = FormatContext(path = "src/App.kt", startLine = 42, endLine = 42)

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/OutputFormatterTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/OutputFormatterTest.kt
@@ -34,6 +34,27 @@ class OutputFormatterTest {
     }
 
     @Test
+    fun `built-in formatters preserve internal backticks byte-for-byte`() {
+        val code = "val inline = \"````\"\n```nested\nbody"
+        val context = FormatContext(
+            path = "src/App.kt",
+            startLine = 4,
+            endLine = 6,
+            code = code,
+            language = "kotlin",
+        )
+
+        assertEquals(
+            " @src/App.kt#L4-6 \n````kotlin\n$code\n````",
+            ClaudeCodeFormatter().format(context),
+        )
+        assertEquals(
+            "src/App.kt:4-6\n````kotlin\n$code\n````",
+            PathLineFormatter().format(context),
+        )
+    }
+
+    @Test
     fun `ClaudeCodeFormatter formats single line`() {
         val formatter = ClaudeCodeFormatter()
         val context = FormatContext(path = "src/App.kt", startLine = 42, endLine = 42)

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/SelectionContextTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/SelectionContextTest.kt
@@ -23,7 +23,6 @@ class SelectionContextTest {
         assertEquals("src/App.kt", context.path)
         assertSame(file, context.file)
         assertEquals(Pair(7, 9), context.lineNumbers)
-        assertEquals("7-9", context.lineRange)
         assertEquals("println(1)", context.code)
         assertEquals("kotlin", context.language)
         assertEquals("App.kt", context.filename)

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/SelectionContextTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/SelectionContextTest.kt
@@ -1,0 +1,56 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.vfs.VirtualFile
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class SelectionContextTest {
+    @Test
+    fun `immutable context carries every captured formatter input`() {
+        val file = mockk<VirtualFile>()
+        val context = SelectionContext(
+            path = "src/App.kt",
+            file = file,
+            startLine = 7,
+            endLine = 9,
+            code = "println(1)",
+            language = "kotlin",
+            filename = "App.kt",
+        )
+
+        assertEquals("src/App.kt", context.path)
+        assertSame(file, context.file)
+        assertEquals(Pair(7, 9), context.lineNumbers)
+        assertEquals("7-9", context.lineRange)
+        assertEquals("println(1)", context.code)
+        assertEquals("kotlin", context.language)
+        assertEquals("App.kt", context.filename)
+    }
+
+    @Test
+    fun `format context is derived only from captured values`() {
+        val context = SelectionContext(
+            path = "src/App.kt",
+            file = mockk(),
+            startLine = 7,
+            endLine = 7,
+            code = "captured()",
+            language = "kotlin",
+            filename = "App.kt",
+        )
+
+        assertEquals(
+            FormatContext(
+                path = "src/App.kt",
+                startLine = 7,
+                endLine = 7,
+                code = "captured()",
+                language = "kotlin",
+                filename = "App.kt",
+            ),
+            context.toFormatContext(context.code),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add an immutable SelectionContext snapshot for path, file, filename, range, code, and language inputs
- capture editor state once per caret and reuse captured values for formatting, analytics, and highlighting
- remove legacy test-only selection and formatting helpers
- share Markdown fence construction across the built-in formatters
- add immutable-context, byte-stability, single-resolution, and post-capture selection-change contracts

## Verification

- PASS: full Gradle test suite (302 tests)
- PASS: compileKotlin
- PASS: buildPlugin
- PASS: verifyPlugin against IntelliJ IDEA Community 2024.3.7.1, 2025.1.7.2, and 2025.2.6.3
- PASS: git diff --check

Closes #70