### PR TITLE
ci: add Kotlin quality gates and Gradle updates

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -7,6 +7,8 @@
 | Kotlin | 2.4.10 |
 | Gradle wrapper | 9.7.1 |
 | IntelliJ Platform Gradle Plugin | 2.18.1 |
+| Detekt | 2.0.0-alpha.6 |
+| Kover | 0.9.8 |
 | IntelliJ IDEA Community test platform | 2024.3 |
 | JVM toolchain and target | 21 |
 | Minimum IDE build | 243 (2024.3) |
@@ -111,6 +113,6 @@ The implementation uses the flat package `com.github.hon454.copyselectioncontext
 
 ## Verification Architecture
 
-Unit tests cover formatters, `{filename}`, exclusive selection ends, multi-caret joins and highlighting, safe previews, five-locale key parity and descriptor presentations, locale-independent persisted format/preset data, worktree-safe Git metadata, history privacy/migration/retention, template editor behavior, and review threshold/version/suppression/environment policy. `CopySelectionActionFixtureTest` exercises real IntelliJ editor, action-event, clipboard, history, highlighter, async permalink, review cardinality, and missing-context flows. `DocumentationSyncTest` derives toolchain values from build sources, checks all localized README structures and feature markers, lists every Kotlin source file, and verifies registered action inheritance. `CiWorkflowTest` keeps test, project/structure verification, three-IDE Plugin Verifier, packaging, and diagnostic artifact gates ordered before publication.
+Unit tests cover formatters, `{filename}`, exclusive selection ends, multi-caret joins and highlighting, safe previews, five-locale key parity and descriptor presentations, locale-independent persisted format/preset data, worktree-safe Git metadata, history privacy/migration/retention, template editor behavior, and review threshold/version/suppression/environment policy. `CopySelectionActionFixtureTest` exercises real IntelliJ editor, action-event, clipboard, history, highlighter, async permalink, review cardinality, and missing-context flows. `DocumentationSyncTest` derives toolchain values from build sources, checks all localized README structures and feature markers, lists every Kotlin source file, and verifies registered action inheritance. `CiWorkflowTest` keeps Detekt, Kover XML/HTML coverage, test, project/structure verification, three-IDE Plugin Verifier, packaging, and diagnostic artifact gates ordered before publication, and structurally validates conservative Gradle Dependabot grouping. Detekt intentionally enables only four reviewed defect rules and uses no baseline; Kover publishes diagnostics without enforcing a coverage percentage.
 
 Gradle separates reusable pure unit execution (`test`) from IntelliJ application and editor-fixture execution (`platformTest`). `CopySelectionActionFixtureTest` and `CopyHistoryPersistenceTest` run through `platformTest` with one class per JVM; `allTests` is the complete local and CI aggregate, and `check` depends on it. `buildPlugin` remains packaging-only because CI and release workflows gate it behind a separate `allTests` invocation. `CiWorkflowTest` keeps standard IntelliJ application/fixture markers synchronized with the explicit task partition so new platform-state tests cannot silently fall into the reusable worker. CI invokes the aggregate with `--continue` and uploads XML and HTML report directories for both test tasks.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,35 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    groups:
+      kotlin-tooling:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.kotlinx*"
+          - "dev.detekt*"
+        update-types:
+          - "minor"
+          - "patch"
+      intellij-tooling:
+        patterns:
+          - "org.jetbrains.intellij.platform*"
+          - "org.jetbrains.changelog*"
+        update-types:
+          - "minor"
+          - "patch"
+      junit:
+        patterns:
+          - "org.junit*"
+          - "junit*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,19 @@ jobs:
       - name: Ensure gradlew is executable
         run: chmod +x ./gradlew
 
-      - name: Run test suite
-        run: ./gradlew allTests --continue --stacktrace --console=plain
+      - name: Run Kotlin static analysis
+        run: ./gradlew detekt --stacktrace --console=plain
+
+      - name: Run test suite and generate Kotlin coverage
+        if: ${{ !cancelled() }}
+        run: >-
+          ./gradlew
+          allTests
+          koverXmlReport
+          koverHtmlReport
+          --continue
+          --stacktrace
+          --console=plain
 
       - name: Verify plugin project and structure
         run: >-
@@ -71,6 +82,8 @@ jobs:
             build/test-results/test/
             build/reports/tests/platformTest/
             build/test-results/platformTest/
+            build/reports/detekt/
+            build/reports/kover/
             build/reports/pluginVerifier/
             build/reports/problems/
           if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,19 @@ jobs:
             "${{ steps.version.outputs.version }}" \
             "${{ steps.version.outputs.tag }}"
 
-      - name: Run test suite
-        run: ./gradlew allTests --continue --stacktrace --console=plain
+      - name: Run Kotlin static analysis
+        run: ./gradlew detekt --stacktrace --console=plain
+
+      - name: Run test suite and generate Kotlin coverage
+        if: ${{ !cancelled() }}
+        run: >-
+          ./gradlew
+          allTests
+          koverXmlReport
+          koverHtmlReport
+          --continue
+          --stacktrace
+          --console=plain
 
       - name: Verify plugin project and structure
         run: >-
@@ -135,6 +146,8 @@ jobs:
             build/test-results/test/
             build/reports/tests/platformTest/
             build/test-results/platformTest/
+            build/reports/detekt/
+            build/reports/kover/
             build/reports/pluginVerifier/
             build/reports/problems/
           if-no-files-found: warn

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ JetBrains IDE plugin for copying code context (file path, line numbers, optional
 | Kotlin | 2.4.10 |
 | Gradle | 9.7.1 |
 | IntelliJ Platform Plugin | 2.18.1 |
+| Detekt | 2.0.0-alpha.6 |
+| Kover | 0.9.8 |
 | JVM Toolchain | 21 |
 | Min IDE Version | 2024.3 |
 
@@ -28,6 +30,7 @@ JetBrains IDE plugin for copying code context (file path, line numbers, optional
 cmd //c "gradlew.bat buildPlugin"    # Build plugin ZIP (build/distributions/)
 cmd //c "gradlew.bat runIde"         # Run IDE with plugin installed
 cmd //c "gradlew.bat verifyPlugin"   # Verify plugin structure
+cmd //c "gradlew.bat detekt koverXmlReport koverHtmlReport" # Static analysis + coverage
 cmd //c "gradlew.bat publishPlugin"  # Publish to Marketplace (requires PUBLISH_TOKEN)
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,8 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "2.4.10"
+    id("dev.detekt") version "2.0.0-alpha.6"
+    id("org.jetbrains.kotlinx.kover") version "0.9.8"
     id("org.jetbrains.intellij.platform") version "2.18.1"
     id("org.jetbrains.changelog") version "2.5.0"
 }
@@ -42,6 +44,12 @@ kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_21)
     }
+}
+
+detekt {
+    config.setFrom(files("config/detekt/detekt.yml"))
+    buildUponDefaultConfig = false
+    ignoreFailures = false
 }
 
 intellijPlatform {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,21 @@
+# Keep this gate intentionally narrow. Add rules only after reviewing the
+# existing codebase; do not replace this policy with Detekt's full defaults.
+config:
+  validation: true
+  warningsAsErrors: true
+
+empty-blocks:
+  EmptyCatchBlock:
+    active: true
+
+exceptions:
+  SwallowedException:
+    active: true
+
+potential-bugs:
+  UnreachableCode:
+    active: true
+
+style:
+  EqualsNullCall:
+    active: true

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
@@ -278,6 +278,99 @@ class CiWorkflowTest {
         )
     }
 
+    @Test
+    fun `Dependabot conservatively groups Gradle updates without auto merge`() {
+        val dependabot = readDependabotConfiguration()
+        assertEquals("2", dependabot.scalarForKey("version"))
+        val updates = dependabot.sequenceForKey("updates")
+        assertEquals(
+            setOf("github-actions", "gradle"),
+            updates.value
+                .filterIsInstance<MappingNode>()
+                .map { it.scalarForKey("package-ecosystem") }
+                .toSet(),
+            "Dependabot must contain only the reviewed update ecosystems",
+        )
+        val gradle =
+            updates.value
+                .filterIsInstance<MappingNode>()
+                .single { it.scalarForKey("package-ecosystem") == "gradle" }
+
+        assertEquals("/", gradle.scalarForKey("directory"))
+        assertEquals("main", gradle.scalarForKey("target-branch"))
+        assertEquals("weekly", gradle.mappingForKey("schedule").scalarForKey("interval"))
+        assertEquals("5", gradle.scalarForKey("open-pull-requests-limit"))
+        assertEquals(
+            listOf("dependencies"),
+            gradle.sequenceForKey("labels").value.map { (it as ScalarNode).value },
+        )
+
+        val groups = gradle.mappingForKey("groups")
+        assertEquals(
+            setOf("kotlin-tooling", "intellij-tooling", "junit"),
+            groups.value.map { (it.keyNode as ScalarNode).value }.toSet(),
+            "Gradle grouping must stay limited to reviewed dependency families",
+        )
+        groups.value.forEach { groupEntry ->
+            val group = groupEntry.valueNode as MappingNode
+            assertTrue(
+                group.sequenceForKey("patterns").value.isNotEmpty(),
+                "Each Gradle group must name a narrow dependency family",
+            )
+            assertEquals(
+                listOf("minor", "patch"),
+                group.sequenceForKey("update-types").value.map { (it as ScalarNode).value },
+                "Grouped updates must exclude majors",
+            )
+        }
+        assertFalse(
+            Files.readString(Path.of(".github", "dependabot.yml")).contains("automerge", ignoreCase = true),
+            "Gradle updates must never be configured for automatic merging",
+        )
+        val githubAutomation =
+            Files.walk(Path.of(".github")).use { paths ->
+                paths
+                    .filter(Files::isRegularFile)
+                    .filter { it.fileName.toString().endsWith(".yml") || it.fileName.toString().endsWith(".yaml") }
+                    .map(Files::readString)
+                    .toList()
+                    .joinToString("\n")
+                    .lowercase()
+            }
+        assertFalse(
+            listOf("automerge", "auto-merge", "enablepullrequestautomerge", "gh pr merge --auto")
+                .any(githubAutomation::contains),
+            "GitHub automation must not auto-merge dependency pull requests",
+        )
+    }
+
+    @Test
+    fun `Detekt gate is baseline free and limited to reviewed defect rules`() {
+        val buildScript = Files.readString(Path.of("build.gradle.kts"))
+        val detekt = readYamlMapping(Path.of("config", "detekt", "detekt.yml"))
+        val configuredRules =
+            detekt.value
+                .filter { (it.keyNode as ScalarNode).value != "config" }
+                .flatMap { ruleSetEntry ->
+                    val ruleSet = (ruleSetEntry.keyNode as ScalarNode).value
+                    val rules = ruleSetEntry.valueNode as MappingNode
+                    rules.value.map { ruleEntry -> "$ruleSet.${(ruleEntry.keyNode as ScalarNode).value}" }
+                }.toSet()
+
+        assertEquals(
+            setOf(
+                "empty-blocks.EmptyCatchBlock",
+                "exceptions.SwallowedException",
+                "potential-bugs.UnreachableCode",
+                "style.EqualsNullCall",
+            ),
+            configuredRules,
+        )
+        assertTrue(buildScript.contains("buildUponDefaultConfig = false"))
+        assertTrue(buildScript.contains("ignoreFailures = false"))
+        assertFalse(buildScript.contains("baseline"), "Detekt must not hide findings behind a baseline")
+    }
+
     private fun assertValidationPipeline(
         workflowName: String,
         publicationStep: String,
@@ -287,7 +380,8 @@ class CiWorkflowTest {
 
         assertInOrder(
             workflow,
-            "name: Run test suite",
+            "name: Run Kotlin static analysis",
+            "name: Run test suite and generate Kotlin coverage",
             "name: Verify plugin project and structure",
             "name: Verify plugin compatibility",
             "name: Build plugin",
@@ -295,8 +389,22 @@ class CiWorkflowTest {
             "name: $publicationStep",
         )
         assertTrue(
-            workflow.contains("run: ./gradlew allTests --continue --stacktrace --console=plain"),
-            "$workflowName must run both test tasks even when one fails",
+            workflow.contains("run: ./gradlew detekt --stacktrace --console=plain"),
+            "$workflowName must fail on Detekt findings",
+        )
+        assertTrue(
+            workflow.contains("name: Run test suite and generate Kotlin coverage\n        if: ${'$'}{{ !cancelled() }}"),
+            "$workflowName must still produce coverage diagnostics after a static-analysis failure",
+        )
+        assertTrue(
+            workflow.contains(
+                "allTests\n          koverXmlReport\n          koverHtmlReport\n          --continue",
+            ),
+            "$workflowName must run both test tasks and generate Kotlin XML and HTML coverage",
+        )
+        assertFalse(
+            workflow.contains("koverVerify"),
+            "$workflowName must report coverage without enforcing a vanity percentage",
         )
         assertTrue(
             workflow.contains("verifyPluginProjectConfiguration") &&
@@ -315,8 +423,10 @@ class CiWorkflowTest {
                     "build/test-results/test/",
                     "build/reports/tests/platformTest/",
                     "build/test-results/platformTest/",
+                    "build/reports/detekt/",
+                    "build/reports/kover/",
                 ).all(workflow::contains),
-            "$workflowName must upload plugin verification and every test task report",
+            "$workflowName must upload static analysis, coverage, plugin verification, and test diagnostics",
         )
         assertTrue(
             buildScript.contains("intellijPlatformTesting.testIde.register(\"platformTest\")") &&
@@ -410,6 +520,20 @@ class CiWorkflowTest {
         return Files.readString(path)
     }
 
+    private fun readDependabotConfiguration(): MappingNode =
+        readYamlMapping(Path.of(".github", "dependabot.yml"))
+
+    private fun readYamlMapping(path: Path): MappingNode {
+        assertTrue(Files.isRegularFile(path), "YAML configuration is required: $path")
+        val settings =
+            LoadSettings
+                .builder()
+                .setLabel(path.toString())
+                .setAllowDuplicateKeys(false)
+                .build()
+        return Compose(settings).composeString(Files.readString(path)).orElseThrow() as MappingNode
+    }
+
     private fun assertWorkflowActionReferencesAreImmutable(
         workflow: String,
         source: String,
@@ -485,6 +609,18 @@ class CiWorkflowTest {
         }
 
     private fun MappingNode.valueForKey(key: String): Node? = entriesForKey(key).singleOrNull()?.value
+
+    private fun MappingNode.scalarForKey(key: String): String =
+        (valueForKey(key) as? ScalarNode)?.value
+            ?: throw AssertionError("Missing scalar Dependabot key: $key")
+
+    private fun MappingNode.mappingForKey(key: String): MappingNode =
+        valueForKey(key) as? MappingNode
+            ?: throw AssertionError("Missing mapping Dependabot key: $key")
+
+    private fun MappingNode.sequenceForKey(key: String): SequenceNode =
+        valueForKey(key) as? SequenceNode
+            ?: throw AssertionError("Missing sequence Dependabot key: $key")
 
     private fun workflowWithStep(step: String): String =
         """

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
@@ -244,37 +244,38 @@ class CiWorkflowTest {
     fun `workflows declare only required token permissions`() {
         assertEquals(
             listOf("contents: read"),
-            workflowPermissions(readWorkflow("build.yml")),
+            workflowPermissions("build.yml"),
             "build.yml must keep the default GITHUB_TOKEN read-only",
         )
         assertEquals(
             listOf("contents: write", "id-token: write", "attestations: write"),
-            workflowPermissions(readWorkflow("release.yml")),
+            workflowPermissions("release.yml"),
             "release.yml needs release publication and artifact attestation permissions only",
         )
     }
 
     @Test
     fun `Dependabot safely updates action pins through pull request validation`() {
-        val dependabotPath = Path.of(".github", "dependabot.yml")
-        assertTrue(Files.isRegularFile(dependabotPath), "Dependabot configuration is required")
-        val dependabot = Files.readString(dependabotPath)
-        val buildWorkflow = readWorkflow("build.yml")
+        val dependabot = readDependabotConfiguration()
+        val githubActions =
+            dependabot.sequenceForKey("updates").value
+                .filterIsInstance<MappingNode>()
+                .single { it.scalarForKey("package-ecosystem") == "github-actions" }
+        val pullRequest =
+            readWorkflowMapping("build.yml")
+                .mappingForKey("on")
+                .mappingForKey("pull_request")
 
-        assertTrue(
-            dependabot.contains("package-ecosystem: \"github-actions\"") &&
-                dependabot.contains("directory: \"/\"") &&
-                dependabot.contains("interval: \"weekly\""),
-            "Dependabot must check GitHub Actions pins at the repository root on a weekly schedule",
+        assertEquals("/", githubActions.scalarForKey("directory"))
+        assertEquals("weekly", githubActions.mappingForKey("schedule").scalarForKey("interval"))
+        assertEquals(
+            listOf("main"),
+            pullRequest.sequenceForKey("branches").value.map { (it as ScalarNode).value },
+            "Every pull request targeting main, including Dependabot updates, must run the build workflow",
         )
         assertFalse(
-            dependabot.contains("automerge", ignoreCase = true),
+            Files.readString(Path.of(".github", "dependabot.yml")).contains("automerge", ignoreCase = true),
             "GitHub Actions updates must not be configured for automatic merging",
-        )
-        assertTrue(
-            Regex("""(?ms)^on:\s.*?^\s{2}pull_request:\s*\n\s{4}branches:\s*\[\s*main\s*]""")
-                .containsMatchIn(buildWorkflow),
-            "Dependabot pull requests targeting main must run the complete build workflow",
         )
     }
 
@@ -306,16 +307,24 @@ class CiWorkflowTest {
         )
 
         val groups = gradle.mappingForKey("groups")
+        val expectedPatterns =
+            mapOf(
+                "kotlin-tooling" to listOf("org.jetbrains.kotlin*", "org.jetbrains.kotlinx*", "dev.detekt*"),
+                "intellij-tooling" to listOf("org.jetbrains.intellij.platform*", "org.jetbrains.changelog*"),
+                "junit" to listOf("org.junit*", "junit*"),
+            )
         assertEquals(
-            setOf("kotlin-tooling", "intellij-tooling", "junit"),
+            expectedPatterns.keys,
             groups.value.map { (it.keyNode as ScalarNode).value }.toSet(),
             "Gradle grouping must stay limited to reviewed dependency families",
         )
         groups.value.forEach { groupEntry ->
+            val groupName = (groupEntry.keyNode as ScalarNode).value
             val group = groupEntry.valueNode as MappingNode
-            assertTrue(
-                group.sequenceForKey("patterns").value.isNotEmpty(),
-                "Each Gradle group must name a narrow dependency family",
+            assertEquals(
+                expectedPatterns.getValue(groupName),
+                group.sequenceForKey("patterns").value.map { (it as ScalarNode).value },
+                "$groupName must remain limited to its reviewed dependency family",
             )
             assertEquals(
                 listOf("minor", "patch"),
@@ -348,14 +357,18 @@ class CiWorkflowTest {
     fun `Detekt gate is baseline free and limited to reviewed defect rules`() {
         val buildScript = Files.readString(Path.of("build.gradle.kts"))
         val detekt = readYamlMapping(Path.of("config", "detekt", "detekt.yml"))
+        val detektConfig = detekt.mappingForKey("config")
         val configuredRules =
             detekt.value
                 .filter { (it.keyNode as ScalarNode).value != "config" }
                 .flatMap { ruleSetEntry ->
                     val ruleSet = (ruleSetEntry.keyNode as ScalarNode).value
                     val rules = ruleSetEntry.valueNode as MappingNode
-                    rules.value.map { ruleEntry -> "$ruleSet.${(ruleEntry.keyNode as ScalarNode).value}" }
-                }.toSet()
+                    rules.value.map { ruleEntry ->
+                        "$ruleSet.${(ruleEntry.keyNode as ScalarNode).value}" to
+                            (ruleEntry.valueNode as MappingNode)
+                    }
+                }.toMap()
 
         assertEquals(
             setOf(
@@ -364,22 +377,43 @@ class CiWorkflowTest {
                 "potential-bugs.UnreachableCode",
                 "style.EqualsNullCall",
             ),
-            configuredRules,
+            configuredRules.keys,
         )
+        assertTrue(configuredRules.values.all { it.scalarForKey("active") == "true" })
+        assertEquals("true", detektConfig.scalarForKey("validation"))
+        assertEquals("true", detektConfig.scalarForKey("warningsAsErrors"))
         assertTrue(buildScript.contains("buildUponDefaultConfig = false"))
         assertTrue(buildScript.contains("ignoreFailures = false"))
         assertFalse(buildScript.contains("baseline"), "Detekt must not hide findings behind a baseline")
+        val baselineFiles =
+            Files.walk(Path.of(".")).use { paths ->
+                paths
+                    .filter(Files::isRegularFile)
+                    .filter { path ->
+                        val normalizedPath = path.normalize().toString().replace('\\', '/')
+                        !normalizedPath.startsWith(".git/") &&
+                            !normalizedPath.startsWith(".gradle/") &&
+                            !normalizedPath.startsWith("build/") &&
+                            path.fileName.toString().contains("baseline", ignoreCase = true)
+                    }.toList()
+            }
+        assertTrue(baselineFiles.isEmpty(), "Detekt baseline files are forbidden: $baselineFiles")
     }
 
     private fun assertValidationPipeline(
         workflowName: String,
         publicationStep: String,
     ) {
-        val workflow = readWorkflow(workflowName)
+        val steps = workflowSteps(workflowName)
+        val detektStep = steps.stepNamed("Run Kotlin static analysis")
+        val coverageStep = steps.stepNamed("Run test suite and generate Kotlin coverage")
+        val reportStep = steps.stepNamed("Upload validation reports")
+        val coverageCommand = coverageStep.scalarForKey("run")
+        val reportPaths = reportStep.mappingForKey("with").scalarForKey("path")
         val buildScript = Files.readString(Path.of("build.gradle.kts"))
 
-        assertInOrder(
-            workflow,
+        assertStepsInOrder(
+            steps,
             "name: Run Kotlin static analysis",
             "name: Run test suite and generate Kotlin coverage",
             "name: Verify plugin project and structure",
@@ -388,44 +422,51 @@ class CiWorkflowTest {
             "name: Upload validation reports",
             "name: $publicationStep",
         )
-        assertTrue(
-            workflow.contains("run: ./gradlew detekt --stacktrace --console=plain"),
+        assertEquals(
+            "./gradlew detekt --stacktrace --console=plain",
+            detektStep.scalarForKey("run"),
             "$workflowName must fail on Detekt findings",
         )
-        assertTrue(
-            workflow.contains("name: Run test suite and generate Kotlin coverage\n        if: ${'$'}{{ !cancelled() }}"),
-            "$workflowName must still produce coverage diagnostics after a static-analysis failure",
+        assertEquals(
+            "${'$'}{{ !cancelled() }}",
+            coverageStep.scalarForKey("if"),
+            "$workflowName must still run tests after a static-analysis failure",
         )
         assertTrue(
-            workflow.contains(
-                "allTests\n          koverXmlReport\n          koverHtmlReport\n          --continue",
-            ),
+            listOf("allTests", "koverXmlReport", "koverHtmlReport", "--continue").all { task ->
+                Regex("""(?:^|\s)$task(?:\s|${'$'})""").containsMatchIn(coverageCommand)
+            },
             "$workflowName must run both test tasks and generate Kotlin XML and HTML coverage",
         )
         assertFalse(
-            workflow.contains("koverVerify"),
+            coverageCommand.contains("koverVerify") ||
+                buildScript.contains("minBound(") ||
+                buildScript.contains("maxBound("),
             "$workflowName must report coverage without enforcing a vanity percentage",
         )
+        val verificationStep = steps.stepNamed("Verify plugin project and structure").scalarForKey("run")
         assertTrue(
-            workflow.contains("verifyPluginProjectConfiguration") &&
-                workflow.contains("verifyPluginStructure") &&
-                workflow.contains("run: ./gradlew verifyPlugin --stacktrace --console=plain"),
+            verificationStep.contains("verifyPluginProjectConfiguration") &&
+                verificationStep.contains("verifyPluginStructure") &&
+                steps.stepNamed("Verify plugin compatibility").scalarForKey("run") ==
+                "./gradlew verifyPlugin --stacktrace --console=plain",
             "$workflowName must run project, structure, and compatibility verification",
         )
-        assertTrue(
-            workflow.contains("name: Upload validation reports\n        if: always()"),
+        assertEquals(
+            "always()",
+            reportStep.scalarForKey("if"),
             "$workflowName must preserve validation reports when a gate fails",
         )
         assertTrue(
-            workflow.contains("build/reports/pluginVerifier/") &&
-                listOf(
-                    "build/reports/tests/test/",
-                    "build/test-results/test/",
-                    "build/reports/tests/platformTest/",
-                    "build/test-results/platformTest/",
-                    "build/reports/detekt/",
-                    "build/reports/kover/",
-                ).all(workflow::contains),
+            listOf(
+                "build/reports/pluginVerifier/",
+                "build/reports/tests/test/",
+                "build/test-results/test/",
+                "build/reports/tests/platformTest/",
+                "build/test-results/platformTest/",
+                "build/reports/detekt/",
+                "build/reports/kover/",
+            ).all(reportPaths::contains),
             "$workflowName must upload static analysis, coverage, plugin verification, and test diagnostics",
         )
         assertTrue(
@@ -439,7 +480,7 @@ class CiWorkflowTest {
         )
         assertPlatformStateTestsAreExplicitlyPartitioned(buildScript)
         assertTrue(
-            workflow.contains("uses: gradle/actions/setup-gradle@"),
+            steps.stepNamed("Setup Gradle").scalarForKey("uses").startsWith("gradle/actions/setup-gradle@"),
             "$workflowName must cache Gradle dependencies used by plugin verification",
         )
     }
@@ -518,6 +559,19 @@ class CiWorkflowTest {
         val path = Path.of(".github", "workflows", workflowName)
         assertTrue(Files.isRegularFile(path), "Workflow not found: $path")
         return Files.readString(path)
+    }
+
+    private fun readWorkflowMapping(workflowName: String): MappingNode =
+        readYamlMapping(Path.of(".github", "workflows", workflowName))
+
+    private fun workflowSteps(workflowName: String): List<MappingNode> {
+        val jobs = readWorkflowMapping(workflowName).mappingForKey("jobs")
+        assertEquals(1, jobs.value.size, "$workflowName must keep one ordered validation job")
+        val job = jobs.value.single().valueNode as? MappingNode
+            ?: throw AssertionError("$workflowName must define its validation job as a mapping")
+        return job.sequenceForKey("steps").value.map { step ->
+            step as? MappingNode ?: throw AssertionError("$workflowName contains a non-mapping step")
+        }
     }
 
     private fun readDependabotConfiguration(): MappingNode =
@@ -638,17 +692,31 @@ class CiWorkflowTest {
         val value: Node,
     )
 
-    private fun workflowPermissions(workflow: String): List<String> {
-        val lines = workflow.lines()
-        val permissionsIndex = lines.indexOfFirst { it == "permissions:" }
-        assertTrue(permissionsIndex >= 0, "Workflow must declare permissions explicitly")
+    private fun workflowPermissions(workflowName: String): List<String> =
+        readWorkflowMapping(workflowName)
+            .mappingForKey("permissions")
+            .value
+            .map { permission ->
+                "${(permission.keyNode as ScalarNode).value}: ${(permission.valueNode as ScalarNode).value}"
+            }
 
-        val permissionLines =
-            lines
-                .drop(permissionsIndex + 1)
-                .takeWhile { it.startsWith("  ") && it.isNotBlank() }
-                .map { it.trim() }
-        return permissionLines
+    private fun List<MappingNode>.stepNamed(name: String): MappingNode =
+        singleOrNull { step -> (step.valueForKey("name") as? ScalarNode)?.value == name }
+            ?: throw AssertionError("Missing or duplicate workflow step: $name")
+
+    private fun assertStepsInOrder(
+        steps: List<MappingNode>,
+        vararg markers: String,
+    ) {
+        val names = steps.map { step -> (step.valueForKey("name") as? ScalarNode)?.value }
+        var previousIndex = -1
+        markers.forEach { marker ->
+            val name = marker.removePrefix("name: ")
+            val markerIndex = names.indexOf(name)
+            assertTrue(markerIndex >= 0, "Missing workflow step: $name")
+            assertTrue(markerIndex > previousIndex, "Workflow step is out of order: $name")
+            previousIndex = markerIndex
+        }
     }
 
     private fun assertInOrder(

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionGutterIconRendererTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionGutterIconRendererTest.kt
@@ -39,6 +39,7 @@ class CopySelectionGutterIconRendererTest {
     }
 
     @Test
+    @Suppress("EqualsNullCall") // Exercise the equals(null) contract directly.
     fun `renderer is not equal to null`() {
         val renderer = CopySelectionGutterIconRenderer()
         assertFalse(renderer.equals(null))


### PR DESCRIPTION
## Summary

- add Detekt 2.0.0-alpha.6 with four reviewed defect rules and no baseline
- add Kover 0.9.8 XML/HTML diagnostics without a coverage threshold
- run static analysis and the complete `allTests` aggregate before plugin verification and packaging
- preserve separate `test` and `platformTest` reports and combine both Kover execution-data files
- upload Detekt, Kover, unit, platform, Plugin Verifier, and Gradle problem reports even when a gate fails
- schedule weekly Gradle Dependabot updates with minor/patch grouping limited to Kotlin, IntelliJ, and JUnit families and no auto-merge automation
- structurally validate workflow triggers, steps, conditions, report paths, permissions, immutable action pins, Detekt policy, and Dependabot configuration in `CiWorkflowTest`

## Independent review fixes

- replace string-position checks for the quality pipeline with YAML AST checks against the actual job steps and `if` expressions
- verify every reviewed Detekt rule remains present and active, configuration validation stays enabled, and no baseline file is introduced
- verify Kover report tasks remain diagnostics-only with no configured percentage bounds
- pin the exact reviewed Dependabot group patterns instead of accepting any non-empty pattern list
- preserve PR #77's explicit unit/platform test partition checks and per-task report paths during rebase

## Validation

- latest head: `da906eaa8773ba22124180eeb78c288b7dbe5023`
- latest base: `850f3c9eb669564417ee58b97727f7ed14b35f19`
- GitHub Actions `build` run 33653679017 — passed in 7m 25s
  - uploaded `validation-reports` and `plugin-artifact`
- `./gradlew test platformTest allTests check detekt koverXmlReport koverHtmlReport verifyPluginProjectConfiguration verifyPluginStructure verifyPlugin buildPlugin --continue --stacktrace --console=plain` — passed
  - unit: 31 suites / 302 tests / 0 failures
  - platform: 2 suites / 15 tests / 0 failures
  - Kover generated both `build/kover/bin-reports/test.ic` and `platformTest.ic`, then one XML and HTML report
  - Detekt: 0 findings
  - Plugin Verifier: IC 2024.3.7.1, 2025.1.7.2, and 2025.2.6.3 compatible
  - plugin ZIP generated at `build/distributions/copy-selection-context-1.2.1.zip`
- targeted `CiWorkflowTest` plus Detekt — passed after the final conflict resolution
- intentional named empty/swallowed catch probe — Detekt failed with `EmptyCatchBlock` and `SwallowedException`; probe removed and clean gate rerun successfully
- intentional `Upload validation reports` condition mutation from `always()` to `failure()` — `CiWorkflowTest` failed; mutation reverted and clean test rerun successfully
- `git diff --check` and conflict preflight — passed

## Security, dependency, and residual risk

- Detekt 2.0.0-alpha.6 is the release compiled against Kotlin 2.4.10; its pre-release status remains the main maintenance risk
- the rule set is intentionally narrow to limit noise, with one test-scoped `EqualsNullCall` suppression for a direct `equals(null)` contract assertion
- no Detekt baseline or Kover percentage threshold is present
- all external actions remain pinned to full commit SHAs; their documented version tags were checked against the pinned commits
- build permissions remain `contents: read`; release keeps only `contents: write`, `id-token: write`, and `attestations: write`
- Dependabot targets the root Gradle ecosystem weekly; grouped updates exclude majors, all pull requests targeting `main` run the complete build workflow, and no auto-merge automation exists

Closes #69
