### PR TITLE
chore(release): prepare v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-09-03
+
+### Added
+- Add complete Japanese, Simplified Chinese, and Traditional Chinese IDE UI bundles with locale-parity validation (#66)
+
 ### Changed
 - Make copy history safer with Unicode-aware previews, localized timestamps, confirmed clearing, and consecutive-duplicate refreshes (#67)
+- Split reusable unit tests from isolated IntelliJ Platform tests while preserving one complete `allTests` verification task (#68)
+- Enforce Detekt analysis and generate Kover coverage reports in CI and release builds, with grouped Gradle Dependabot updates (#69)
+- Consolidate per-caret selection capture into an immutable context and remove legacy helpers without changing formatted output (#70)
 
 ## [1.2.1] - 2026-09-02
 
@@ -136,7 +144,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toast notifications
 - IntelliJ Platform 2024.3+ compatibility
 
-[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/hon454/copy-selection-context/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/hon454/copy-selection-context/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/hon454/copy-selection-context/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/hon454/copy-selection-context/compare/v1.1.0...v1.1.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.github.hon454"
-version = "1.2.1"
+version = "1.3.0"
 
 repositories {
     mavenCentral()

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -13,8 +13,8 @@ class ReleaseVersionParityTest {
     private val verifier = projectRoot.resolve("scripts/verify-release-version.sh")
 
     @Test
-    fun `canonical project version is 1_2_1`() {
-        assertEquals("1.2.1", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
+    fun `canonical project version is 1_3_0`() {
+        assertEquals("1.3.0", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
     }
 
     @Test
@@ -22,7 +22,7 @@ class ReleaseVersionParityTest {
         val result = runVerifier("v${canonicalVersion(projectRoot.resolve("build.gradle.kts"))}")
 
         assertEquals(0, result.exitCode, result.output)
-        assertTrue(result.output.contains("Version verified: v1.2.1"), result.output)
+        assertTrue(result.output.contains("Version verified: v1.3.0"), result.output)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- bump the canonical plugin version from 1.2.1 to 1.3.0
- promote the completed v1.3.0 milestone scope (#66–#70) into a dated `CHANGELOG.md` release section
- refresh the `[Unreleased]` and `[1.3.0]` comparison links
- align the release-version parity test with the new canonical version

## Milestone readiness

The v1.3.0 milestone has 0 open and 5 closed issues. Each issue was closed by a PR merged into `main`:

- #66 → #78
- #67 → #76
- #68 → #77
- #69 → #80
- #70 → #79

## Validation

- `bash scripts/verify-release-version.sh v1.3.0` — passed
- `bash scripts/generate-release-notes.sh 1.3.0 v1.3.0 /private/tmp/copy-selection-context-v1.3.0-release-notes.md` — passed; output contains only the v1.3.0 `Added`/`Changed` entries for #66–#70
- `./gradlew detekt --stacktrace --console=plain` — passed with 0 findings
- `./gradlew allTests koverXmlReport koverHtmlReport --continue --stacktrace --console=plain` — passed; 302 unit tests and 15 platform tests, 0 failures/errors; XML and HTML Kover reports generated
- `./gradlew check --stacktrace --console=plain` — passed
- `./gradlew verifyPluginProjectConfiguration verifyPluginStructure --stacktrace --console=plain` — passed
- `./gradlew verifyPlugin --stacktrace --console=plain` — passed; compatible with IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97
- `./gradlew buildPlugin --stacktrace --console=plain` — passed; produced `copy-selection-context-1.3.0.zip`
- `git diff --check` — passed

Local unsigned ZIP SHA-256: `44a1184f4cdf2075e3e9b289d25fd1f43a446b501086d032d59f89b48fb2fb49`

## Before publishing

- [ ] Merge this PR into `main` after required review and CI checks pass
- [ ] Confirm `PUBLISH_TOKEN`, `CERTIFICATE_CHAIN`, `PRIVATE_KEY`, and `PRIVATE_KEY_PASSWORD` are correctly configured for the release workflow
- [ ] Create annotated tag `v1.3.0` on the merged release-preparation commit and confirm it matches `version = "1.3.0"`
- [ ] Push only the `v1.3.0` tag to trigger `.github/workflows/release.yml`
- [ ] Confirm the workflow signs and verifies the canonical ZIP, generates `SHA256SUMS`, and verifies GitHub provenance for that exact artifact
- [ ] Confirm the GitHub Release notes contain only the v1.3.0 changelog section and the release assets include the canonical ZIP plus `SHA256SUMS`
- [ ] Confirm the same canonical signed ZIP is published to JetBrains Marketplace

## Not performed in this PR

- no tag was created or pushed
- no GitHub Release or Marketplace publication was triggered
- this PR was not merged
