### PR TITLE
fix: remove flagged IntelliJ APIs for v1.3.1

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -27,8 +27,8 @@
 6. When analytics are enabled, `CopySelectionAnalytics` increments total, selected-format, and detected-language counters exactly once per standard copy action, including multi-caret copies.
 7. `CopySelectionHighlighter` replaces the previous gutter markers for the active editor ranges, and the project-level `CopyHistoryService` prepends the result using the configured entry-count limit plus UTF-8 content budgets of 256 KiB per entry and 2 MiB per project. A consecutive duplicate refreshes the newest entry's timestamp instead of adding another row. Oversized results remain on the clipboard but are not persisted.
 8. `CopySelectionNotifier` shows a bounded, single-line, markup-escaped preview when notifications are enabled.
-9. `CopySelectionStatusBarWidget` stores the full result, displays a safe preview capped at 40 characters including its prefix, and copies the full value again when clicked.
-10. `CopySelectionReviewService` counts an eligible successful standard copy action once, regardless of caret count or analytics preference. Notifications must be enabled and the context must have a supported plugin version and be non-test and non-headless before the session counter can change. On exactly the tenth eligible copy in the IDE session, one localized review balloon may appear.
+9. `CopySelectionStatusBarWidget` uses the public custom-widget API, stores the full result, displays a safe preview capped at 40 characters including its prefix, and copies the full value again when clicked.
+10. `CopySelectionReviewService` counts an eligible successful standard copy action once, regardless of caret count or analytics preference. It reads the canonical plugin version from a build-expanded resource without relying on internal plugin-manager APIs. Notifications must be enabled and the context must have a supported plugin version and be non-test and non-headless before the session counter can change. On exactly the tenth eligible copy in the IDE session, one localized review balloon may appear.
 
 `ShowCopyHistoryAction` opens the current project's history popup. Each row combines a bounded, single-line `CopyPreview` with a localized timestamp while retaining the full stored content for re-copy. Choosing the clear-all item requires explicit confirmation before deleting history.
 
@@ -76,6 +76,7 @@ The implementation uses the flat package `com.github.hon454.copyselectioncontext
 
 | File | Responsibility |
 |------|----------------|
+| `CustomStatusBarWidgetAdapter.java` | Public custom-widget bridge that avoids Kotlin-generated deprecated status API methods |
 | `CopyAbsolutePathAction.kt` | Context-menu action with an absolute path |
 | `CopyGitPermalinkAction.kt` | Asynchronous, latest-request-wins Git permalink action |
 | `CopyHistoryPopup.kt` | History chooser, re-copy, and clear-all behavior |
@@ -84,16 +85,16 @@ The implementation uses the flat package `com.github.hon454.copyselectioncontext
 | `CopyRelativePathAction.kt` | Context-menu action with a project-relative path |
 | `CopySelectionAnalytics.kt` | Thread-safe opt-in application-local counters and immutable snapshots |
 | `CopySelectionBaseAction.kt` | Shared standard-copy lifecycle and post-copy integrations |
-| `CopySelectionBundle.kt` | Localized message lookup |
+| `CopySelectionBundle.kt` | Localized message lookup through the public class-aware `DynamicBundle` constructor |
 | `CopySelectionConfigurable.kt` | Tools settings UI, multiline template editor, preview, validation, and local analytics controls |
 | `CopySelectionContextAction.kt` | Settings-driven primary action |
 | `CopySelectionGutterIconRenderer.kt` | Gutter icon and safe tooltip preview |
 | `CopySelectionHighlighter.kt` | Editor-scoped multi-range gutter marker lifecycle |
 | `CopySelectionNotifier.kt` | Settings-aware success and localized permalink-failure balloons |
 | `CopySelectionReviewNotifier.kt` | Localized honest-review balloon and Review on Marketplace / Later / Don't ask again actions |
-| `CopySelectionReviewService.kt` | Session-only threshold, version and environment policy, non-roaming suppression state, and Marketplace opening |
+| `CopySelectionReviewService.kt` | Session-only threshold, build-resource version and environment policy, non-roaming suppression state, and Marketplace opening |
 | `CopySelectionSettings.kt` | Persistent application settings and path enum |
-| `CopySelectionStatusBarWidget.kt` | Safe last-copy preview and click-to-copy interaction |
+| `CopySelectionStatusBarWidget.kt` | Public custom status widget with safe last-copy preview and click-to-copy interaction |
 | `CopySelectionStatusBarWidgetFactory.kt` | Status-bar widget registration lifecycle |
 | `CopySelectionUtils.kt` | VFS paths, language detection, exclusive-end ranges, and single-pass caret context capture |
 | `CopySelectionWebHelpProvider.kt` | README help-topic URLs |

--- a/.agents/gotchas.md
+++ b/.agents/gotchas.md
@@ -18,15 +18,16 @@
 | 7 | **CommonDataKeys null** | Always null-check `e.getData()` results. Can return null outside editor context. |
 | 8 | **Relative paths** | Use `virtualFile.path` + `project.basePath`. Handle null `basePath` (default project). |
 | 9 | **Line numbers** | 0-indexed internally, display as 1-indexed. Always add 1 when formatting. |
-| 10 | **StatusBarWidget** | `TextPresentation.getAlignment()` must return Float. Missing it causes compilation errors. |
+| 10 | **StatusBarWidget** | Use the public `CustomStatusBarWidget` API through the Java adapter and create its Swing component lazily; direct Kotlin implementation generates deprecated default-method bridges, `EditorBasedWidget` is implementation-only, and `com.intellij.util.Consumer` is obsolete. |
 | 11 | **Shortcut syntax** | Use `"control"` not `"ctrl"` in plugin.xml keyboard-shortcut elements. |
+| 12 | **Plugin metadata** | Read this plugin's build-expanded version resource instead of `PluginManagerCore`; plugin descriptor lookup is internal in 2026.3+. Use the class-aware `DynamicBundle(Class, String)` constructor rather than subclassing it. |
 
 ## Build & Deployment
 
 | # | Issue | Detail |
 |---|-------|--------|
-| 12 | **Gradle memory** | IntelliJ Platform plugin is memory-intensive. May need `org.gradle.jvmargs=-Xmx2048m`. |
-| 13 | **Verify first** | Always `./gradlew verifyPlugin` before publishing. Catches compatibility issues. |
-| 14 | **Marketplace token** | `PUBLISH_TOKEN` env var or `~/.gradle/gradle.properties`. |
-| 15 | **Windows builds** | Use PowerShell wrapper: `powershell.exe -Command ".\gradlew.bat buildPlugin"` or run via Java directly. |
-| 16 | **Java 21** | `JAVA_HOME` must point to JDK 21 installation. Build fails with other versions. |
+| 13 | **Gradle memory** | IntelliJ Platform plugin is memory-intensive. May need `org.gradle.jvmargs=-Xmx2048m`. |
+| 14 | **Verify first** | Always `./gradlew verifyPlugin` before publishing. Catches compatibility issues. |
+| 15 | **Marketplace token** | `PUBLISH_TOKEN` env var or `~/.gradle/gradle.properties`. |
+| 16 | **Windows builds** | Use PowerShell wrapper: `powershell.exe -Command ".\gradlew.bat buildPlugin"` or run via Java directly. |
+| 17 | **Java 21** | `JAVA_HOME` must point to JDK 21 installation. Build fails with other versions. |

--- a/.agents/patterns.md
+++ b/.agents/patterns.md
@@ -62,6 +62,8 @@ class CopySelectionSettings : PersistentStateComponent<CopySelectionSettings.Sta
 
 Review-prompt decisions use a separate application service with `RoamingType.DISABLED`. Gate notification-disabled, unit-test, headless, unsupported-version, and already-suppressed contexts before changing the session counter or persisted state. Keep the eligible-copy counter outside persisted `State`; store only the last prompted plugin version and permanent suppression signals. Mark the version before notifying so closing the balloon or choosing `Later` cannot repeat the prompt in that version.
 
+Read the current plugin version from `META-INF/copy-selection-context-version.properties`, which `processResources` expands from the canonical Gradle project version. Do not use `PluginManagerCore` for plugin metadata; its lookup methods are internal in newer IDE builds.
+
 ## Selection Range and Current-Line Fallback
 
 ```kotlin
@@ -93,8 +95,7 @@ There are 39 explicit mappings, including Kotlin, Java, C#, JavaScript/TypeScrip
 ## Status Bar Widget
 
 ```kotlin
-class CopySelectionStatusBarWidget(project: Project) :
-    EditorBasedWidget(project), TextPresentation
+class CopySelectionStatusBarWidget : CustomStatusBarWidgetAdapter()
 ```
 
-The widget stores the full last-copied content in an `AtomicReference`, shows a bounded single-line preview with a total 40-character budget including its prefix, and copies the full value again when clicked. `CopyPreview` preserves Unicode code points, escapes notification/tooltip markup, and never cuts an escape entity. `CopySelectionStatusBarWidgetFactory` registers the widget through `statusBarWidgetFactory` in `plugin.xml`; standard path/code actions call `update()` after copying.
+The Java `CustomStatusBarWidgetAdapter` implements the public `CustomStatusBarWidget` API without Kotlin generating compatibility bridges for deprecated `StatusBarWidget` default methods. The Kotlin widget extends that adapter instead of implementation-only editor widget classes or the obsolete IntelliJ `Consumer` callback. Its Swing label is created lazily, stores the full last-copied content in an `AtomicReference`, shows a bounded single-line preview with a total 40-character budget including its prefix, and copies the full value again when clicked. `CopyPreview` preserves Unicode code points, escapes notification/tooltip markup, and never cuts an escape entity. `CopySelectionStatusBarWidgetFactory` registers the widget through `statusBarWidgetFactory` in `plugin.xml`; standard path/code actions call `update()` after copying.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-09-03
+
+### Fixed
+- Remove deprecated and internal IntelliJ API usages from status widgets, localization, and runtime version lookup so Marketplace verification stays clean on 2026.2 and 2026.3 IDE builds (#84)
+
 ## [1.3.0] - 2026-09-03
 
 ### Added
@@ -144,7 +149,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toast notifications
 - IntelliJ Platform 2024.3+ compatibility
 
-[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/hon454/copy-selection-context/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/hon454/copy-selection-context/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/hon454/copy-selection-context/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/hon454/copy-selection-context/compare/v1.1.1...v1.2.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.github.hon454"
-version = "1.3.0"
+version = "1.3.1"
 
 repositories {
     mavenCentral()
@@ -115,6 +115,14 @@ intellijPlatformTesting.testIde.register("platformTest") {
 }
 
 tasks {
+    processResources {
+        val pluginVersion = project.version.toString()
+        inputs.property("pluginVersion", pluginVersion)
+        filesMatching("META-INF/copy-selection-context-version.properties") {
+            expand("pluginVersion" to pluginVersion)
+        }
+    }
+
     withType<JavaCompile> {
         sourceCompatibility = "21"
         targetCompatibility = "21"

--- a/src/main/java/com/github/hon454/copyselectioncontext/CustomStatusBarWidgetAdapter.java
+++ b/src/main/java/com/github/hon454/copyselectioncontext/CustomStatusBarWidgetAdapter.java
@@ -1,0 +1,10 @@
+package com.github.hon454.copyselectioncontext;
+
+import com.intellij.openapi.wm.CustomStatusBarWidget;
+
+/**
+ * Prevents Kotlin from generating compatibility bridges for deprecated
+ * {@code StatusBarWidget} default methods when implementing the public custom-widget API.
+ */
+public abstract class CustomStatusBarWidgetAdapter implements CustomStatusBarWidget {
+}

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBundle.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBundle.kt
@@ -3,9 +3,11 @@ package com.github.hon454.copyselectioncontext
 import com.intellij.DynamicBundle
 import org.jetbrains.annotations.PropertyKey
 
-private const val BUNDLE = "messages.CopySelectionBundle"
+private const val BUNDLE_NAME = "messages.CopySelectionBundle"
 
-object CopySelectionBundle : DynamicBundle(BUNDLE) {
-    fun message(@PropertyKey(resourceBundle = BUNDLE) key: String, vararg params: Any): String =
-        getMessage(key, *params)
+object CopySelectionBundle {
+    private val bundle = DynamicBundle(CopySelectionBundle::class.java, BUNDLE_NAME)
+
+    fun message(@PropertyKey(resourceBundle = BUNDLE_NAME) key: String, vararg params: Any): String =
+        bundle.getMessage(key, *params)
 }

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionReviewService.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionReviewService.kt
@@ -1,15 +1,14 @@
 package com.github.hon454.copyselectioncontext
 
 import com.intellij.ide.BrowserUtil
-import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.RoamingType
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
+import java.util.Properties
 import java.util.concurrent.atomic.AtomicInteger
 
 @Service(Service.Level.APP)
@@ -104,16 +103,18 @@ class CopySelectionReviewService : PersistentStateComponent<CopySelectionReviewS
 
     internal fun sessionCopyCount(): Int = successfulCopiesThisSession.get()
 
-    private fun currentPluginVersion(): String? = PluginManagerCore
-        .getPlugin(PluginId.getId(PLUGIN_ID))
-        ?.version
-        ?.takeIf(String::isNotBlank)
+    internal fun currentPluginVersion(): String? = pluginVersion
 
     companion object {
         internal const val PROMPT_THRESHOLD = 10
         internal const val MARKETPLACE_REVIEW_URL =
             "https://plugins.jetbrains.com/plugin/30262-copy-selection-context/reviews"
-        private const val PLUGIN_ID = "com.github.hon454.copy-selection-context"
+        private const val VERSION_RESOURCE = "/META-INF/copy-selection-context-version.properties"
+        private val pluginVersion: String? by lazy {
+            CopySelectionReviewService::class.java.getResourceAsStream(VERSION_RESOURCE)
+                ?.use { stream -> Properties().apply { load(stream) }.getProperty("version") }
+                ?.takeIf(String::isNotBlank)
+        }
 
         fun getInstance(): CopySelectionReviewService =
             ApplicationManager.getApplication().getService(CopySelectionReviewService::class.java)

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionStatusBarWidget.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionStatusBarWidget.kt
@@ -1,17 +1,15 @@
 package com.github.hon454.copyselectioncontext
 
 import com.intellij.openapi.ide.CopyPasteManager
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.StatusBar
-import com.intellij.openapi.wm.StatusBarWidget.TextPresentation
-import com.intellij.openapi.wm.impl.status.EditorBasedWidget
-import com.intellij.util.Consumer
 import java.awt.datatransfer.StringSelection
+import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.util.concurrent.atomic.AtomicReference
+import javax.swing.JComponent
+import javax.swing.JLabel
 
-class CopySelectionStatusBarWidget(project: Project) :
-    EditorBasedWidget(project), TextPresentation {
+class CopySelectionStatusBarWidget : CustomStatusBarWidgetAdapter() {
 
     companion object {
         const val ID = "CopySelectionStatusBarWidget"
@@ -19,10 +17,25 @@ class CopySelectionStatusBarWidget(project: Project) :
     }
 
     private val lastCopied = AtomicReference("")
+    private var statusBar: StatusBar? = null
+    private val label: JLabel by lazy {
+        JLabel().apply {
+            text = getText()
+            toolTipText = getTooltipText()
+            addMouseListener(
+                object : MouseAdapter() {
+                    override fun mouseClicked(event: MouseEvent) {
+                        copyLastValue()
+                    }
+                },
+            )
+        }
+    }
 
     override fun ID() = ID
-    override fun getPresentation() = this
-    override fun getText() = lastCopied.get().let { content ->
+    override fun getComponent(): JComponent = label
+
+    fun getText() = lastCopied.get().let { content ->
         if (content.isBlank()) {
             ""
         } else {
@@ -30,22 +43,23 @@ class CopySelectionStatusBarWidget(project: Project) :
         }
     }
 
-    override fun getTooltipText() = lastCopied.get().let { content ->
+    fun getTooltipText() = lastCopied.get().let { content ->
         if (content.isBlank()) CopySelectionBundle.message("widget.tooltip") else CopyPreview.tooltip(content)
-    }
-    override fun getAlignment() = 0f
-
-    override fun getClickConsumer() = Consumer<MouseEvent> {
-        copyLastValue()
     }
 
     override fun install(statusBar: StatusBar) {
-        super.install(statusBar)
+        this.statusBar = statusBar
+    }
+
+    override fun dispose() {
+        statusBar = null
     }
 
     fun update(content: String) {
         lastCopied.set(content)
-        myStatusBar?.updateWidget(ID)
+        label.text = getText()
+        label.toolTipText = getTooltipText()
+        statusBar?.updateWidget(ID)
     }
 
     private fun copyLastValue() {

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionStatusBarWidgetFactory.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionStatusBarWidgetFactory.kt
@@ -9,7 +9,7 @@ class CopySelectionStatusBarWidgetFactory : StatusBarWidgetFactory {
     override fun getId() = CopySelectionStatusBarWidget.ID
     override fun getDisplayName() = CopySelectionBundle.message("settings.title")
     override fun isAvailable(project: Project) = true
-    override fun createWidget(project: Project): StatusBarWidget = CopySelectionStatusBarWidget(project)
+    override fun createWidget(project: Project): StatusBarWidget = CopySelectionStatusBarWidget()
     override fun disposeWidget(widget: StatusBarWidget) = widget.dispose()
     override fun canBeEnabledOn(statusBar: StatusBar) = true
 }

--- a/src/main/resources/META-INF/copy-selection-context-version.properties
+++ b/src/main/resources/META-INF/copy-selection-context-version.properties
@@ -1,0 +1,1 @@
+version=${pluginVersion}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionStatusBarWidgetTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionStatusBarWidgetTest.kt
@@ -1,7 +1,6 @@
 package com.github.hon454.copyselectioncontext
 
 import com.intellij.openapi.ide.CopyPasteManager
-import com.intellij.openapi.project.Project
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -11,6 +10,7 @@ import io.mockk.slot
 import io.mockk.unmockkStatic
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
+import javax.swing.JLabel
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -19,11 +19,14 @@ import kotlin.test.assertTrue
 class CopySelectionStatusBarWidgetTest {
     @Test
     fun `status and tooltip use safe bounded previews`() {
-        val widget = CopySelectionStatusBarWidget(mockk<Project>(relaxed = true))
+        val widget = CopySelectionStatusBarWidget()
         val content = "src/App.kt:10-20\n<script>😀 ${"x".repeat(1_000)}</script>"
 
         widget.update(content)
+        val label = widget.component as JLabel
 
+        assertEquals(widget.getText(), label.text)
+        assertEquals(widget.getTooltipText(), label.toolTipText)
         assertTrue(widget.getText().length <= CopyPreview.STATUS_MAX_LENGTH)
         assertTrue(widget.getTooltipText().length <= CopyPreview.TOOLTIP_MAX_LENGTH)
         assertFalse(widget.getText().any { it == '\n' || it == '\r' })
@@ -41,11 +44,12 @@ class CopySelectionStatusBarWidgetTest {
             every { CopyPasteManager.getInstance() } returns manager
             every { manager.setContents(capture(copied)) } just runs
 
-            val widget = CopySelectionStatusBarWidget(mockk<Project>(relaxed = true))
+            val widget = CopySelectionStatusBarWidget()
             val content = "src/App.kt:10-20\n<script>😀 ${"x".repeat(1_000)}</script>"
             widget.update(content)
 
-            widget.getClickConsumer().consume(mockk(relaxed = true))
+            val mouseEvent = mockk<java.awt.event.MouseEvent>(relaxed = true)
+            widget.component.mouseListeners.forEach { it.mouseClicked(mouseEvent) }
 
             assertEquals(content, copied.captured.getTransferData(DataFlavor.stringFlavor))
         } finally {

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -13,8 +13,16 @@ class ReleaseVersionParityTest {
     private val verifier = projectRoot.resolve("scripts/verify-release-version.sh")
 
     @Test
-    fun `canonical project version is 1_3_0`() {
-        assertEquals("1.3.0", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
+    fun `canonical project version is 1_3_1`() {
+        assertEquals("1.3.1", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
+    }
+
+    @Test
+    fun `runtime version resource matches the canonical project version`() {
+        assertEquals(
+            canonicalVersion(projectRoot.resolve("build.gradle.kts")),
+            CopySelectionReviewService().currentPluginVersion(),
+        )
     }
 
     @Test
@@ -22,7 +30,7 @@ class ReleaseVersionParityTest {
         val result = runVerifier("v${canonicalVersion(projectRoot.resolve("build.gradle.kts"))}")
 
         assertEquals(0, result.exitCode, result.output)
-        assertTrue(result.output.contains("Version verified: v1.3.0"), result.output)
+        assertTrue(result.output.contains("Version verified: v1.3.1"), result.output)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- replace the internal and obsolete status-bar implementation with the public `CustomStatusBarWidget` API while preserving bounded previews and click-to-recopy
- replace deprecated `DynamicBundle` subclass construction and internal `PluginManagerCore` version lookup with public APIs and a build-expanded version resource
- bump the canonical plugin version to 1.3.1 and publish the verified fix in the dated changelog section

Closes #84

## Validation

- `bash scripts/verify-release-version.sh v1.3.1` — passed
- `bash scripts/generate-release-notes.sh 1.3.1 v1.3.1 ...` — passed; output contains only the v1.3.1 `Fixed` entry
- `./gradlew detekt` — passed with 0 findings
- `./gradlew allTests koverXmlReport koverHtmlReport check` — passed
- `./gradlew verifyPluginProjectConfiguration verifyPluginStructure` — passed
- `./gradlew verifyPlugin` — passed; compatible with IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97
- standalone Plugin Verifier 1.410 against IU-263.3889.65 — compatible with no deprecated or internal API findings
- `./gradlew buildPlugin` — passed; produced `copy-selection-context-1.3.1.zip`
- `git diff --check` — passed

Local unsigned ZIP SHA-256: `890ee7a461edb1961305d3e3a6943c9e0728b76ef4569054cba463af3399c646`

## Release plan

- merge after required checks pass
- create and push annotated tag `v1.3.1` on the merge commit
- verify the release workflow signs, verifies, checksums, attests, and uploads the canonical ZIP
- verify the same canonical ZIP is published to JetBrains Marketplace
