### PR TITLE
chore(release): prepare v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-09-03
+
 ### Changed
 - Route standard and Git permalink successes through one project-scoped result publisher, giving permalinks consistent history, gutter, notification, and status feedback while preserving standard-only analytics and review accounting (#71)
 - Suppress stale permalink completions across separate permalink actions and newer standard copies so older async work cannot replace the latest plugin copy (#71)
@@ -156,7 +158,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toast notifications
 - IntelliJ Platform 2024.3+ compatibility
 
-[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/hon454/copy-selection-context/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/hon454/copy-selection-context/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/hon454/copy-selection-context/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/hon454/copy-selection-context/compare/v1.2.0...v1.2.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.github.hon454"
-version = "1.3.1"
+version = "1.4.0"
 
 repositories {
     mavenCentral()

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -13,8 +13,8 @@ class ReleaseVersionParityTest {
     private val verifier = projectRoot.resolve("scripts/verify-release-version.sh")
 
     @Test
-    fun `canonical project version is 1_3_1`() {
-        assertEquals("1.3.1", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
+    fun `canonical project version is 1_4_0`() {
+        assertEquals("1.4.0", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
     }
 
     @Test
@@ -30,7 +30,7 @@ class ReleaseVersionParityTest {
         val result = runVerifier("v${canonicalVersion(projectRoot.resolve("build.gradle.kts"))}")
 
         assertEquals(0, result.exitCode, result.output)
-        assertTrue(result.output.contains("Version verified: v1.3.1"), result.output)
+        assertTrue(result.output.contains("Version verified: v1.4.0"), result.output)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- bump the canonical Gradle/plugin version from 1.3.1 to 1.4.0
- promote the completed #71 and #72 entries into the dated 2026-09-03 `1.4.0` changelog section
- leave a fresh empty `[Unreleased]` section and update the `v1.4.0...HEAD` / `v1.3.1...v1.4.0` comparison links
- align `ReleaseVersionParityTest` with the new canonical version

## Milestone readiness

The GitHub `v1.4.0` milestone has exactly 0 open and 2 closed issues:

- #71, integrated by #86
- #72, integrated by #87

All five localized README files plus `AGENTS.md` and `.agents/architecture.md` were checked against the integrated behavior. They are already synchronized, so no documentation edits are needed. Dependency PR #82 is not included or modified.

## Verification

- `./gradlew patchChangelog --stacktrace --console=plain` — passed using the documented changelog workflow
- `bash scripts/verify-release-version.sh v1.4.0` — passed (`Version verified: v1.4.0`)
- `bash scripts/generate-release-notes.sh 1.4.0 v1.4.0 /private/tmp/copy-selection-context-v1.4.0-release-notes.md` — passed; notes contain only the two #71 `Changed` entries and the #72 `Fixed` entry
- `./gradlew detekt --stacktrace --console=plain` — passed with 0 findings
- `./gradlew allTests koverXmlReport koverHtmlReport --continue --stacktrace --console=plain` — passed; 323 unit tests and 17 platform tests, 0 failures/errors/skips; Kover XML and HTML reports generated
- `./gradlew verifyPluginProjectConfiguration verifyPluginStructure --stacktrace --console=plain` — passed
- `./gradlew verifyPlugin --stacktrace --console=plain` — passed; compatible with IC-243.28141.41, IC-251.29188.72, and IC-252.28539.97
- `./gradlew buildPlugin --stacktrace --console=plain` — passed; produced `copy-selection-context-1.4.0.zip`
- generated plugin resources and archive entries report version 1.4.0
- `git diff --check` — passed

Local unsigned ZIP SHA-256: `de79668e88feef24fe98ec08588513fc88b93cd6c6ade204a4d78f62b00c0029`

## Release checklist

- [x] Confirm the `v1.4.0` milestone contains only closed issues #71 and #72
- [x] Confirm the changelog categories and comparison links
- [x] Run the complete local release-quality gate
- [x] Confirm the expected 1.4.0 distribution ZIP exists
- [ ] Merge this PR into `main` after required review and CI checks pass
- [ ] Confirm release signing and Marketplace secrets before tagging
- [ ] Create and push `v1.4.0` only after this commit is merged to `main`
- [ ] Confirm the release workflow signs/verifies or explicitly selects unsigned mode, checksums, attests, and publishes the canonical ZIP as configured

## Not performed

- no `v1.4.0` tag was created or pushed
- no GitHub Release or Marketplace publication was triggered
- this PR was not merged
