### PR TITLE
chore(release): prepare v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-09-03
+
+### Changed
+- Upgrade the Kover Gradle plugin from 0.9.8 to 0.9.9 (#82)
+
 ## [1.4.0] - 2026-09-03
 
 ### Changed
@@ -158,7 +163,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toast notifications
 - IntelliJ Platform 2024.3+ compatibility
 
-[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/hon454/copy-selection-context/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/hon454/copy-selection-context/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/hon454/copy-selection-context/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/hon454/copy-selection-context/compare/v1.2.1...v1.3.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.github.hon454"
-version = "1.4.0"
+version = "1.4.1"
 
 repositories {
     mavenCentral()

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -13,8 +13,8 @@ class ReleaseVersionParityTest {
     private val verifier = projectRoot.resolve("scripts/verify-release-version.sh")
 
     @Test
-    fun `canonical project version is 1_4_0`() {
-        assertEquals("1.4.0", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
+    fun `canonical project version is 1_4_1`() {
+        assertEquals("1.4.1", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
     }
 
     @Test
@@ -30,7 +30,7 @@ class ReleaseVersionParityTest {
         val result = runVerifier("v${canonicalVersion(projectRoot.resolve("build.gradle.kts"))}")
 
         assertEquals(0, result.exitCode, result.output)
-        assertTrue(result.output.contains("Version verified: v1.4.0"), result.output)
+        assertTrue(result.output.contains("Version verified: v1.4.1"), result.output)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- prepare the project version and changelog for v1.4.1
- document the Kover 0.9.9 update merged from #82
- align release version parity assertions with the v1.4.1 tag

## Verification

- `bash scripts/verify-release-version.sh v1.4.1`
- generated release notes from the v1.4.1 changelog section
- `./gradlew detekt allTests koverXmlReport koverHtmlReport --continue`
- `./gradlew verifyPluginProjectConfiguration verifyPluginStructure`
- `./gradlew verifyPlugin`
- `./gradlew buildPlugin`
