### PR TITLE
test(release): align version parity with v1.5.0

### DIFF
--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -13,8 +13,8 @@ class ReleaseVersionParityTest {
     private val verifier = projectRoot.resolve("scripts/verify-release-version.sh")
 
     @Test
-    fun `canonical project version is 1_4_1`() {
-        assertEquals("1.4.1", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
+    fun `canonical project version is 1_5_0`() {
+        assertEquals("1.5.0", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
     }
 
     @Test
@@ -30,7 +30,7 @@ class ReleaseVersionParityTest {
         val result = runVerifier("v${canonicalVersion(projectRoot.resolve("build.gradle.kts"))}")
 
         assertEquals(0, result.exitCode, result.output)
-        assertTrue(result.output.contains("Version verified: v1.4.1"), result.output)
+        assertTrue(result.output.contains("Version verified: v1.5.0"), result.output)
     }
 
     @Test


### PR DESCRIPTION
The v1.5.0 release workflow reached its existing test gate and found two release-specific assertions still pinned to v1.4.1. Update only those expected version values to v1.5.0 so the canonical project version, verifier output, and release test agree.

Failed run: https://github.com/hon454/copy-selection-context/actions/runs/33974303458