### PR TITLE
docs: document Windows Bash test prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,40 @@
 - JDK 21+
 - IntelliJ IDEA (Community or Ultimate)
 
+Windows contributors who run `test`, `platformTest`, or `allTests` also need a
+Bash executable and the basic Unix command-line tools used by the release
+script tests. Those tests invoke the repository's `scripts/*.sh` files through
+`ProcessBuilder("bash", ...)`; the scripts use tools such as `mktemp`, `dirname`,
+`find`, `sort`, `basename`, `mv`, `rm`, and a SHA-256 utility (`sha256sum` or
+`shasum`). This is a development
+and test requirement only. Plugin users do not need Bash or these tools to
+install or use the plugin.
+
+Git for Windows with Git Bash is one example of an environment that provides
+these tools. Before starting Gradle, check the environment from the same
+terminal that will launch it:
+
+```text
+bash --version
+where bash
+where mktemp
+where find
+where sort
+where basename
+# At least one of these must resolve:
+where sha256sum
+where shasum
+```
+
+Each required command should resolve to an executable; at least one of
+`sha256sum` or `shasum` must be available. If a command is not found,
+install or enable a Bash distribution that provides the required Unix tools,
+then open a new terminal with that distribution's `bin` directory on `PATH`.
+The important detail is that `bash` and those tools must be discoverable by the
+Gradle process itself, not only by a separate Git Bash window. Re-run the
+checks in the terminal where `gradlew.bat` will be invoked; this guide does
+not modify the user's PATH automatically.
+
 ### Build & Run
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 - JDK 21+
 - IntelliJ IDEA (Community or Ultimate)
 
-Windows contributors who run `test`, `platformTest`, or `allTests` also need a
+Windows contributors who run `test` or `allTests` also need a
 Bash executable and the basic Unix command-line tools used by the release
 script tests. Those tests invoke the repository's `scripts/*.sh` files through
 `ProcessBuilder("bash", ...)`; the scripts use tools such as `mktemp`, `dirname`,
@@ -17,23 +17,20 @@ and test requirement only. Plugin users do not need Bash or these tools to
 install or use the plugin.
 
 Git for Windows with Git Bash is one example of an environment that provides
-these tools. Before starting Gradle, check the environment from the same
-terminal that will launch it:
+these tools. From Windows Command Prompt (`cmd.exe`) or PowerShell, first
+locate Bash, then check the tools inside that Bash environment before starting
+Gradle:
 
 ```text
 bash --version
-where bash
-where mktemp
-where find
-where sort
-where basename
-# At least one of these must resolve:
-where sha256sum
-where shasum
+where.exe bash
+bash -lc "for tool in bash mktemp dirname find sort basename mv rm sha256sum shasum; do printf '%s=' \"\$tool\"; command -v \"\$tool\" || exit 1; done"
 ```
 
-Each required command should resolve to an executable; at least one of
-`sha256sum` or `shasum` must be available. If a command is not found,
+`where.exe bash` confirms which Bash a Windows shell would start, while
+`command -v` checks the Unix tools in Bash rather than Windows `find` or
+`sort` commands. The check should find every required tool except that at
+least one of `sha256sum` or `shasum` must be available. If a command is not found,
 install or enable a Bash distribution that provides the required Unix tools,
 then open a new terminal with that distribution's `bin` directory on `PATH`.
 The important detail is that `bash` and those tools must be discoverable by the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,22 +17,23 @@ and test requirement only. Plugin users do not need Bash or these tools to
 install or use the plugin.
 
 Git for Windows with Git Bash is one example of an environment that provides
-these tools. From Windows Command Prompt (`cmd.exe`) or PowerShell, first
-locate Bash, then check the tools inside that Bash environment before starting
-Gradle:
+these tools. From the same Windows Command Prompt (`cmd.exe`) that will launch
+Gradle, check the tools inside the Bash environment before starting Gradle:
 
 ```text
 bash --version
 where.exe bash
-bash -lc "for tool in bash mktemp dirname find sort basename mv rm sha256sum shasum; do printf '%s=' \"\$tool\"; command -v \"\$tool\" || exit 1; done"
+bash -c "command -v bash mktemp dirname find sort basename mv rm && (command -v sha256sum || command -v shasum)"
 ```
 
 `where.exe bash` confirms which Bash a Windows shell would start, while
 `command -v` checks the Unix tools in Bash rather than Windows `find` or
-`sort` commands. The check should find every required tool except that at
-least one of `sha256sum` or `shasum` must be available. If a command is not found,
-install or enable a Bash distribution that provides the required Unix tools,
-then open a new terminal with that distribution's `bin` directory on `PATH`.
+`sort` commands. Confirm that the printed paths point into the Bash
+distribution's Unix tools, not Windows `System32` binaries. The check should
+find every required tool and at least one of `sha256sum` or `shasum`. If a
+command is not found, install or enable a Bash distribution that provides the
+required Unix tools, then open a new terminal with that distribution's `bin`
+directory on `PATH`.
 The important detail is that `bash` and those tools must be discoverable by the
 Gradle process itself, not only by a separate Git Bash window. Re-run the
 checks in the terminal where `gradlew.bat` will be invoked; this guide does


### PR DESCRIPTION
## Summary

Closes #100.

Document the Windows prerequisites for running the release-script tests through
`test` and `allTests`.

## Acceptance criteria

- Windows development setup now explains that the release-script tests invoke
  `scripts/*.sh` with `ProcessBuilder("bash", ...)` and need Bash plus the
  basic Unix tools used by those scripts.
- The guide includes `bash --version`, `where.exe bash`, and the Bash
  `command -v` check from the same Windows Command Prompt that launches
  `gradlew.bat`, including the `sha256sum`/`shasum` fallback requirement.
- The existing Windows `gradlew.bat` commands remain unchanged, and the guide
  explicitly separates development/test prerequisites from plugin installation
  and use.
- The guide does not modify PATH or install tools automatically.
- README files were intentionally not changed: #101 owns the release guidance,
  while #100 requests the detailed explanation in CONTRIBUTING.

## Evidence and verification

- Base: latest `origin/main` fetched before branch creation.
- Branch: `codex/issue-100`
- Final commit: `c4acbde60095c65e83c066bd1bbbfa29d2ee41bb`
- Static checks: `git diff --check` passed.
- Bash preflight syntax: `bash -c "command -v bash mktemp dirname find sort basename mv rm && (command -v sha256sum || command -v shasum)"` passed on the macOS Bash host. Windows execution was not claimed.
- Manual review: cross-checked `CONTRIBUTING.md` against
  `scripts/generate-release-notes.sh`, `scripts/generate-release-checksum.sh`,
  `scripts/select-release-artifact.sh`, `scripts/resolve-release-mode.sh`,
  `scripts/verify-release-version.sh`, and the release test `ProcessBuilder`
  calls. The documented command dependencies and SHA-256 fallback match the
  implementation.
- Host observed for this work: macOS Darwin 25.6.0 ARM64; GNU Bash 3.2.57;
  `mktemp`, `dirname`, `find`, `sort`, `basename`, `mv`, `rm`, `sha256sum`, and
  `shasum` were available. JDK 21 was present at
  `/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home` (OpenJDK
  21.0.12.1) and `/Users/van/.local/share/mise/installs/java/21.0.2` (OpenJDK
  21.0.2); the default `java` command was not configured in PATH.
- Not run: Windows validation, Gradle tests, `allTests`, IDE fixtures, and
  Plugin Verifier. Gradle was not run because this is a documentation-only
  change and the coordination task reserved the Gradle slot for #98. CI is
  tracked separately below.

## Before/after

- Before: Windows prerequisites listed only JDK and IntelliJ IDEA, although
  release tests start Bash scripts directly.
- After: contributors can verify Bash, Unix tools, and the Gradle-launching
  process PATH before running the existing Windows wrapper commands; plugin
  users are told these tools are not required.
