### PR TITLE
fix(ci): validate release tags before shell evaluation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
-    env:
-      PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-      CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
-      PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-      PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
-
     steps:
       - name: Maximize Build Space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -32,15 +26,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Extract version from tag
-        id: version
-        run: |
-          TAG="${GITHUB_REF#refs/tags/v}"
-          echo "version=$TAG" >> "$GITHUB_OUTPUT"
-          echo "tag=v$TAG" >> "$GITHUB_OUTPUT"
-
       - name: Verify version matches build.gradle.kts
-        run: bash scripts/verify-release-version.sh "${{ steps.version.outputs.tag }}"
+        id: version
+        run: bash scripts/verify-release-version.sh "$GITHUB_REF_NAME" build.gradle.kts "$GITHUB_OUTPUT"
 
       - name: Set up JDK 21
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
@@ -55,10 +43,13 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Generate release notes from changelog
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
         run: |
           bash scripts/generate-release-notes.sh \
-            "${{ steps.version.outputs.version }}" \
-            "${{ steps.version.outputs.tag }}"
+            "$RELEASE_VERSION" \
+            "$RELEASE_TAG"
 
       - name: Run Kotlin static analysis
         run: ./gradlew detekt --stacktrace --console=plain
@@ -90,10 +81,18 @@ jobs:
 
       - name: Resolve release mode
         id: release-mode
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
         run: bash scripts/resolve-release-mode.sh "$GITHUB_OUTPUT"
 
       - name: Sign and verify canonical release ZIP
         if: steps.release-mode.outputs.signed == 'true'
+        env:
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
         run: |
           signing_certificate_file="$RUNNER_TEMP/copy-selection-context-signing-chain.crt"
           trap 'rm -f "$signing_certificate_file"' EXIT
@@ -106,16 +105,20 @@ jobs:
 
       - name: Select canonical release ZIP
         id: release-artifact
+        env:
+          RELEASE_SIGNED: ${{ steps.release-mode.outputs.signed }}
         run: >-
           bash scripts/select-release-artifact.sh
           build/distributions
-          "${{ steps.release-mode.outputs.signed }}"
+          "$RELEASE_SIGNED"
           "$GITHUB_OUTPUT"
 
       - name: Generate and verify release checksum
+        env:
+          RELEASE_ARCHIVE: ${{ steps.release-artifact.outputs.path }}
         run: >-
           bash scripts/generate-release-checksum.sh
-          "${{ steps.release-artifact.outputs.path }}"
+          "$RELEASE_ARCHIVE"
           SHA256SUMS
 
       - name: Generate release ZIP attestation
@@ -127,14 +130,16 @@ jobs:
       - name: Verify release ZIP attestation
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_ARCHIVE: ${{ steps.release-artifact.outputs.path }}
+          ATTESTATION_BUNDLE: ${{ steps.attestation.outputs.bundle-path }}
         run: >-
           gh attestation verify
-          "${{ steps.release-artifact.outputs.path }}"
-          --bundle "${{ steps.attestation.outputs.bundle-path }}"
-          --repo "${{ github.repository }}"
-          --signer-workflow "${{ github.repository }}/.github/workflows/release.yml"
-          --source-digest "${{ github.sha }}"
-          --source-ref "${{ github.ref }}"
+          "$RELEASE_ARCHIVE"
+          --bundle "$ATTESTATION_BUNDLE"
+          --repo "$GITHUB_REPOSITORY"
+          --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml"
+          --source-digest "$GITHUB_SHA"
+          --source-ref "$GITHUB_REF"
 
       - name: Upload validation reports
         if: always()
@@ -168,8 +173,11 @@ jobs:
 
       - name: Publish to JetBrains Marketplace
         if: steps.release-mode.outputs.publish == 'true'
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          RELEASE_ARCHIVE: ${{ steps.release-artifact.outputs.path }}
         run: >-
           ./gradlew publishPlugin
-          -PcanonicalPluginArchive="${{ steps.release-artifact.outputs.path }}"
+          -PcanonicalPluginArchive="$RELEASE_ARCHIVE"
           --stacktrace
           --console=plain

--- a/scripts/verify-release-version.sh
+++ b/scripts/verify-release-version.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 release_tag="${1:-${GITHUB_REF_NAME:-}}"
 build_file="${2:-build.gradle.kts}"
+output_file="${3:-}"
 
 if [[ -z "$release_tag" ]]; then
   echo "::error::Release tag is required (argument 1 or GITHUB_REF_NAME)." >&2
@@ -36,3 +37,9 @@ if [[ "$canonical_version" != "$tag_version" ]]; then
 fi
 
 echo "Version verified: $release_tag"
+
+# Only validated values may become inputs to later workflow steps. Keep the
+# standalone verifier usable without a GitHub Actions output file.
+if [[ -n "$output_file" ]]; then
+  printf 'version=%s\ntag=%s\n' "$tag_version" "$release_tag" >> "$output_file"
+fi

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CiWorkflowTest.kt
@@ -16,6 +16,77 @@ import kotlin.test.assertTrue
 
 class CiWorkflowTest {
     @Test
+    fun `release credentials are scoped to only the steps that consume them`() {
+        val workflow = readWorkflowMapping("release.yml")
+        val job = workflow.mappingForKey("jobs").mappingForKey("release")
+        assertTrue(workflow.valueForKey("env") == null, "Release must not inherit workflow credentials")
+        assertTrue(job.valueForKey("env") == null, "Release must not inherit job credentials")
+        val expected = mapOf(
+            "Resolve release mode" to setOf("PUBLISH_TOKEN", "CERTIFICATE_CHAIN", "PRIVATE_KEY"),
+            "Sign and verify canonical release ZIP" to
+                setOf("CERTIFICATE_CHAIN", "PRIVATE_KEY", "PRIVATE_KEY_PASSWORD"),
+            "Publish to JetBrains Marketplace" to setOf("PUBLISH_TOKEN"),
+        )
+        val steps = workflowSteps("release.yml")
+        expected.keys.forEach { steps.stepNamed(it) }
+        steps.forEach { step ->
+            val name = step.scalarForKey("name")
+            val env = step.valueForKey("env") as? MappingNode
+            val secrets = env?.value.orEmpty().filter { entry ->
+                (entry.valueNode as ScalarNode).value.contains("secrets.")
+            }.associate { entry ->
+                (entry.keyNode as ScalarNode).value to (entry.valueNode as ScalarNode).value
+            }
+            assertEquals(
+                expected[name].orEmpty().associateWith { "${'$'}{{ secrets.$it }}" },
+                secrets,
+                "$name must receive only its required credentials",
+            )
+            step.value.filter { (it.keyNode as ScalarNode).value != "env" }.forEach {
+                assertFalse(it.valueNode.toString().contains("secrets."), "$name must inject secrets only via env")
+            }
+        }
+    }
+
+    @Test
+    fun `release shell sources never interpolate workflow expressions`() {
+        workflowSteps("release.yml").forEach { step ->
+            val command = step.valueForKey("run") as? ScalarNode
+            assertFalse(
+                command?.value.orEmpty().contains("${'$'}{{"),
+                "${step.scalarForKey("name")} must pass workflow values through env instead of shell source",
+            )
+        }
+    }
+
+    @Test
+    fun `release env inputs preserve validated outputs and canonical artifact bindings`() {
+        val steps = workflowSteps("release.yml")
+        val expected = mapOf(
+            "Generate release notes from changelog" to mapOf(
+                "RELEASE_VERSION" to "${'$'}{{ steps.version.outputs.version }}",
+                "RELEASE_TAG" to "${'$'}{{ steps.version.outputs.tag }}",
+            ),
+            "Select canonical release ZIP" to mapOf("RELEASE_SIGNED" to "${'$'}{{ steps.release-mode.outputs.signed }}"),
+            "Generate and verify release checksum" to mapOf("RELEASE_ARCHIVE" to "${'$'}{{ steps.release-artifact.outputs.path }}"),
+            "Verify release ZIP attestation" to mapOf(
+                "RELEASE_ARCHIVE" to "${'$'}{{ steps.release-artifact.outputs.path }}",
+                "ATTESTATION_BUNDLE" to "${'$'}{{ steps.attestation.outputs.bundle-path }}",
+                "GH_TOKEN" to "${'$'}{{ github.token }}",
+            ),
+            "Publish to JetBrains Marketplace" to mapOf("RELEASE_ARCHIVE" to "${'$'}{{ steps.release-artifact.outputs.path }}"),
+        )
+        expected.forEach { (name, bindings) ->
+            val env = steps.stepNamed(name).mappingForKey("env")
+            bindings.forEach { (key, value) -> assertEquals(value, env.scalarForKey(key), "$name: $key") }
+        }
+        val version = steps.stepNamed("Verify version matches build.gradle.kts")
+        assertEquals("version", version.scalarForKey("id"))
+        assertTrue(version.valueForKey("if") == null, "Version validation must always gate the release")
+        assertTrue(version.valueForKey("continue-on-error") == null, "Version errors must fail closed")
+    }
+
+    @Test
     fun `build validates before packaging and artifact upload`() {
         assertValidationPipeline(
             workflowName = "build.yml",
@@ -60,7 +131,7 @@ class CiWorkflowTest {
         )
         assertTrue(
             workflow.contains("bash scripts/select-release-artifact.sh") &&
-                workflow.contains("\"${'$'}{{ steps.release-mode.outputs.signed }}\"") &&
+                workflow.contains("\"${'$'}RELEASE_SIGNED\"") &&
                 workflow.contains("\"${'$'}GITHUB_OUTPUT\""),
             "release.yml must select the canonical ZIP through the fail-closed selector",
         )
@@ -69,9 +140,9 @@ class CiWorkflowTest {
             "the attestation must identify the exact ZIP selected for publication",
         )
         assertTrue(
-            workflow.contains("--bundle \"${'$'}{{ steps.attestation.outputs.bundle-path }}\"") &&
-                workflow.contains("--source-digest \"${'$'}{{ github.sha }}\"") &&
-                workflow.contains("--source-ref \"${'$'}{{ github.ref }}\""),
+            workflow.contains("--bundle \"${'$'}ATTESTATION_BUNDLE\"") &&
+                workflow.contains("--source-digest \"${'$'}GITHUB_SHA\"") &&
+                workflow.contains("--source-ref \"${'$'}GITHUB_REF\""),
             "release.yml must verify the generated attestation against the triggering commit and tag",
         )
         assertTrue(
@@ -84,7 +155,7 @@ class CiWorkflowTest {
         )
         assertTrue(
             workflow.contains("if: steps.release-mode.outputs.publish == 'true'") &&
-                workflow.contains("-PcanonicalPluginArchive=\"${'$'}{{ steps.release-artifact.outputs.path }}\""),
+                workflow.contains("-PcanonicalPluginArchive=\"${'$'}RELEASE_ARCHIVE\""),
             "Marketplace publication must receive the exact canonical ZIP selected for release",
         )
         assertTrue(
@@ -110,8 +181,8 @@ class CiWorkflowTest {
         )
         val generationCommand =
             "bash scripts/generate-release-notes.sh \\\n" +
-                "            \"${'$'}{{ steps.version.outputs.version }}\" \\\n" +
-                "            \"${'$'}{{ steps.version.outputs.tag }}\""
+                "            \"${'$'}RELEASE_VERSION\" \\\n" +
+                "            \"${'$'}RELEASE_TAG\""
         assertTrue(
             workflow.contains(generationCommand),
             "release.yml must delegate deterministic note generation to the tested script",

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.snakeyaml.engine.v2.api.Load
+import org.snakeyaml.engine.v2.api.LoadSettings
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -67,7 +69,7 @@ class ReleaseVersionParityTest {
         val releaseNotesGenerator = Files.readString(projectRoot.resolve("scripts/generate-release-notes.sh"))
 
         assertTrue(
-            workflow.contains("bash scripts/verify-release-version.sh \"${'$'}{{ steps.version.outputs.tag }}\""),
+            workflow.contains("bash scripts/verify-release-version.sh \"${'$'}GITHUB_REF_NAME\""),
             workflow
         )
         assertFalse(workflow.contains("grep -oP"), workflow)
@@ -79,6 +81,53 @@ class ReleaseVersionParityTest {
             releaseNotesGenerator.contains("--project-version \"${'$'}release_version\""),
             releaseNotesGenerator,
         )
+    }
+
+    @Test
+    fun `workflow publishes version outputs only after matching tag validation`(@TempDir tempDir: Path) {
+        val version = canonicalVersion(projectRoot.resolve("build.gradle.kts"))
+        val result = runWorkflowVersionBoundary("v$version", tempDir)
+
+        assertEquals(0, result.exitCode, result.output)
+        assertEquals(mapOf("version" to version, "tag" to "v$version"), result.outputs)
+    }
+
+    @Test
+    fun `workflow rejects missing mismatched and malformed tags without outputs`(@TempDir tempDir: Path) {
+        listOf("", "v9.9.9", "1.5.0", "v1.5.0-rc.1").forEachIndexed { index, tag ->
+            val result = runWorkflowVersionBoundary(tag, tempDir.resolve(index.toString()))
+
+            assertEquals(1, result.exitCode, result.output)
+            assertTrue(result.outputs.isEmpty(), "Invalid tag must not reach downstream outputs: $result")
+        }
+    }
+
+    @Test
+    fun `workflow rejects command substitutions as literal tag data`(@TempDir tempDir: Path) {
+        val tags = listOf(
+            "v${'$'}(printf${'$'}{IFS}TAG_COMMAND_EXECUTED)",
+            "v`printf${'$'}{IFS}TAG_COMMAND_EXECUTED`",
+        )
+        tags.forEachIndexed { index, tag ->
+            val refCheck = ProcessBuilder("git", "check-ref-format", "refs/tags/$tag").start()
+            assertEquals(0, refCheck.waitFor(), "The harmless regression input must be a valid Git ref")
+            assertLiteralRejection(tag, runWorkflowVersionBoundary(tag, tempDir.resolve(index.toString())))
+        }
+    }
+
+    @Test
+    fun `boundary regression detects reverting env input to shell interpolation`(@TempDir tempDir: Path) {
+        val tag = "v${'$'}(printf${'$'}{IFS}TAG_COMMAND_EXECUTED)"
+        val workflow = Files.readString(projectRoot.resolve(".github/workflows/release.yml"))
+        val unsafeWorkflow = workflow.replace(
+            "\"${'$'}GITHUB_REF_NAME\"",
+            "\"${'$'}{{ github.ref_name }}\"",
+        )
+        assertFalse(workflow == unsafeWorkflow, "Mutation must change the actual workflow boundary")
+        val result = runWorkflowVersionBoundary(tag, tempDir, unsafeWorkflow)
+
+        assertTrue(result.output.contains("vTAG_COMMAND_EXECUTED"), result.output)
+        org.junit.jupiter.api.assertThrows<AssertionError> { assertLiteralRejection(tag, result) }
     }
 
     @Test
@@ -105,10 +154,77 @@ class ReleaseVersionParityTest {
         val process = ProcessBuilder(command)
             .directory(projectRoot.toFile())
             .redirectErrorStream(true)
+            .apply { environment().remove("GITHUB_REF_NAME") }
             .start()
         val output = process.inputStream.bufferedReader().use { it.readText() }
         return CommandResult(process.waitFor(), output)
     }
 
     private data class CommandResult(val exitCode: Int, val output: String)
+
+    private fun assertLiteralRejection(tag: String, result: WorkflowResult) {
+        assertEquals(1, result.exitCode, result.output)
+        assertTrue(
+            result.output.contains("Release tag must use v<major>.<minor>.<patch>: $tag"),
+            "The workflow must reject the original tag without evaluating substitutions: ${result.output}",
+        )
+        assertTrue(result.outputs.isEmpty(), "Rejected tags must not produce version outputs: $result")
+    }
+
+    // Execute the checked-in run source with Actions-style expression substitution
+    // and step outputs. Passing the tag only as a script argv would miss the bug.
+    // Only the pre-JDK version boundary is executed, with no inherited credentials.
+    private fun runWorkflowVersionBoundary(
+        tag: String,
+        tempDir: Path,
+        workflow: String = Files.readString(projectRoot.resolve(".github/workflows/release.yml")),
+    ): WorkflowResult {
+        val root = Load(LoadSettings.builder().build()).loadFromString(workflow) as Map<*, *>
+        val job = (root["jobs"] as Map<*, *>)["release"] as Map<*, *>
+        val steps = (job["steps"] as List<*>).map { it as Map<*, *> }
+            .takeWhile { it["name"] != "Set up JDK 21" }
+            .filter { it["run"] is String }
+        assertTrue(steps.isNotEmpty(), "The workflow must validate the version before JDK setup")
+        val context = mutableMapOf("github.ref_name" to tag, "github.ref" to "refs/tags/$tag")
+        val outputs = mutableMapOf<String, String>()
+        val log = StringBuilder()
+        Files.createDirectories(tempDir)
+        steps.forEachIndexed { index, step ->
+            val outputFile = Files.createFile(tempDir.resolve("step-$index-output"))
+            val builder = ProcessBuilder(
+                "bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c",
+                renderExpressions(step["run"] as String, context),
+            ).directory(projectRoot.toFile()).redirectErrorStream(true)
+            val environment = builder.environment()
+            val executablePath = environment["PATH"].orEmpty()
+            environment.clear()
+            environment.putAll(mapOf(
+                "PATH" to executablePath,
+                "GITHUB_REF_NAME" to tag,
+                "GITHUB_REF" to "refs/tags/$tag",
+                "GITHUB_OUTPUT" to outputFile.toString(),
+            ))
+            (step["env"] as? Map<*, *>)?.forEach { (key, value) ->
+                environment[key as String] = renderExpressions(value as String, context)
+            }
+            val process = builder.start()
+            log.append(process.inputStream.bufferedReader().use { it.readText() })
+            val exitCode = process.waitFor()
+            Files.readAllLines(outputFile).forEach { line ->
+                val key = line.substringBefore('=')
+                val value = line.substringAfter('=')
+                outputs[key] = value
+                context["steps.${step["id"]}.outputs.$key"] = value
+            }
+            if (exitCode != 0) return WorkflowResult(exitCode, log.toString(), outputs)
+        }
+        return WorkflowResult(0, log.toString(), outputs)
+    }
+
+    private fun renderExpressions(source: String, context: Map<String, String>): String =
+        Regex("""\$\{\{\s*(.*?)\s*}}""").replace(source) { match ->
+            context.getValue(match.groupValues[1])
+        }
+
+    private data class WorkflowResult(val exitCode: Int, val output: String, val outputs: Map<String, String>)
 }


### PR DESCRIPTION
검증 전 태그가 `run` 소스에 직접 삽입되어 명령 치환이 먼저 실행되는 경로를 제거했습니다. `GITHUB_REF_NAME`을 인용된 환경 변수로 전달하고, 형식·Gradle 버전 일치 검증이 성공한 뒤에만 후속 단계용 `version`·`tag` 출력을 기록합니다. 나머지 release 입력도 env를 통해 전달하며, job 전체의 signing/Marketplace secrets를 각 소비 단계로 좁혔습니다.

관련 이슈: #98. 착수 시 최신 본문·댓글(없음)·네이티브 Blocked by(없음)를 직접 확인했습니다. 병합과 이슈 종료는 조율 task가 담당합니다.

| 수용 조건 | 구현 및 검증 근거 |
| --- | --- |
| 1. 정상 태그와 Gradle 버전 일치 | 기존 standalone verifier 계약 유지. 실제 workflow 경계에서 현재 canonical 버전 태그를 실행해 성공 및 정확한 두 outputs 검증 |
| 2. 악의적 태그의 원문 거부 | YAML에서 읽은 실제 pre-JDK `run` 소스를 Bash로 실행. `v$(printf${IFS}TAG_COMMAND_EXECUTED)` 및 backtick 변형이 Git ref 형식으로 유효함을 확인하고, 원문 그대로 오류에 남는지 검증 |
| 3. 잘못된 태그의 조기 실패 | 누락·버전 불일치·v 누락·prerelease 입력 모두 exit 1, outputs 없음. 버전 검증 단계가 무조건 실행되고 continue-on-error가 없으며 notes·검증·서명·게시 순서 유지 |
| 4. 단계별 최소 secrets | workflow/job env 없음. 모드 판정: certificate/key/publish token 3개; 서명: certificate/key/password 3개; Marketplace: publish token 1개. 모든 다른 단계는 해당 secrets 없음. YAML 구조로 검사 |
| 5. 기존 모드와 canonical ZIP | 기존 ReleaseArtifactSelectionTest 7개 및 checksum/notes tests 통과. signed/unsigned/부분 서명/게시 토큰 부재, 서명 및 signature 검증, checksum·attestation·정확한 ZIP 게시 gate와 archive rebuild 방지 assertions 유지 |
| 6. workflow 자체 회귀 검출 | 실제 workflow를 읽어 입력 경계만 직접 표현식 삽입으로 바꾼 in-memory mutant를 같은 실행기에 전달. 무해한 printf 치환 발생을 확인하고 원문 거부 assertion이 실패함을 검증. 원격 태그·credentials·네트워크 없는 테스트 |

전후 예시: 이전 직접 삽입 경계에서는 위 태그가 verifier 도달 전에 `vTAG_COMMAND_EXECUTED`로 바뀝니다. 변경 후에는 `v$(printf${IFS}TAG_COMMAND_EXECUTED)` 그대로 형식 오류로 거부되며 downstream outputs가 생기지 않습니다. 정상 `v1.5.0`은 `version=1.5.0`, `tag=v1.5.0`을 기록합니다.

검증한 최종 소스 SHA: `a7251a4f7ab507f169dad1b614d1766dd9447252`. Base: `aef13d78b406d9ab4f8259cad294375883654156`. 브랜치: `codex/issue-98-safe-release-input`. Worktree: `/Users/van/.codex/worktrees/bab1/copy-selection-context`. 커밋 전 동일한 최종 소스로 아래 검증을 실행했고 이후 코드 변경은 없습니다.

실행 환경: macOS 26.6.2 (25G83), arm64; Homebrew OpenJDK 21.0.12.1; Gradle 9.7.1. IDE fixture 대상은 IC 2024.3 (243.21565.193), 해당 번들 runtime의 release 파일은 JBR 21.0.5+8-b631.16입니다. worker별 java.home은 별도로 계측하지 않았습니다.

실행 명령:

```bash
JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew detekt allTests koverXmlReport koverHtmlReport --continue --stacktrace --console=plain
actionlint .github/workflows/release.yml
bash -n scripts/verify-release-version.sh
git diff --check
```

결과: 모두 성공. Gradle exit 0, BUILD SUCCESSFUL 1m4s, 23 tasks executed. XML 기준 일반 테스트 367개/34 suites, platformTest 42개/5 suites, 총 409개, failures/errors/skips 모두 0. 관련 suite는 ReleaseVersionParityTest 11, CiWorkflowTest 17, ReleaseArtifactSelectionTest 7, ReleaseNotesGenerationTest 2, ReleaseChecksumGenerationTest 2, ReleaseDocumentationTest 4개입니다. 기존 fixture deprecation/CDS 경고는 남아 있습니다. Detekt 및 Kover XML/HTML 생성 완료. 로컬 로그 `/private/tmp/csc-98-gradle.log`, 보고서 `build/test-results/{test,platformTest}/`, `build/reports/{detekt,kover}/`에 보존했습니다.

직접 검토: actionlint로 YAML/Actions 문법 검사, 실제 YAML 구조와 단계별 env·검증/서명/checksum/attestation/publication 순서 검토 완료. 재현은 위 테스트의 실제 workflow shell boundary에서 수행했습니다. GUI 수동 동작·OS별 IDE 기능 검증은 수행하지 않았으며 fixture 성공을 GUI 검증으로 대체하지 않습니다. 로컬 Plugin Verifier는 미실행이며 아래 PR CI에서 성공했습니다. 실제 signing credentials 사용, 원격 tag push, Release 생성, attestation 발급/게시, Marketplace 게시도 실행하지 않았습니다. 버전·태그·출시 artifact 정책은 변경하지 않았습니다.

CI: [Build run 34182604688](https://github.com/hon454/copy-selection-context/actions/runs/34182604688) **SUCCESS**, 최종 SHA `a7251a4f7ab507f169dad1b614d1766dd9447252`, build job 7m41s. Ubuntu 24.04.4 LTS x64, Zulu JDK 21.0.12+8, Gradle 9.7.1에서 Detekt, allTests/coverage, project/structure, Plugin Verifier, ZIP build 및 artifact upload 모두 통과했습니다. Verifier 로그가 IC 2024.3 번들 JBR 경로 사용을 확인하며 IC-243.28141.41, IC-251.29188.72, IC-252.28539.97 모두 `Compatible`입니다.

CI의 추가 실행 명령:

```bash
./gradlew verifyPluginProjectConfiguration verifyPluginStructure --stacktrace --console=plain
./gradlew verifyPlugin --stacktrace --console=plain
./gradlew buildPlugin --stacktrace --console=plain
```

별도 검토는 조율자가 `gpt-6-astra` / `high`로 배정합니다. 로컬 증거 사본과 최종 소스 SHA-256 목록은 `build/evidence/issue-98/`에 보존했습니다. 실제 릴리스 workflow는 실행하지 않았으며 이 CI의 ZIP은 검증용 산출물입니다.

위임 설정 근거: 조율자가 이 구현 task 생성 시 `create_thread`의 구조화 인수 `model="gpt-6-astra"`, `thinking="high"`를 전달하고 성공 응답을 받았음을 확인했습니다. 실행 task ID는 `01a07ef7-8095-75b0-94d0-d1764c8dc701`, 조율 task ID는 `01a07ef4-e7e1-7f23-bb36-0a8d03641be6`입니다. 이는 생성·실행 수락 증거이며 모델 내부 런타임을 독립 계측했다는 주장은 아닙니다.

