### PR TITLE
fix(analytics): disable roaming for usage counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Honor the last branch remote value from ordered Git config includes when selecting permalink remotes (#105)
 
+### Changed
+
+- Explicitly keep opt-in usage counters in non-roaming IDE storage while preserving existing analytics state compatibility (#107)
+
 ## [1.5.0] - 2026-09-06
 
 ### Added

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionAnalytics.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionAnalytics.kt
@@ -2,19 +2,23 @@ package com.github.hon454.copyselectioncontext
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.RoamingType
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import java.util.Collections
 
 @Service(Service.Level.APP)
-@State(name = "CopySelectionAnalytics", storages = [Storage("copySelectionAnalytics.xml")])
+@State(
+    name = "CopySelectionAnalytics",
+    storages = [Storage("copySelectionAnalytics.xml", roamingType = RoamingType.DISABLED)],
+)
 class CopySelectionAnalytics : PersistentStateComponent<CopySelectionAnalytics.State> {
 
     data class State(
         var totalCopyCount: Int = 0,
-        val formatUsage: MutableMap<String, Int> = mutableMapOf(),
-        val languageUsage: MutableMap<String, Int> = mutableMapOf()
+        var formatUsage: MutableMap<String, Int> = mutableMapOf(),
+        var languageUsage: MutableMap<String, Int> = mutableMapOf(),
     )
 
     data class Snapshot(

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionAnalyticsTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionAnalyticsTest.kt
@@ -1,10 +1,23 @@
 package com.github.hon454.copyselectioncontext
 
+import com.intellij.openapi.components.RoamingType
+import com.intellij.openapi.components.State
+import com.intellij.util.xmlb.XmlSerializer
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import kotlin.concurrent.thread
 
 class CopySelectionAnalyticsTest {
+
+    @Test
+    fun `analytics storage is explicitly local and keeps its established identity`() {
+        val annotation = requireNotNull(CopySelectionAnalytics::class.java.getAnnotation(State::class.java))
+
+        assertEquals("CopySelectionAnalytics", annotation.name)
+        assertEquals(1, annotation.storages.size)
+        assertEquals("copySelectionAnalytics.xml", annotation.storages.single().value)
+        assertEquals(RoamingType.DISABLED, annotation.storages.single().roamingType)
+    }
 
     @Test
     fun `default state has zero copy count`() {
@@ -90,6 +103,30 @@ class CopySelectionAnalyticsTest {
         assertEquals(3, analytics.snapshot().totalCopyCount)
         assertEquals(mapOf("claude" to 2, "pathline" to 1), analytics.snapshot().formatUsage)
         assertEquals(mapOf("kotlin" to 3), analytics.snapshot().languageUsage)
+    }
+
+    @Test
+    fun `existing serialized analytics counters load without data loss`() {
+        val existingState = CopySelectionAnalytics.State(
+            totalCopyCount = 3,
+            formatUsage = mutableMapOf("claude" to 2, "pathline" to 1),
+            languageUsage = mutableMapOf("kotlin" to 3),
+        )
+        val serialized = XmlSerializer.serialize(existingState)
+        val restoredState = CopySelectionAnalytics.State()
+        XmlSerializer.deserializeInto(restoredState, serialized)
+        val analytics = CopySelectionAnalytics()
+
+        analytics.loadState(restoredState)
+
+        assertEquals(
+            CopySelectionAnalytics.Snapshot(
+                totalCopyCount = 3,
+                formatUsage = mapOf("claude" to 2, "pathline" to 1),
+                languageUsage = mapOf("kotlin" to 3),
+            ),
+            analytics.snapshot(),
+        )
     }
 
     @Test

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionAnalyticsTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionAnalyticsTest.kt
@@ -2,6 +2,7 @@ package com.github.hon454.copyselectioncontext
 
 import com.intellij.openapi.components.RoamingType
 import com.intellij.openapi.components.State
+import com.intellij.openapi.util.JDOMUtil
 import com.intellij.util.xmlb.XmlSerializer
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -107,14 +108,8 @@ class CopySelectionAnalyticsTest {
 
     @Test
     fun `existing serialized analytics counters load without data loss`() {
-        val existingState = CopySelectionAnalytics.State(
-            totalCopyCount = 3,
-            formatUsage = mutableMapOf("claude" to 2, "pathline" to 1),
-            languageUsage = mutableMapOf("kotlin" to 3),
-        )
-        val serialized = XmlSerializer.serialize(existingState)
         val restoredState = CopySelectionAnalytics.State()
-        XmlSerializer.deserializeInto(restoredState, serialized)
+        XmlSerializer.deserializeInto(restoredState, JDOMUtil.load(LEGACY_ANALYTICS_STATE_XML))
         val analytics = CopySelectionAnalytics()
 
         analytics.loadState(restoredState)
@@ -130,13 +125,30 @@ class CopySelectionAnalyticsTest {
     }
 
     @Test
+    fun `legacy analytics XML fixture keeps the established state layout`() {
+        val currentState = CopySelectionAnalytics.State(
+            totalCopyCount = 3,
+            formatUsage = mutableMapOf("claude" to 2, "pathline" to 1),
+            languageUsage = mutableMapOf("kotlin" to 3),
+        )
+
+        assertEquals(
+            LEGACY_ANALYTICS_STATE_XML,
+            JDOMUtil.writeElement(XmlSerializer.serialize(currentState)),
+        )
+    }
+
+    @Test
     fun `reset state remains empty after persistence reload`() {
         val analytics = CopySelectionAnalytics()
         analytics.recordCopy("template", "typescript")
         analytics.reset()
+        val persistedState = XmlSerializer.serialize(analytics.state)
+        val restoredState = CopySelectionAnalytics.State()
+        XmlSerializer.deserializeInto(restoredState, persistedState)
 
         val reloaded = CopySelectionAnalytics()
-        reloaded.loadState(analytics.state)
+        reloaded.loadState(restoredState)
 
         assertEquals(CopySelectionAnalytics.Snapshot(0, emptyMap(), emptyMap()), reloaded.snapshot())
     }
@@ -161,5 +173,24 @@ class CopySelectionAnalyticsTest {
     fun `analyticsEnabled defaults to false in settings`() {
         val settings = CopySelectionSettings.State()
         assertFalse(settings.analyticsEnabled)
+    }
+
+    private companion object {
+        val LEGACY_ANALYTICS_STATE_XML = """
+            <State>
+              <option name="formatUsage">
+                <map>
+                  <entry key="claude" value="2" />
+                  <entry key="pathline" value="1" />
+                </map>
+              </option>
+              <option name="languageUsage">
+                <map>
+                  <entry key="kotlin" value="3" />
+                </map>
+              </option>
+              <option name="totalCopyCount" value="3" />
+            </State>
+        """.trimIndent()
     }
 }


### PR DESCRIPTION
## Summary

Explicitly mark analytics storage as non-roaming while retaining the established application component name, `copySelectionAnalytics.xml` filename, and counter field names. Make the mutable counter maps writable by the IntelliJ XML deserializer, so existing persisted format/language maps are restored during a real serializer load.

Closes #107.

## Acceptance criteria evidence

- `CopySelectionAnalytics` now declares exactly one `copySelectionAnalytics.xml` storage with `RoamingType.DISABLED`; a focused annotation regression test also asserts the established component name and filename.
- The existing `totalCopyCount`, `formatUsage`, and `languageUsage` state shape remains unchanged. A literal legacy XML fixture containing `claude=2`, `pathline=1`, and `kotlin=3` is loaded by `XmlSerializer.deserializeInto`; a separate serializer-shape assertion prevents format drift, without a migration or a second storage.
- Existing unit coverage passes for default opt-in (`false`), actual XML serialize → deserialize → load after reset, synchronized concurrent increments, and detached immutable snapshots.
- No publisher, clipboard coordinator, analytics accounting policy, review, history, gutter, or network behavior changed.
- The changelog describes the policy clarification only; it does not claim that data was previously transmitted or that OS/external backups are controlled.

## Before / after

Before, the analytics `Storage("copySelectionAnalytics.xml")` used the platform default roaming policy. Targeted raw IntelliJ XML deserialization also showed that the immutable `val` map properties could not be populated on a fresh state instance.

After, the exact same component, filename, fields, and counter values use `Storage(..., roamingType = RoamingType.DISABLED)`; writable map properties preserve the existing XML representation while allowing its format/language counters to reload.

## Verification

Environment:

- macOS 26.6.2 (25G83)
- Gradle JVM: Homebrew OpenJDK 21.0.12.1 at `/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home`
- IntelliJ Platform test runtime: bundled JBR `21.0.5+8-b631.16-jcef` at the IDEA 2024.3 test distribution path

Executed successfully:

```text
JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew test --tests com.github.hon454.copyselectioncontext.CopySelectionAnalyticsTest detekt --no-daemon
# 14 analytics tests passed; Detekt reported 0 findings.

JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew allTests --no-daemon
# BUILD SUCCESSFUL in 57s.

JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew buildPlugin --no-daemon
# BUILD SUCCESSFUL in 11s.
```

Packaged artifact:

```text
build/distributions/copy-selection-context-1.5.0.zip
SHA-256 41a307a297f4001fc91dfecc28f05b513772ecc22d6186d6cbc86ced48a1ec98
```

Manual first-run/restart verification passed separately in the coordinator's isolated IntelliJ 2025.2 session (IC252.28539.97, JBR 21.0.9+10-b1038.78-jcef): default counters and opt-in were false; one enabled standard copy yielded Total 1 / `pathline` 1 / `markdown` 1 and survived restart; confirmed reset returned all counters and opt-in to defaults after restart. Evidence: `build/evidence/issue-107/manual/{settings-enabled.xml,after-copy-restart.xml}`. This GUI result is recorded separately from fixture tests.

Final commit: `94bcce5d70e615c4ca57315e55f2e47f822a318c`
