### PR TITLE
test(release): derive assertions from canonical version

### DIFF
--- a/scripts/verify-release-version.sh
+++ b/scripts/verify-release-version.sh
@@ -31,6 +31,11 @@ fi
 canonical_version="$(printf '%s\n' "$version_lines" | sed -E 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/')"
 tag_version="${release_tag#v}"
 
+if [[ ! "$canonical_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "::error::Canonical version must use <major>.<minor>.<patch>: $canonical_version" >&2
+  exit 1
+fi
+
 if [[ "$canonical_version" != "$tag_version" ]]; then
   echo "::error::Version mismatch: tag=$tag_version, $build_file=$canonical_version" >&2
   exit 1

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -115,7 +115,10 @@ class ReleaseVersionParityTest {
 
     @Test
     fun `workflow rejects missing mismatched and malformed tags without outputs`(@TempDir tempDir: Path) {
-        listOf("", "v9.9.9", "3.14.1", "v3.14.1-rc.1").forEachIndexed { index, tag ->
+        val version = canonicalVersion(projectRoot.resolve("build.gradle.kts"))
+        val invalidTags = listOf("", "v${differentSemanticVersion(version)}", "3.14.1", "v3.14.1-rc.1")
+
+        invalidTags.forEachIndexed { index, tag ->
             val result = runWorkflowVersionBoundary(tag, tempDir.resolve(index.toString()))
 
             assertEquals(1, result.exitCode, result.output)
@@ -172,6 +175,11 @@ class ReleaseVersionParityTest {
     private fun writeCanonicalBuildFile(path: Path, version: String): Path {
         Files.writeString(path, "version = \"$version\"")
         return path
+    }
+
+    private fun differentSemanticVersion(version: String): String {
+        val (major, minor, patch) = version.split('.').map(String::toInt)
+        return "$major.$minor.${patch + 1}"
     }
 
     private fun runVerifier(tag: String, buildFile: Path? = null): CommandResult {

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/ReleaseVersionParityTest.kt
@@ -15,8 +15,10 @@ class ReleaseVersionParityTest {
     private val verifier = projectRoot.resolve("scripts/verify-release-version.sh")
 
     @Test
-    fun `canonical project version is 1_5_0`() {
-        assertEquals("1.5.0", canonicalVersion(projectRoot.resolve("build.gradle.kts")))
+    fun `canonical project version uses supported semantic version format`() {
+        val version = canonicalVersion(projectRoot.resolve("build.gradle.kts"))
+
+        assertTrue(version.matches(SEMVER), version)
     }
 
     @Test
@@ -29,21 +31,40 @@ class ReleaseVersionParityTest {
 
     @Test
     fun `verifier accepts the tag matching the canonical version`() {
-        val result = runVerifier("v${canonicalVersion(projectRoot.resolve("build.gradle.kts"))}")
+        val version = canonicalVersion(projectRoot.resolve("build.gradle.kts"))
+        val result = runVerifier("v$version")
 
         assertEquals(0, result.exitCode, result.output)
-        assertTrue(result.output.contains("Version verified: v1.5.0"), result.output)
+        assertTrue(result.output.contains("Version verified: v$version"), result.output)
     }
 
     @Test
-    fun `verifier rejects mismatched and malformed tags`() {
-        val mismatch = runVerifier("v9.9.9")
-        val malformed = runVerifier("1.1.0")
+    fun `verifier accepts matching tags for independent normal semantic version fixtures`(@TempDir tempDir: Path) {
+        listOf("2.17.3", "7.24.8").forEachIndexed { index, version ->
+            val buildFile = writeCanonicalBuildFile(tempDir.resolve("build-$index.gradle.kts"), version)
+            val result = runVerifier("v$version", buildFile)
+
+            assertEquals(0, result.exitCode, result.output)
+            assertTrue(result.output.contains("Version verified: v$version"), result.output)
+        }
+    }
+
+    @Test
+    fun `verifier rejects mismatched malformed tag and malformed canonical version`(@TempDir tempDir: Path) {
+        val buildFile = writeCanonicalBuildFile(tempDir.resolve("mismatch.gradle.kts"), "4.12.6")
+        val mismatch = runVerifier("v4.12.7", buildFile)
+        val malformedTag = runVerifier("4.12.6", buildFile)
+        val malformedCanonical = runVerifier(
+            "v4.12.6",
+            writeCanonicalBuildFile(tempDir.resolve("malformed.gradle.kts"), "4.12.6-rc.1"),
+        )
 
         assertEquals(1, mismatch.exitCode, mismatch.output)
         assertTrue(mismatch.output.contains("Version mismatch"), mismatch.output)
-        assertEquals(1, malformed.exitCode, malformed.output)
-        assertTrue(malformed.output.contains("must use v<major>.<minor>.<patch>"), malformed.output)
+        assertEquals(1, malformedTag.exitCode, malformedTag.output)
+        assertTrue(malformedTag.output.contains("must use v<major>.<minor>.<patch>"), malformedTag.output)
+        assertEquals(1, malformedCanonical.exitCode, malformedCanonical.output)
+        assertTrue(malformedCanonical.output.contains("Canonical version must use <major>.<minor>.<patch>"), malformedCanonical.output)
     }
 
     @Test
@@ -94,7 +115,7 @@ class ReleaseVersionParityTest {
 
     @Test
     fun `workflow rejects missing mismatched and malformed tags without outputs`(@TempDir tempDir: Path) {
-        listOf("", "v9.9.9", "1.5.0", "v1.5.0-rc.1").forEachIndexed { index, tag ->
+        listOf("", "v9.9.9", "3.14.1", "v3.14.1-rc.1").forEachIndexed { index, tag ->
             val result = runWorkflowVersionBoundary(tag, tempDir.resolve(index.toString()))
 
             assertEquals(1, result.exitCode, result.output)
@@ -146,6 +167,11 @@ class ReleaseVersionParityTest {
     private fun canonicalVersion(buildFile: Path): String {
         val match = Regex("(?m)^\\s*version\\s*=\\s*\"([^\"]+)\"").find(Files.readString(buildFile))
         return requireNotNull(match) { "Canonical version declaration not found in $buildFile" }.groupValues[1]
+    }
+
+    private fun writeCanonicalBuildFile(path: Path, version: String): Path {
+        Files.writeString(path, "version = \"$version\"")
+        return path
     }
 
     private fun runVerifier(tag: String, buildFile: Path? = null): CommandResult {
@@ -227,4 +253,8 @@ class ReleaseVersionParityTest {
         }
 
     private data class WorkflowResult(val exitCode: Int, val output: String, val outputs: Map<String, String>)
+
+    private companion object {
+        val SEMVER = Regex("[0-9]+\\.[0-9]+\\.[0-9]+")
+    }
 }


### PR DESCRIPTION
## Summary

Derive release-version expectations from `build.gradle.kts` instead of the current project release string, while retaining the release workflow injection-boundary regression coverage added by #98.

## Acceptance evidence

1. The checked-in canonical version and success output are calculated at test time; no current release literal remains in those assertions.
2. The runtime version resource parity test remains and compares `CopySelectionReviewService().currentPluginVersion()` with the canonical Gradle value.
3. Temporary independent normal SemVer build fixtures `2.17.3` and `7.24.8` each accept their corresponding tags.
4. Independent `4.12.6` / `v4.12.7` mismatch, malformed tag, malformed canonical version, and duplicate canonical declaration fixtures fail. The verifier now rejects a malformed canonical declaration explicitly.
5. Workflow-boundary mismatch input derives a distinct valid SemVer by incrementing the canonical patch, so it cannot accidentally become valid after a future project version bump.
6. A future release bump changes the canonical source only; tests derive their expected tag and success message from it.
7. This branch does not modify `build.gradle.kts` or `CHANGELOG.md`.

The #98 workflow input-boundary, literal command-substitution rejection, and unsafe-workflow-mutation assertions are unchanged.

## Before / after

- Before: canonical test and success message expected `1.5.0` / `v1.5.0`; a workflow mismatch case could match a future `9.9.9` project version.
- After: current expectations derive the canonical value; temporary fixture inputs prove `v2.17.3` and `v7.24.8`, while every workflow mismatch is derived to differ from the canonical value.

## Verification

- Final head: `74faab345cd79aba992c62e0fed972363647d002`.
- macOS 26.6.2 (25G83); JDK: Homebrew OpenJDK 21.0.12.1 at `/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home`. JBR/GUI: not used; this is a non-GUI pure test.
- PASS on final head: `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew test --tests com.github.hon454.copyselectioncontext.ReleaseVersionParityTest` — 12 tests, 0 failures, 0 errors; BUILD SUCCESSFUL in 4s.
- PASS: `git diff --check`, `bash -n scripts/verify-release-version.sh`, and direct verifier checks for the actual version, `v2.17.3`, and malformed canonical `4.12.6-rc.1`.
- CI: PASS on final head — GitHub Build run [34184343512](https://github.com/hon454/copy-selection-context/actions/runs/34184343512).
- No GUI validation is required by #99 and none was performed.