### PR TITLE
chore(release): prepare v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-09-08
+
 ### Fixed
 
 - Preserve CommonMark closing fences indented by up to three spaces inside built-in copied code blocks (#97)
 - Honor the last branch remote value from ordered Git config includes when selecting permalink remotes (#105)
 - Keep standard copy, history, and Git permalink actions available while IDE indexing is in progress (#106)
+- Pass release tags safely to validation and restrict signing and publishing secrets to their required steps (#98)
 
 ### Changed
 
 - Explicitly keep opt-in usage counters in non-roaming IDE storage while preserving existing analytics state compatibility (#107)
+- Derive release version checks from canonical metadata so future version updates do not require hardcoded test changes (#99)
+- Document Windows Bash prerequisites and synchronize Context Collection guidance across all five README languages (#100, #101)
 
 ## [1.5.0] - 2026-09-06
 
@@ -184,7 +189,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toast notifications
 - IntelliJ Platform 2024.3+ compatibility
 
-[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.4.1...HEAD
+[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/hon454/copy-selection-context/compare/v1.5.0...v1.5.1
+[1.5.0]: https://github.com/hon454/copy-selection-context/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/hon454/copy-selection-context/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/hon454/copy-selection-context/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/hon454/copy-selection-context/compare/v1.3.0...v1.3.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.github.hon454"
-version = "1.5.0"
+version = "1.5.1"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Summary

Prepare v1.5.1 from the completed milestone at main `11edb3bae0fa01644016f395cc9826ec2b1b9b5c`. Set the canonical Gradle version to 1.5.1 and move the accumulated changes into a dated changelog section, including all eight milestone issues and corrected comparison links. Historical release prose is preserved.

The user explicitly requested the v1.5.1 release. After this preparation commit is reviewed, passes CI and reaches main, the annotated v1.5.1 tag will trigger the existing Release workflow. That workflow owns the canonical signed ZIP, checksum/provenance verification, GitHub Release and conditional Marketplace upload.

## Verification

- Ran `patchChangelog` and the same `generate-release-notes.sh 1.5.1 v1.5.1` path as the Release workflow; the output contains only the intended v1.5.1 changes.
- Focused `ReleaseVersionParityTest`, `ReleaseDocumentationTest` and `CiWorkflowTest` passed with the new version.
- Full `detekt allTests koverXmlReport koverHtmlReport verifyPluginProjectConfiguration verifyPluginStructure verifyPlugin buildPlugin` verification passed using Homebrew OpenJDK21.0.12.1 on macOS26.6.2 arm64.
- No product code, workflow policy, default shortcuts or localized README behavior changed in this release preparation.

The milestone's actual GUI and independent review evidence is recorded in [the final integration report](https://github.com/hon454/copy-selection-context/pull/118#issuecomment-5579719489). This metadata-only preparation does not claim a new manual GUI test run.
