### PR TITLE
chore(release): prepare 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-09-08
+
 ### Fixed
 
 - Validate permalink paths and current editor content against the original local HEAD, block absent or unverifiable targets, and confirm changed files once with Cancel as the default; use bounded system Git queries without implicit fetches or helpers (#110)
+- Report clipboard write failures for standard copies, Git permalinks, collection Copy All, history and status re-copy even when success notifications are disabled, while suppressing duplicate, superseded and disposed-request errors without retrying (#109)
+- Prepare Context Collection preview geometry in the background and render visible text fragments so long bidirectional lines remain responsive without truncating display, selection, or copying (#103)
 
 ### Changed
 
@@ -18,12 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
-- Skip source-status scans, state allocation and EDT scheduling for unrelated document changes in context collections while preserving file and ancestor move/delete detection.
-
-### Fixed
-
-- Report clipboard write failures for standard copies, Git permalinks, collection Copy All, history and status re-copy even when success notifications are disabled, while suppressing duplicate, superseded and disposed-request errors without retrying.
-- Prepare Context Collection preview geometry in the background and render visible text fragments so long bidirectional lines remain responsive without truncating display, selection, or copying (#103)
+- Skip source-status scans, state allocation and EDT scheduling for unrelated document changes in context collections while preserving file and ancestor move/delete detection (#104)
 
 ## [1.5.1] - 2026-09-08
 
@@ -207,7 +206,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toast notifications
 - IntelliJ Platform 2024.3+ compatibility
 
-[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/hon454/copy-selection-context/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/hon454/copy-selection-context/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/hon454/copy-selection-context/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/hon454/copy-selection-context/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/hon454/copy-selection-context/compare/v1.4.0...v1.4.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "com.github.hon454"
-version = "1.5.1"
+version = "1.6.0"
 
 data class PluginVerificationTarget(
     val label: String,


### PR DESCRIPTION
v1.6.0 게시를 위해 Gradle 버전을 1.6.0으로 올리고, 완료된 여섯 변경을 2026-09-08 릴리스 항목으로 확정합니다. 중복된 Fixed 제목을 합치고 #104/#109 참조를 추가했으며, 기존 릴리스 기록은 보존했습니다.

검증:
- JDK 21에서 공식 `patchChangelog` 실행 성공. 이전 버전의 불필요한 자동 재서식은 제외했습니다.
- `verify-release-version.sh v1.6.0` 및 실제 `generate-release-notes.sh` 실행 성공; 생성된 노트에 여섯 항목이 모두 포함됩니다.
- `git diff --check` 통과. 변경은 `build.gradle.kts` 버전 한 줄과 `CHANGELOG.md`뿐입니다.
- 기반 main `6be7587e5a6f51934fe98d55afa0e8dc71f4d981`: [최종 CI](https://github.com/hon454/copy-selection-context/actions/runs/34218616678), [동일 tree의 3OS/3IDE 검증](https://github.com/hon454/copy-selection-context/actions/runs/34217295027) 성공. OS별 529 tests 통과.
- 제품 동작 변경이 없으므로 완료된 GUI/성능 검증을 재사용합니다. 수동 재현 절차는 플러그인 설치 → 표준/멀티캐럿 복사 → permalink 변경 파일 확인/취소 → collection Copy All 및 긴 양방향 텍스트 미리보기 → history/status 재복사입니다. 이번 메타데이터 변경에서 GUI를 새로 실행하지 않았습니다.

이 PR의 Build CI 통과 후 정상 병합하고, 병합 커밋의 CI 성공을 확인한 뒤 v1.6.0 태그를 게시합니다. 태그 Release workflow가 3OS 테스트와 Linux IDE 검증을 다시 수행하고, 검증·서명·checksum·provenance를 통과한 canonical ZIP으로 GitHub Release 및 설정 조건에 따른 Marketplace 게시를 수행합니다.
