### PR TITLE
feat(shortcuts): add shared g-prefix defaults

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -101,7 +101,7 @@ The implementation uses the flat package `com.github.hon454.copyselectioncontext
 | `ContextCollectionTextNavigation.kt` | Cached line-boundary actions that avoid native per-character Home/End and line-selection scans |
 | `ContextCollectionPanel.kt` | Keyboard-accessible collection management consuming shared snapshots/output/copy |
 | `ContextCollectionToolWindowFactory.kt` / `ToolWindowFactoryAdapter.java` | Lazy right tool window with one non-closeable content and its disposable; public Java adapter avoids Kotlin bridges to internal platform defaults |
-| `ShowContextCollectionAction.kt` | No-editor, assignable localized open action with no default shortcut |
+| `ShowContextCollectionAction.kt` | No-editor, assignable localized open action using the shared G-prefix default |
 | `ContextCollectionItem.kt` | Immutable captures, source locations, snapshots and typed add results |
 | `ContextCollectionStore.kt` | Pure bounded capture transaction and session mutation engine |
 | `ContextCollectionService.kt` | Project-only session service and editor capture adapter |
@@ -122,6 +122,7 @@ The implementation uses the flat package `com.github.hon454.copyselectioncontext
 | `CopySelectionBundle.kt` | Localized message lookup through the public class-aware `DynamicBundle` constructor |
 | `CopySelectionConfigurable.kt` | Tools settings UI, multiline template editor, preview, validation, and local analytics controls |
 | `CopySelectionContextAction.kt` | Settings-driven primary action |
+| `CopySelectionShortcuts.kt` | Shared nine-command G-prefix defaults and active-keymap lineage selection |
 | `CopySelectionGutterIconRenderer.kt` | Gutter icon and safe tooltip preview |
 | `CopySelectionHighlighter.kt` | Editor-scoped multi-range gutter marker lifecycle |
 | `CopySelectionNotifier.kt` | Settings-aware success, guarded clipboard-failure and localized permalink-failure balloons |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,6 +131,7 @@ changelog {
 }
 
 val platformStateTestClasses = listOf(
+    "com.github.hon454.copyselectioncontext.CopySelectionShortcutFixtureTest",
     "com.github.hon454.copyselectioncontext.ContextCollectionSourceFixtureTest",
     "com.github.hon454.copyselectioncontext.ClipboardFailureFixtureTest",
     "com.github.hon454.copyselectioncontext.GitPermalinkFixtureTest",

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcuts.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcuts.kt
@@ -1,0 +1,69 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.actionSystem.KeyboardShortcut
+import com.intellij.openapi.keymap.Keymap
+import com.intellij.openapi.keymap.KeymapManager
+import com.intellij.openapi.util.SystemInfo
+import javax.swing.KeyStroke
+
+/** Shared source of truth for the plugin's assignable commands and defaults. */
+internal object CopySelectionShortcuts {
+    val commands: Map<String, String> = linkedMapOf(
+        "CopySelectionContext.Copy" to "C",
+        "CopySelectionContext.ShowHistory" to "H",
+        "CopySelectionContext.AddToCollection" to "A",
+        "CopySelectionContext.ShowCollection" to "O",
+        "CopySelectionContext.CopyAllCollection" to "F",
+        "CopySelectionContext.CopyRelativePath" to "R",
+        "CopySelectionContext.CopyAbsolutePath" to "P",
+        "CopySelectionContext.CopyWithCodeContent" to "B",
+        "CopySelectionContext.CopyGitPermalink" to "L",
+    )
+
+    val macKeymapIds: Set<String> = linkedSetOf(
+        "Mac OS X",
+        "Mac OS X 10.5+",
+        "macOS System Shortcuts",
+        "Visual Studio OSX",
+        "ReSharper OSX",
+        "VSCode OSX",
+        "Visual Assist OSX",
+        "Sublime Text (Mac OS X)",
+    )
+
+    fun defaultShortcuts(mac: Boolean): Map<String, KeyboardShortcut> {
+        val prefix = KeyStroke.getKeyStroke(if (mac) MAC_PREFIX else DEFAULT_PREFIX)
+        return commands.mapValues { (_, secondKey) ->
+            KeyboardShortcut(prefix, KeyStroke.getKeyStroke(secondKey))
+        }
+    }
+
+    fun defaultShortcuts(
+        keymap: Keymap?,
+        macHost: Boolean = SystemInfo.isMac,
+    ): Map<String, KeyboardShortcut> = defaultShortcuts(usesMacKeymap(keymap, macHost))
+
+    fun activeDefaultShortcuts(
+        keymapManager: KeymapManager = KeymapManager.getInstance(),
+        macHost: Boolean = SystemInfo.isMac,
+    ): Map<String, KeyboardShortcut> = defaultShortcuts(keymapManager.activeKeymap, macHost)
+
+    fun usesMacKeymap(
+        keymap: Keymap?,
+        macHost: Boolean = SystemInfo.isMac,
+    ): Boolean {
+        val visited = mutableSetOf<Keymap>()
+        var current = keymap
+        while (current != null && visited.add(current)) {
+            when (current.name) {
+                in macKeymapIds -> return true
+                KeymapManager.DEFAULT_IDEA_KEYMAP -> return false
+            }
+            current = current.parent
+        }
+        return macHost
+    }
+
+    private const val DEFAULT_PREFIX = "control alt shift G"
+    private const val MAC_PREFIX = "meta alt shift G"
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -79,40 +79,124 @@ Source and issue tracker: <a href="https://github.com/hon454/copy-selection-cont
             <action id="CopySelectionContext.Copy"
                     class="com.github.hon454.copyselectioncontext.CopySelectionContextAction"
                     icon="/icons/copyContext.svg">
-                <keyboard-shortcut keymap="$default" first-keystroke="control alt C"/>
-                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt C" replace-all="true"/>
-                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt C" replace-all="true"/>
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="C"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
             </action>
 
             <separator/>
 
             <action id="CopySelectionContext.ShowHistory"
                     class="com.github.hon454.copyselectioncontext.ShowCopyHistoryAction">
-                <keyboard-shortcut keymap="$default" first-keystroke="control alt H"/>
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="H"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
             </action>
 
             <action id="CopySelectionContext.ShowCollection"
-                    class="com.github.hon454.copyselectioncontext.ShowContextCollectionAction"/>
+                    class="com.github.hon454.copyselectioncontext.ShowContextCollectionAction">
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="O"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
+            </action>
             <action id="CopySelectionContext.CopyAllCollection"
-                    class="com.github.hon454.copyselectioncontext.CopyAllContextCollectionAction"/>
+                    class="com.github.hon454.copyselectioncontext.CopyAllContextCollectionAction">
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="F"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
+            </action>
             <action id="CopySelectionContext.AddToCollection"
-                    class="com.github.hon454.copyselectioncontext.AddToContextCollectionAction"/>
+                    class="com.github.hon454.copyselectioncontext.AddToContextCollectionAction">
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="A"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
+            </action>
 
-            <!-- Explicit Actions (context menu only, no shortcuts) -->
+            <!-- Explicit copy actions -->
             <action id="CopySelectionContext.CopyRelativePath"
                     class="com.github.hon454.copyselectioncontext.CopyRelativePathAction"
-                    icon="/icons/copyRelative.svg"/>
+                    icon="/icons/copyRelative.svg">
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="R"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
+            </action>
 
             <action id="CopySelectionContext.CopyAbsolutePath"
                     class="com.github.hon454.copyselectioncontext.CopyAbsolutePathAction"
-                    icon="/icons/copyAbsolute.svg"/>
+                    icon="/icons/copyAbsolute.svg">
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="P"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
+            </action>
 
             <action id="CopySelectionContext.CopyWithCodeContent"
                     class="com.github.hon454.copyselectioncontext.CopyWithCodeContentAction"
-                    icon="/icons/copyWithCode.svg"/>
+                    icon="/icons/copyWithCode.svg">
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="B"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
+            </action>
 
             <action id="CopySelectionContext.CopyGitPermalink"
-                    class="com.github.hon454.copyselectioncontext.CopyGitPermalinkAction"/>
+                    class="com.github.hon454.copyselectioncontext.CopyGitPermalinkAction">
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="L"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
+            </action>
 
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>
         </group>

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcutFixtureTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcutFixtureTest.kt
@@ -1,12 +1,16 @@
 package com.github.hon454.copyselectioncontext
 
+import com.intellij.configurationStore.SchemeDataHolder
 import com.intellij.openapi.actionSystem.KeyboardShortcut
+import com.intellij.openapi.actionSystem.MouseShortcut
+import com.intellij.openapi.actionSystem.Shortcut
 import com.intellij.openapi.keymap.Keymap
 import com.intellij.openapi.keymap.KeymapManager
 import com.intellij.openapi.keymap.ex.KeymapManagerEx
 import com.intellij.openapi.keymap.impl.KeymapImpl
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import javax.swing.KeyStroke
+import org.jdom.Element
 
 class CopySelectionShortcutFixtureTest : BasePlatformTestCase() {
     fun testRegisteredDefaultsUseOneTwoStrokeShortcutPerCommand() {
@@ -84,47 +88,103 @@ class CopySelectionShortcutFixtureTest : BasePlatformTestCase() {
         assertTrue(CopySelectionShortcuts.usesMacKeymap(macChild, macHost = false))
     }
 
-    fun testDefaultInheritancePreservesOverridesUnassignedAndUnrelatedEdits() {
-        val parent = keymap("Old plugin defaults")
+    fun testPersistedUserChoicesSurviveDefaultUpgradeAcrossAllCommands() {
+        val oldParent = keymap(PARENT_NAME)
         val oldCopy = keyboard("control alt C")
         val oldHistory = keyboard("control alt H")
-        parent.addShortcut(COPY, oldCopy)
-        parent.addShortcut(HISTORY, oldHistory)
-        parent.canModify = false
+        val removedIdeShortcut = keyboard("control alt I")
+        oldParent.addShortcut(COPY, oldCopy)
+        oldParent.addShortcut(HISTORY, oldHistory)
+        oldParent.addShortcut(REMOVED_IDE_ACTION, removedIdeShortcut)
+        oldParent.canModify = false
 
-        val untouched = parent.deriveKeymap("Untouched")
-        val unrelated = parent.deriveKeymap("Unrelated edits").apply {
-            addShortcut("Unrelated.Action", keyboard("control Q"))
+        val customKeyboard = keyboard("control shift A")
+        val customMouse = MouseShortcut(2, 0, 1)
+        val mouseOnly = MouseShortcut(3, 0, 1)
+        val unrelatedKeyboard = keyboard("control Q")
+        val staged = oldParent.deriveKeymap("Persisted user keymap").apply {
+            addShortcut(ADD_TO_COLLECTION, customKeyboard)
+            addShortcut(ADD_TO_COLLECTION, customMouse)
+            addShortcut(COPY_ALL_COLLECTION, mouseOnly)
+            removeAllActionShortcuts(REMOVED_IDE_ACTION)
+            addShortcut(UNRELATED_ACTION, unrelatedKeyboard)
         }
-        val explicitlyUnassigned = parent.deriveKeymap("Explicitly unassigned").apply {
-            removeAllActionShortcuts(COPY)
-            removeAllActionShortcuts(HISTORY)
-        }
-
-        CopySelectionShortcuts.defaultShortcuts(mac = false).forEach { (actionId, shortcut) ->
-            parent.removeAllActionShortcuts(actionId)
-            parent.addShortcut(actionId, shortcut)
-        }
-        val explicitOld = parent.deriveKeymap("Explicit old defaults").apply {
-            removeAllActionShortcuts(COPY)
-            addShortcut(COPY, oldCopy)
-            removeAllActionShortcuts(HISTORY)
-            addShortcut(HISTORY, oldHistory)
+        val persisted = staged.writeScheme().apply {
+            replaceAction(COPY, oldCopy)
+            replaceAction(HISTORY, oldHistory)
+            replaceAction(SHOW_COLLECTION)
         }
 
-        assertPluginDefaults(untouched)
-        assertPluginDefaults(unrelated)
-        assertEquals(listOf(keyboard("control Q")), unrelated.getShortcuts("Unrelated.Action").toList())
-        assertContainsElements(explicitOld.getShortcuts(COPY).toList(), oldCopy)
-        assertContainsElements(explicitOld.getShortcuts(HISTORY).toList(), oldHistory)
-        assertEmpty(explicitlyUnassigned.getShortcuts(COPY).toList())
-        assertEmpty(explicitlyUnassigned.getShortcuts(HISTORY).toList())
+        val before = loadPersisted(persisted, oldParent)
+        val beforeCommands = shortcutSnapshot(before, CopySelectionShortcuts.commands.keys)
+        assertEquals(listOf(oldCopy), beforeCommands.getValue(COPY))
+        assertEquals(listOf(oldHistory), beforeCommands.getValue(HISTORY))
+        assertEquals(listOf(customKeyboard, customMouse), beforeCommands.getValue(ADD_TO_COLLECTION))
+        assertEmpty(beforeCommands.getValue(SHOW_COLLECTION))
+        assertEquals(listOf(mouseOnly), beforeCommands.getValue(COPY_ALL_COLLECTION))
+        assertEmpty(before.getShortcuts(REMOVED_IDE_ACTION).toList())
+        assertEquals(listOf(unrelatedKeyboard), before.getShortcuts(UNRELATED_ACTION).toList())
+
+        val newParent = keymap(PARENT_NAME).apply {
+            CopySelectionShortcuts.defaultShortcuts(mac = false).forEach { (actionId, shortcut) ->
+                addShortcut(actionId, shortcut)
+            }
+            addShortcut(REMOVED_IDE_ACTION, removedIdeShortcut)
+            canModify = false
+        }
+        val after = loadPersisted(persisted, newParent)
+        val afterCommands = shortcutSnapshot(after, CopySelectionShortcuts.commands.keys)
+        val explicitlyPersisted = setOf(
+            COPY,
+            HISTORY,
+            ADD_TO_COLLECTION,
+            SHOW_COLLECTION,
+            COPY_ALL_COLLECTION,
+        )
+        val expectedAfter = CopySelectionShortcuts.commands.keys.associateWith { actionId ->
+            if (actionId in explicitlyPersisted) {
+                beforeCommands.getValue(actionId)
+            } else {
+                listOf(CopySelectionShortcuts.defaultShortcuts(mac = false).getValue(actionId))
+            }
+        }
+
+        assertEquals(expectedAfter, afterCommands)
+        assertEmpty(after.getShortcuts(REMOVED_IDE_ACTION).toList())
+        assertEquals(listOf(unrelatedKeyboard), after.getShortcuts(UNRELATED_ACTION).toList())
     }
 
-    private fun assertPluginDefaults(keymap: Keymap) {
-        CopySelectionShortcuts.defaultShortcuts(mac = false).forEach { (actionId, shortcut) ->
-            assertEquals(actionId, listOf(shortcut), keymap.getShortcuts(actionId).toList())
+    private fun loadPersisted(element: Element, parent: Keymap): Keymap = PersistedKeymap(parent, element)
+
+    private fun shortcutSnapshot(keymap: Keymap, actionIds: Collection<String>): Map<String, List<Shortcut>> =
+        actionIds.associateWith { actionId -> keymap.getShortcuts(actionId).toList() }
+
+    private fun Element.replaceAction(actionId: String, vararg shortcuts: KeyboardShortcut) {
+        getChildren("action").firstOrNull { it.getAttributeValue("id") == actionId }?.let(::removeContent)
+        addContent(Element("action").setAttribute("id", actionId).apply {
+            shortcuts.forEach { shortcut ->
+                addContent(
+                    Element("keyboard-shortcut")
+                        .setAttribute("first-keystroke", shortcut.firstKeyStroke.toString()),
+                )
+            }
+        })
+    }
+
+    private class PersistedKeymap(
+        private val resolvedParent: Keymap,
+        element: Element,
+    ) : KeymapImpl(
+        object : SchemeDataHolder<KeymapImpl> {
+            override fun read(): Element = element.clone()
+        },
+    ) {
+        init {
+            name = element.getAttributeValue("name")
         }
+
+        override fun findParentScheme(parentSchemeName: String): Keymap? =
+            resolvedParent.takeIf { it.name == parentSchemeName }
     }
 
     private fun keymap(name: String) = KeymapImpl().apply { this.name = name }
@@ -132,7 +192,13 @@ class CopySelectionShortcutFixtureTest : BasePlatformTestCase() {
     private fun keyboard(stroke: String) = KeyboardShortcut(KeyStroke.getKeyStroke(stroke), null)
 
     companion object {
+        private const val PARENT_NAME = "Synthetic plugin defaults"
         private const val COPY = "CopySelectionContext.Copy"
         private const val HISTORY = "CopySelectionContext.ShowHistory"
+        private const val ADD_TO_COLLECTION = "CopySelectionContext.AddToCollection"
+        private const val SHOW_COLLECTION = "CopySelectionContext.ShowCollection"
+        private const val COPY_ALL_COLLECTION = "CopySelectionContext.CopyAllCollection"
+        private const val REMOVED_IDE_ACTION = "IntroduceConstant"
+        private const val UNRELATED_ACTION = "Unrelated.Action"
     }
 }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcutFixtureTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcutFixtureTest.kt
@@ -1,0 +1,138 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.actionSystem.KeyboardShortcut
+import com.intellij.openapi.keymap.Keymap
+import com.intellij.openapi.keymap.KeymapManager
+import com.intellij.openapi.keymap.ex.KeymapManagerEx
+import com.intellij.openapi.keymap.impl.KeymapImpl
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import javax.swing.KeyStroke
+
+class CopySelectionShortcutFixtureTest : BasePlatformTestCase() {
+    fun testRegisteredDefaultsUseOneTwoStrokeShortcutPerCommand() {
+        val manager = KeymapManager.getInstance()
+        val requiredKeymaps = listOf(
+            "\$default",
+            "Mac OS X",
+            "Mac OS X 10.5+",
+            "macOS System Shortcuts",
+            "Sublime Text (Mac OS X)",
+        )
+
+        requiredKeymaps.forEach { keymapId ->
+            val keymap = requireNotNull(manager.getKeymap(keymapId))
+            val expected = CopySelectionShortcuts.defaultShortcuts(keymap, macHost = false)
+            expected.forEach { (actionId, shortcut) ->
+                val keyboardShortcuts = keymap.getShortcuts(actionId).filterIsInstance<KeyboardShortcut>()
+                assertEquals("$keymapId / $actionId", listOf(shortcut), keyboardShortcuts)
+                assertNotNull(keyboardShortcuts.single().secondKeyStroke)
+            }
+        }
+    }
+
+    fun testKnownKeymapParentsResolveToTheirDeclaredFamilies() {
+        val manager = KeymapManager.getInstance()
+        val expectedParents = mapOf(
+            "Mac OS X" to "\$default",
+            "Mac OS X 10.5+" to "\$default",
+            "macOS System Shortcuts" to "Mac OS X 10.5+",
+            "Sublime Text (Mac OS X)" to "Mac OS X 10.5+",
+        )
+        expectedParents.forEach { (keymapId, parentId) ->
+            val keymap = requireNotNull(manager.getKeymap(keymapId))
+            assertEquals(parentId, keymap.parent?.name)
+            assertTrue(keymapId, CopySelectionShortcuts.usesMacKeymap(keymap, macHost = false))
+        }
+
+        CopySelectionShortcuts.macKeymapIds.mapNotNull(manager::getKeymap).forEach { keymap ->
+            assertTrue(keymap.name, CopySelectionShortcuts.usesMacKeymap(keymap, macHost = false))
+        }
+    }
+
+    fun testActiveKeymapLineageWinsOverTheHostOperatingSystem() {
+        val manager = KeymapManagerEx.getInstanceEx()
+        val original = manager.activeKeymap
+        val windowsKeymap = requireNotNull(manager.getKeymap("\$default"))
+        val macKeymap = requireNotNull(manager.getKeymap("Mac OS X 10.5+"))
+        try {
+            manager.setActiveKeymap(windowsKeymap)
+            assertEquals(
+                CopySelectionShortcuts.defaultShortcuts(mac = false),
+                CopySelectionShortcuts.activeDefaultShortcuts(manager, macHost = true),
+            )
+
+            manager.setActiveKeymap(macKeymap)
+            assertEquals(
+                CopySelectionShortcuts.defaultShortcuts(mac = true),
+                CopySelectionShortcuts.activeDefaultShortcuts(manager, macHost = false),
+            )
+        } finally {
+            manager.setActiveKeymap(original)
+        }
+        assertSame(original, manager.activeKeymap)
+    }
+
+    fun testUnknownIndependentKeymapUsesHostFallbackOnlyWithoutKnownLineage() {
+        val independent = keymap("Independent")
+        assertFalse(CopySelectionShortcuts.usesMacKeymap(independent, macHost = false))
+        assertTrue(CopySelectionShortcuts.usesMacKeymap(independent, macHost = true))
+
+        val windowsChild = keymap("\$default").apply { canModify = false }.deriveKeymap("Windows child")
+        assertFalse(CopySelectionShortcuts.usesMacKeymap(windowsChild, macHost = true))
+
+        val macChild = keymap("Mac OS X 10.5+").apply { canModify = false }.deriveKeymap("Mac child")
+        assertTrue(CopySelectionShortcuts.usesMacKeymap(macChild, macHost = false))
+    }
+
+    fun testDefaultInheritancePreservesOverridesUnassignedAndUnrelatedEdits() {
+        val parent = keymap("Old plugin defaults")
+        val oldCopy = keyboard("control alt C")
+        val oldHistory = keyboard("control alt H")
+        parent.addShortcut(COPY, oldCopy)
+        parent.addShortcut(HISTORY, oldHistory)
+        parent.canModify = false
+
+        val untouched = parent.deriveKeymap("Untouched")
+        val unrelated = parent.deriveKeymap("Unrelated edits").apply {
+            addShortcut("Unrelated.Action", keyboard("control Q"))
+        }
+        val explicitlyUnassigned = parent.deriveKeymap("Explicitly unassigned").apply {
+            removeAllActionShortcuts(COPY)
+            removeAllActionShortcuts(HISTORY)
+        }
+
+        CopySelectionShortcuts.defaultShortcuts(mac = false).forEach { (actionId, shortcut) ->
+            parent.removeAllActionShortcuts(actionId)
+            parent.addShortcut(actionId, shortcut)
+        }
+        val explicitOld = parent.deriveKeymap("Explicit old defaults").apply {
+            removeAllActionShortcuts(COPY)
+            addShortcut(COPY, oldCopy)
+            removeAllActionShortcuts(HISTORY)
+            addShortcut(HISTORY, oldHistory)
+        }
+
+        assertPluginDefaults(untouched)
+        assertPluginDefaults(unrelated)
+        assertEquals(listOf(keyboard("control Q")), unrelated.getShortcuts("Unrelated.Action").toList())
+        assertContainsElements(explicitOld.getShortcuts(COPY).toList(), oldCopy)
+        assertContainsElements(explicitOld.getShortcuts(HISTORY).toList(), oldHistory)
+        assertEmpty(explicitlyUnassigned.getShortcuts(COPY).toList())
+        assertEmpty(explicitlyUnassigned.getShortcuts(HISTORY).toList())
+    }
+
+    private fun assertPluginDefaults(keymap: Keymap) {
+        CopySelectionShortcuts.defaultShortcuts(mac = false).forEach { (actionId, shortcut) ->
+            assertEquals(actionId, listOf(shortcut), keymap.getShortcuts(actionId).toList())
+        }
+    }
+
+    private fun keymap(name: String) = KeymapImpl().apply { this.name = name }
+
+    private fun keyboard(stroke: String) = KeyboardShortcut(KeyStroke.getKeyStroke(stroke), null)
+
+    companion object {
+        private const val COPY = "CopySelectionContext.Copy"
+        private const val HISTORY = "CopySelectionContext.ShowHistory"
+    }
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/DocumentationSyncTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/DocumentationSyncTest.kt
@@ -88,8 +88,8 @@ class DocumentationSyncTest {
     @Test
     fun `collection copy descriptor and documentation retain output ordering contracts`() {
         val descriptor = repositoryRoot.resolve("src/main/resources/META-INF/plugin.xml").readText()
-        val action = Regex("""<action id="CopySelectionContext.CopyAllCollection"\s+class="[^"]+"\s*/>""")
-        assertTrue(action.containsMatchIn(descriptor), "Copy All must remain localized and have no default shortcut")
+        val action = Regex("""<action id="CopySelectionContext.CopyAllCollection"\s+class="[^"]+">""")
+        assertTrue(action.containsMatchIn(descriptor), "Copy All must remain localized and registered")
         val contract = repositoryRoot.resolve("docs/development/context-collection-output-contract.md").readText()
         listOf("Calculating", "BlankItem", "AboveHardLimit", "262144", "4194304", "Published(feedbackFailures)",
             "SNAPSHOT_LABELS_ABSENT", "HISTORICAL_CODE_ABSENT", "EDT", "source", "Ctrl/Cmd+C").forEach {

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/PluginDescriptorLocalizationTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/PluginDescriptorLocalizationTest.kt
@@ -72,12 +72,11 @@ class PluginDescriptorLocalizationTest {
     }
 
     @Test
-    fun `collection add is registered without a default shortcut`() {
+    fun `collection add remains registered in the copy selection group`() {
         val actions = descriptor.getElementsByTagName("action")
         val action = (0 until actions.length).map { actions.item(it) as org.w3c.dom.Element }
             .single { it.getAttribute("id") == "CopySelectionContext.AddToCollection" }
         assertEquals("com.github.hon454.copyselectioncontext.AddToContextCollectionAction", action.getAttribute("class"))
-        assertEquals(0, action.getElementsByTagName("keyboard-shortcut").length)
         assertEquals("CopySelectionContextGroup", (action.parentNode as org.w3c.dom.Element).getAttribute("id"))
     }
 
@@ -92,8 +91,46 @@ class PluginDescriptorLocalizationTest {
         val actions = descriptor.getElementsByTagName("action")
         val open = (0 until actions.length).map { actions.item(it) as org.w3c.dom.Element }
             .single { it.getAttribute("id") == "CopySelectionContext.ShowCollection" }
-        assertEquals(0, open.getElementsByTagName("keyboard-shortcut").length)
         assertEquals("CopySelectionContextGroup", (open.parentNode as org.w3c.dom.Element).getAttribute("id"))
+    }
+
+    @Test
+    fun `descriptor and shared command table declare the same g prefix defaults`() {
+        val actions = descriptor.getElementsByTagName("action")
+        val registered = (0 until actions.length)
+            .map { actions.item(it) as org.w3c.dom.Element }
+            .associateBy { it.getAttribute("id") }
+        assertEquals(CopySelectionShortcuts.commands.keys, registered.keys)
+        assertEquals(9, CopySelectionShortcuts.commands.values.toSet().size)
+
+        CopySelectionShortcuts.commands.forEach { (actionId, secondKey) ->
+            val shortcuts = registered.getValue(actionId).getElementsByTagName("keyboard-shortcut")
+            val declared = (0 until shortcuts.length)
+                .map { shortcuts.item(it) as org.w3c.dom.Element }
+                .associateBy { it.getAttribute("keymap") }
+            assertEquals(CopySelectionShortcuts.macKeymapIds + "\$default", declared.keys, actionId)
+
+            val default = declared.getValue("\$default")
+            assertEquals("control alt shift G", default.getAttribute("first-keystroke"), actionId)
+            assertEquals(secondKey, default.getAttribute("second-keystroke"), actionId)
+            assertEquals("", default.getAttribute("replace-all"), actionId)
+
+            CopySelectionShortcuts.macKeymapIds.forEach { keymapId ->
+                val mac = declared.getValue(keymapId)
+                assertEquals("meta alt shift G", mac.getAttribute("first-keystroke"), "$keymapId / $actionId")
+                assertEquals(secondKey, mac.getAttribute("second-keystroke"), "$keymapId / $actionId")
+                assertEquals("true", mac.getAttribute("replace-all"), "$keymapId / $actionId")
+            }
+        }
+
+        val shortcutXml = registered.values
+            .flatMap { action ->
+                val shortcuts = action.getElementsByTagName("keyboard-shortcut")
+                (0 until shortcuts.length).map { shortcuts.item(it) as org.w3c.dom.Element }
+            }
+        assertFalse(shortcutXml.any { it.getAttribute("second-keystroke").isEmpty() })
+        assertFalse(shortcutXml.any { it.getAttribute("first-keystroke") in setOf("control alt C", "meta alt C") })
+        assertFalse(shortcutXml.any { it.getAttribute("first-keystroke") == "control alt H" })
     }
 
     private fun descriptorPresentationKeys(properties: Properties): Set<String> =


### PR DESCRIPTION
## 요약

- 기존 충돌 가능성이 있는 단일 단축키를 아홉 액션의 공통 G-prefix 2단계 기본값으로 교체합니다.
- `CopySelectionShortcuts`에 action ID/두 번째 키 명령표, 기본 `KeyboardShortcut`, 활성 keymap parent 계보 판별을 모읍니다.
- descriptor와 실제 IntelliJ `KeymapManager` fixture가 등록값, 상속, persisted upgrade, 명시적 배정/미배정 보존, macOS에서 Windows keymap 선택을 검증합니다.

Related to #128

## 수용 조건 대응

| 요구사항 | 구현·검증 |
| --- | --- |
| 9개 ID와 C/H/A/O/F/R/P/B/L | `plugin.xml`과 `CopySelectionShortcuts.commands`; descriptor 테스트가 두 목록의 정확한 일치와 고유 두 번째 키를 검사 |
| Windows/Linux Ctrl+Alt+Shift+G, native mac Cmd+Option+Shift+G | `$default` 및 실제 macOS 계열에 2-stroke 등록; mac 계열은 `replace-all=true`로 Windows 접두가 함께 남지 않게 함 |
| 계보가 host OS보다 우선 | `usesMacKeymap`; active `$default` on mac host와 mac keymap on non-mac host 양방향 fixture |
| 독립 unknown만 OS fallback | parent가 `$default`/mac 계열인 파생 keymap과 parent 없는 unknown fixture |
| custom/unassigned/unrelated 보존 | 동일한 persisted user XML을 구/신 parent에 차례로 lazy reload하여 명시적 구 C/H, custom keyboard+mouse, mouse-only, 명시적 미배정, unrelated action, 삭제한 IDE 기본 배정의 정확한 전체 shortcut 목록을 검증 |
| old C/H alias·G 단독 action 없음 | 모든 descriptor shortcut의 second stroke 필수 및 구 first stroke 부재 검사 |
| 기존 액션 계약 보존 | action ID/class는 변경하지 않았고 기존 action/dumb-mode 전체 platform fixture가 통과 |
| platform fixture 격리 | `platformStateTestClasses`에 등록; full run에서 일반 `test` 결과에는 없고 `platformTest`에 단일 suite/5 tests로 존재 |

## 기준

- Base: `d1450a5dceb0807a489c08c2bd483256bd5b2f72`
- HEAD: `3be5081b06de89fd31c94932a6adc64146446d6d`
- 제품 버전: `1.6.0` 유지

## 검증

환경: macOS Darwin arm64, JDK 21 (`/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home`), Gradle wrapper 9.7.1, IC 2024.3 test platform.

- `bash gradlew test --tests '*PluginDescriptorLocalizationTest' --stacktrace --console=plain` — 통과
- `bash gradlew platformTest --tests '*CopySelectionShortcutFixtureTest' --stacktrace --console=plain` — persisted upgrade fixture 포함 5 tests, 통과
- `bash gradlew detekt verifyPluginStructure --stacktrace --console=plain` — Detekt 0 findings, 통과
- `bash gradlew allTests detekt verifyPluginProjectConfiguration verifyPluginStructure buildPlugin --stacktrace --console=plain` — unit 440 + platform 95, 통과
- `bash gradlew verifyPlugin --stacktrace --console=plain` — IC 243.21565.193, IU 262.10315.125, RD 262.9437.287 모두 Compatible
- `bash gradlew koverXmlReport koverHtmlReport --stacktrace --console=plain` — XML/HTML 보고서 생성, 통과
- `git diff --check` — 통과
- 산출물: `copy-selection-context-1.6.0.zip`, SHA-256 `c4e1e7a63bbd674972cb406b0fb429ea17b30d19118f9b24cd04c9a75bb03d7e`

## keymap ID 조사

- IC 2024.3 배포물에서 `Mac OS X`, `Mac OS X 10.5+`, `macOS System Shortcuts`, `Sublime Text (Mac OS X)`, `Visual Studio OSX`의 실제 XML과 parent를 확인했습니다.
- Rider 2026.2.1 배포물에서 `Visual Studio OSX`, `ReSharper OSX`, `VSCode OSX`, `Visual Assist OSX`의 실제 XML을 확인했습니다. Rider 전용 3종은 `Mac OS X 10.5+` 또는 `Visual Studio OSX`를 통해 mac 계보로 이어집니다.

## 수동 검증·위험

- 실제 IDE 키 입력/UI 검증은 이 PR에서 수행하지 않았습니다. 마일스톤 #132가 최종 통합 SHA와 격리된 macOS IDE 프로필로 수행합니다.
- Windows/Linux 실제 입력 실기는 사용자 범위 제외이며 통과/N/A로 계산하지 않습니다. 3 OS 자동 CI는 유지합니다.
- Rider 전용 keymap은 IC fixture에 모두 로드되지 않으므로 배포물 XML 조사와 후속 Plugin Verifier/마일스톤 실기로 보완합니다.
- 외부 action 해제, keymap 전체 reset, raw key interception, 구 단축키 자동 alias는 추가하지 않았습니다.
