### PR TITLE
test(shortcuts): prepare isolated runtime audit and upgrade matrix

### DIFF
--- a/docs/development/shortcut-audit-runbook.md
+++ b/docs/development/shortcut-audit-runbook.md
@@ -100,8 +100,13 @@ python3 scripts/shortcut-audit/audit.py compare-prefixes \
   --output NEW_PREFIX_COMPARISON.json
 ```
 
-The default comparison covers A–Z and F1–F24 with both Ctrl+Alt+Shift and
-Meta+Alt+Shift. Repeated `--key J --key F13` narrows it explicitly. Every first
+The default comparison covers A–Z, F1–F24 and eleven punctuation key codes with
+both Ctrl+Alt+Shift and Meta+Alt+Shift. Repeated `--key J --key SEMICOLON` narrows
+it explicitly. Punctuation uses Swing names: `SEMICOLON`, `COMMA`, `PERIOD`,
+`SLASH`, `BACK_SLASH`, `OPEN_BRACKET`, `CLOSE_BRACKET`, `MINUS`, `EQUALS`,
+`BACK_QUOTE` and `QUOTE`. These identify pressed key codes with modifiers, not
+the characters a layout/IME produces. Literal punctuation is rejected to avoid
+confusing typed and pressed strokes. Every first
 stroke match counts, regardless of its second key or whether the action is
 currently registered. Only the exact nine product IDs are excluded from
 external conflicts; their occupancies remain separately listed. Results retain
@@ -114,6 +119,26 @@ candidate's availability on physical keyboards, Fn/media handling, macOS or
 desktop interception, input layout and Korean IME remain separate real-input
 requirements. F13–F24 may be unoccupied yet unavailable on ordinary keyboards.
 No candidate is selected or applied to the product by this tool.
+
+To additionally compare the modifier the product chooses for each keymap, pass
+`--defaults-source PATH_TO_CopySelectionShortcuts.kt`. This is an explicit,
+source-pinned policy: the currently supported source is the #128 implementation
+at commit `1909df4ec318fda5ebab33400ceca1e912fb7549` (the exact source hash is in
+`lineage.py`; a test fixture preserves that file). Any source change is rejected
+until the rule and mirror are reviewed and the pin is updated. This intentionally
+includes unrelated changes; the tool must never guess compatibility.
+
+The mirror walks the recorded keymap chain from self to ancestors. The first
+exact member of the source's `macKeymapIds` chooses Meta; the first `$default`
+chooses Ctrl. If neither occurs, it uses the recorded host OS, rejecting unknown
+hosts. It does not infer a family from substrings such as `Mac` or `OSX`, or use
+an old action's shortcut as a proxy. Each decision retains the chain, decisive
+ancestor or host fallback, while the report records product and comparator
+source hashes. The existing both-modifier result remains intact; the additional
+`productRuleComparison` separates selected and opposite modifier occupancies.
+A zero there means only that the selected modifier has no external first-stroke
+match in those recorded maps. It is not a product execution or physical-input
+verdict, and opposite-modifier entries are never discarded.
 
 Preserve old harness directories, exports and accepted profiles unchanged.
 Use their pinned exporter revision for revalidation: a newer exporter correctly

--- a/docs/development/shortcut-audit-runbook.md
+++ b/docs/development/shortcut-audit-runbook.md
@@ -255,6 +255,15 @@ same run directory. Use the GUI export action after the fixture project opens.
 The nine-key behavioral run should also be repeated without
 the diagnostic harness. A harness action invocation is only a data export.
 
+For a separate normal GUI inventory of bundled OS families hidden on macOS,
+`launch-gui --all-os-keymaps` appends `-Dkeymap.current.os.only=false` to that
+run's private VM options. It preserves the distribution's options and records
+`keymapOsFilterOverride: false` in the launch evidence; without the flag the
+field is null and no override is added. Keep the ordinary GUI snapshot and this
+explicit override run separate. The flag requests loading only: validate the
+actual exported keymaps, parent chains, plugin owners and complete inventory.
+It does not establish Windows/Linux physical input behavior or waive licensing.
+
 ## Native GUI launch and input precautions
 
 Use an intact signed `.app` from the official distribution. Do not rewrite

--- a/docs/development/shortcut-audit-runbook.md
+++ b/docs/development/shortcut-audit-runbook.md
@@ -13,8 +13,19 @@ The user limited real keyboard, UI and upgrade execution to **macOS** on
 scope**, never PASS or N/A. Windows/macOS/Linux automated CI and the effective
 keymaps for every OS family remain required.
 
+On 2026-09-09 KST, the user additionally excluded actual effective-keymap/runtime
+measurements for **CLion, DataGrip, GoLand, PhpStorm, RubyMine and WebStorm** after
+their license-blocked attempts. Record those products as `USER-EXCLUDED` and
+preserve their exit-7 evidence as history, not PASS or N/A. They are no longer
+completion gates. No broader account or license use was authorized.
+
+Required runtime coverage is now minimum IC, latest IDEA, latest Rider, PyCharm
+and Android Studio, with their applicable OS keymap families. The macOS
+IC/IDEA/Rider real input/UI/upgrade matrix, US and Korean input, installed Rider
+families, three-OS automated CI and three-IDE Plugin Verifier remain required.
+
 Use `PASS`, `FAIL`, `NOT RUN`, `BLOCKED`, `N/A (specific unavailable combination)`
-or `EXCLUDED BY USER SCOPE`. A missing distribution, license or GUI driver is
+or `USER-EXCLUDED` (`EXCLUDED BY USER SCOPE`). A missing distribution, license or GUI driver is
 BLOCKED/NOT RUN, not evidence that its keymap is absent. An absent Rider family
 can be N/A only after recording the loaded distribution's full keymap inventory.
 Any outstanding required macOS row prevents issue/milestone completion.
@@ -43,15 +54,15 @@ Quail 4. These are distribution selection data, not runtime test results.
 | IntelliJ IDEA latest | 2026.2.2 | 262.10315.125 | Effective keymaps and macOS real input/UI/upgrade |
 | Rider latest | 2026.2.1 | 262.9437.287 | Effective keymaps and macOS real input/UI/upgrade |
 | PyCharm | 2026.2.2 | 262.10315.174 | Effective keymaps |
-| WebStorm | 2026.2.2 | 262.10315.144 | Effective keymaps |
-| PhpStorm | 2026.2.2 | 262.10315.130 | Effective keymaps |
-| GoLand | 2026.2.2.1 | 262.10315.160 | Effective keymaps |
-| CLion | 2026.2.2 | 262.10315.131 | Effective keymaps |
-| DataGrip | 2026.2.5 | 262.10315.132 | Effective keymaps |
-| RubyMine | 2026.2.2 | 262.10315.129 | Effective keymaps |
+| WebStorm | 2026.2.2 | 262.10315.144 | USER-EXCLUDED; preserve attempted license failure |
+| PhpStorm | 2026.2.2 | 262.10315.130 | USER-EXCLUDED; preserve attempted license failure |
+| GoLand | 2026.2.2.1 | 262.10315.160 | USER-EXCLUDED; preserve attempted license failure |
+| CLion | 2026.2.2 | 262.10315.131 | USER-EXCLUDED; preserve attempted license failure |
+| DataGrip | 2026.2.5 | 262.10315.132 | USER-EXCLUDED; preserve attempted license failure |
+| RubyMine | 2026.2.2 | 262.10315.129 | USER-EXCLUDED; preserve attempted license failure |
 | Android Studio | Quail 4 / 2026.1.4 | AI-261.26222.65.2614.16204760 (downloaded distribution) | Effective keymaps |
 
-For each product enumerate every loaded keymap, including Windows/Linux and
+For each retained product enumerate every loaded keymap, including Windows/Linux and
 macOS variants; record ID, parent chain and bundled/selected third-party
 contributions. In Rider explicitly locate IntelliJ, Visual Studio, Visual Studio
 2022, ReSharper and VS Code families and their OS variants. Do not infer IDs from
@@ -278,8 +289,10 @@ and newlines, rather than rely only on the success balloon.
 Run these rows for IC 2024.3, the selected latest IDEA and latest Rider, with
 US/QWERTY and Korean input. In Rider repeat across every installed required
 keymap family. Prefix expectations follow the **active keymap lineage**, so a
-Windows-style keymap selected on macOS keeps Ctrl+Alt+Shift+G. A native macOS
-keymap uses Cmd+Option+Shift+G.
+Windows-style keymap selected on macOS keeps Ctrl+Alt+Shift plus the recorded
+candidate first key. A native macOS keymap uses Cmd+Option+Shift plus that key.
+Z is the current validation candidate; record its exact source/ZIP and keep
+candidate testing separate from final prefix approval.
 
 Prepare a local committed Git repository containing `example.txt` with exactly
 `alpha\nbeta\ngamma\n`, an HTTPS GitHub fixture remote and a recorded HEAD SHA.

--- a/docs/development/shortcut-audit-runbook.md
+++ b/docs/development/shortcut-audit-runbook.md
@@ -1,0 +1,291 @@
+# Shortcut audit runbook
+
+This is the reproducible procedure for #132. Preparing a profile, querying a
+distribution, running a fixture and sending real keys are separate activities.
+Only observed results belong in the evidence sections of the
+[audit](../plans/shortcut-keymap-audit.md) and
+[migration contract](shortcut-migration-contract.md).
+
+## Scope and verdicts
+
+The user limited real keyboard, UI and upgrade execution to **macOS** on
+2026-09-08. Windows and Linux GNOME/KDE real execution is **excluded by user
+scope**, never PASS or N/A. Windows/macOS/Linux automated CI and the effective
+keymaps for every OS family remain required.
+
+Use `PASS`, `FAIL`, `NOT RUN`, `BLOCKED`, `N/A (specific unavailable combination)`
+or `EXCLUDED BY USER SCOPE`. A missing distribution, license or GUI driver is
+BLOCKED/NOT RUN, not evidence that its keymap is absent. An absent Rider family
+can be N/A only after recording the loaded distribution's full keymap inventory.
+Any outstanding required macOS row prevents issue/milestone completion.
+
+The final candidate must be the same integrated main SHA and ZIP SHA-256 used
+by the final CI/Verifier run, after #128–#131 have merged and their required CI
+has passed. The plugin version alone does not identify that candidate: this
+work does not bump the version or publish a release. Re-record affected results
+when code or ZIP changes. Never present earlier draft or v1.6.0 probe results as
+candidate verification.
+
+## Distribution inventory
+
+Refresh versions at execution time. Record the official source URL and UTC
+retrieval time, downloaded file hash, `product-info.json`, actual IDE build,
+loaded plugin inventory, architecture and profile paths.
+
+The JetBrains [release API](https://data.services.jetbrains.com/products/releases?code=IIU,RD,PY,WS,PS,GO,CL,DG,RM&latest=true&type=release)
+reported these stable releases on 2026-09-08. Android's
+[stable release page](https://developer.android.com/studio/releases) reported
+Quail 4. These are distribution selection data, not runtime test results.
+
+| Product | Stable version selected for preparation | Build from official release data | Required execution |
+| --- | --- | --- | --- |
+| IntelliJ IDEA Community minimum | 2024.3 | IC-243.21565.193 (installed distribution) | Effective keymaps and macOS real input/UI/upgrade |
+| IntelliJ IDEA latest | 2026.2.2 | 262.10315.125 | Effective keymaps and macOS real input/UI/upgrade |
+| Rider latest | 2026.2.1 | 262.9437.287 | Effective keymaps and macOS real input/UI/upgrade |
+| PyCharm | 2026.2.2 | 262.10315.174 | Effective keymaps |
+| WebStorm | 2026.2.2 | 262.10315.144 | Effective keymaps |
+| PhpStorm | 2026.2.2 | 262.10315.130 | Effective keymaps |
+| GoLand | 2026.2.2.1 | 262.10315.160 | Effective keymaps |
+| CLion | 2026.2.2 | 262.10315.131 | Effective keymaps |
+| DataGrip | 2026.2.5 | 262.10315.132 | Effective keymaps |
+| RubyMine | 2026.2.2 | 262.10315.129 | Effective keymaps |
+| Android Studio | Quail 4 / 2026.1.4 | AI-261.26222.65.2614.16204760 (downloaded distribution) | Effective keymaps |
+
+For each product enumerate every loaded keymap, including Windows/Linux and
+macOS variants; record ID, parent chain and bundled/selected third-party
+contributions. In Rider explicitly locate IntelliJ, Visual Studio, Visual Studio
+2022, ReSharper and VS Code families and their OS variants. Do not infer IDs from
+the visible name or a reference card. Keep the exact raw inventory even when
+summarizing equivalent inheritance chains.
+
+## Isolated tooling
+
+`scripts/shortcut-audit/audit.py` uses Python 3.9+ and a JDK 21 to package a small
+**separate diagnostic plugin**. It does not build or change the product ZIP,
+download IDEs, discover personal profiles, change shortcuts, call product
+`actionPerformed`, or access accounts. Use fresh output paths. It refuses to
+overwrite profiles, archives or evidence. Run only one Gradle/IDE process at a
+time when the coordinator has assigned the execution slot.
+
+The diagnostic reads registered actions including lazy action stubs, unions
+their IDs with every keymap and ancestor's action IDs, then reads effective
+shortcuts through the platform keymap API. It inspects the entire first stroke,
+including single strokes and chords with different second keys. It dumps both
+`control alt shift G` and `meta alt shift G`, and all Ctrl/Meta+Alt+C/H comparisons.
+Only the nine exact product IDs are excluded when classifying external prefix
+occupancy. Dormant mappings remain visible with `registered=false`. Owner plugin
+IDs, bundled flags and the loaded plugin inventory distinguish contributions.
+
+The headless application starter exports data after application startup. Because
+project startup or optional plugins can register additional actions, repeat the
+export in the GUI after the audit project finishes loading, using Find Action →
+**Export CSC Keymap Audit**. The export action has no shortcut. Compare the
+registered action counts and occupancy; retain both snapshots. A headless dump
+does not certify project-dependent or real key behavior. Do not instantiate
+every IDE action to force lazy initialization: registered stubs already carry
+their keymap data and plugin identity.
+
+Example (replace every uppercase placeholder with an absolute path/value):
+
+```bash
+python3 scripts/shortcut-audit/audit.py build-harness \
+  --ide-home IDE_APP_CONTENTS --jdk JDK21_HOME --output NEW_HARNESS_DIRECTORY
+python3 scripts/shortcut-audit/audit.py prepare \
+  --zip PRODUCT_ZIP --sha256 PRODUCT_SHA256 --output NEW_AUDIT_PROFILE
+python3 scripts/shortcut-audit/audit.py audit \
+  --ide-home IDE_APP_CONTENTS --profile NEW_AUDIT_PROFILE \
+  --harness NEW_HARNESS_DIRECTORY/csc-keymap-audit --timeout 120
+```
+
+The starter is invoked with the distribution's own JBR, boot classpath and
+runtime arguments from `product-info.json`. Config, system, plugins, logs and
+error dumps are scoped to the new profile. This runner currently launches
+macOS arm64 distributions; it still enumerates their installed OS-family
+keymaps. Run other host distributions separately if their bundled contributions
+differ. Never label macOS-hosted keymap data as Windows/Linux runtime evidence.
+
+Output includes the exact launch argv and product identity (`audit-command.json`),
+`audit-console.log`, the complete `keymaps.tsv` and `summary.json`. A nonzero IDE
+exit, absent completion marker, zero keymaps or missing product action is a
+failure. A complete export containing external G-prefix occupancy is evidence
+of a conflict, not a passing audit. Report it for a product decision; do not
+choose replacement keys or unbind external actions.
+
+For GUI export, install only the candidate and the audit harness in a fresh
+test plugin directory, and add `csc.audit.output=EVIDENCE_DIRECTORY` to its
+`idea.properties`. The nine-key behavioral run should also be repeated without
+the diagnostic harness. A harness action invocation is only a data export.
+
+## Native GUI launch and input precautions
+
+Use an intact signed `.app` from the official distribution. Do not rewrite
+Info.plist, replace the native launcher, or reconstruct a bundle around the
+Gradle Java process. Pass the test `idea.properties` through the product's
+`IDEA_PROPERTIES`/`RIDER_PROPERTIES` environment variable and use a private
+VM-options file for crash/heap dumps. All four paths must point at the test
+profile. Confirm them in `idea.log` before any UI changes.
+
+In this host's restricted execution boundary, the native IC launcher failed at
+`DirectoryLock` with `UnixDomainSockets.bind: Operation not permitted`, followed
+by SIGABRT/134. The same native bundle and explicit profile started successfully
+outside that boundary. An empty older log and reported exit137 do not establish
+the same cause. The earlier Gradle Java GUI log ended with SIGTERM/143.
+
+The GUI tool can automatically start a stopped app. Confirm the prepared process
+is alive first, then target its bundle identifier; never let an inspection call
+silently start the app with default user paths. Do not access or import personal
+IDE settings, accounts, licenses or keymaps. Finish by terminating only the
+process started for the allocated test profile.
+
+Use actual separate key events: press the prefix, release **all** modifiers,
+then press a plain second letter. Record US/QWERTY and Korean input source IDs
+and actual delivered modifier behavior. A driver that cannot hold/release keys,
+switch focus or observe OS interception cannot certify those timing/global
+cases. Record that precise limitation and obtain operator evidence for those
+rows. Clipboard verification must inspect the actual result, including spaces
+and newlines, rather than rely only on the success balloon.
+
+## macOS real execution matrix
+
+Run these rows for IC 2024.3, the selected latest IDEA and latest Rider, with
+US/QWERTY and Korean input. In Rider repeat across every installed required
+keymap family. Prefix expectations follow the **active keymap lineage**, so a
+Windows-style keymap selected on macOS keeps Ctrl+Alt+Shift+G. A native macOS
+keymap uses Cmd+Option+Shift+G.
+
+Prepare a local committed Git repository containing `example.txt` with exactly
+`alpha\nbeta\ngamma\n`, an HTTPS GitHub fixture remote and a recorded HEAD SHA.
+No remote writes or network Git operations are necessary. Use a valid project
+base and select exactly line 2 without its following newline. Start with default
+Claude output, absolute path and include-code disabled. Record the absolute
+fixture path as `FILE`.
+
+| Row | Real action/steps | Expected observation |
+| --- | --- | --- |
+| K-C | Prefix, release, C | Clipboard is exactly ` @FILE#L2 `; history/status update once |
+| K-R | Prefix, release, R | Clipboard is exactly ` @example.txt#L2 `, including leading/trailing spaces |
+| K-P | Prefix, release, P | Clipboard is exactly ` @FILE#L2 `, including leading/trailing spaces |
+| K-B | Prefix, release, B | Existing path/range plus fenced `beta` text; inspect full clipboard |
+| K-L | Prefix, release, L on clean committed text | Commit-pinned fixture URL with `#L2`; unchanged existing permalink publication contract |
+| K-L-dirty | Change line 2, run L, cancel; repeat and confirm | Cancel preserves clipboard; confirm uses captured HEAD/range; no duplicate write |
+| K-A | Seed a known clipboard value, prefix/release/A | One collection capture, clipboard/history/status unchanged |
+| K-H | Prepare history, close every editor, prefix/release/H | History opens; re-copy selected item produces its exact payload |
+| K-O | Close every editor, prefix/release/O | Collection tool window opens with the saved capture |
+| K-F | With no editor, prefix/release/F | Existing combined collection payload copied once; compare preview/full clipboard |
+| K-release | Prefix with modifiers held, varied release timing, then letter | Record platform behavior and verify the documented all-released/plain-letter path |
+| K-Escape | Prefix, Escape, then type a sentinel | No product action; normal typing resumes |
+| K-timeout | Prefix, wait beyond observed platform timeout, then type | No stuck chord state or unintended product action; record actual timeout |
+| K-wrong | Prefix, unused second letter, then type | Record platform handling; subsequent normal input works |
+| K-disabled | No selection/editor/project as applicable | Disabled editor actions do not copy; no-editor actions retain their contracts |
+| K-focus | Prefix, move focus between editor/tool window/settings/another app | No stale context action or trapped typing after cancellation |
+| K-indexing | Trigger while indexing; cancel and resume typing | Dumb-aware action behavior is preserved; no index dependency exception |
+
+## Settings matrix
+
+Run each row in the three required macOS IDEs. Use independent cloned profiles
+for scenarios that mutate bindings. Capture dialog bounds and actual displayed
+current/default shortcuts, including multi-shortcut, long Unicode labels and
+unassigned rows. Check EN/KO/JA/zh-CN/zh-TW at normal and increased IDE scale;
+record the scale and any unavailable localization combination.
+
+| Row | Scenario | Expected observation |
+| --- | --- | --- |
+| S-list | Open plugin settings on default/custom/unassigned keymaps | Nine current/default rows and Keymap navigation reflect the active scheme |
+| S-confirm | Restore then decline/close confirmation | No pending plan or active keymap change |
+| S-pending | Confirm restore, inspect before Apply | Pending state visible; source identity/shortcuts unchanged |
+| S-apply | Apply pending restore | One uniquely named derived scheme active; original preserved |
+| S-ok | Confirm then OK | Same transaction as Apply and settings close |
+| S-repeat | Apply again; reopen settings | No duplicate derivation; displayed current values refreshed |
+| S-cancel | Confirm then Cancel; repeat with Reset/disposal | Pending plan discarded; no keymap mutation |
+| S-template | Invalid custom template with pending restore, Apply/OK | Validation fails before keymap transaction |
+| S-prefix-single | Give an external action the first stroke alone | Restore blocked with action ID; external action unchanged |
+| S-prefix-chord | Give an external action same prefix with different second key | Restore blocked, even when all nine exact chords are free |
+| S-stale-map | Confirm, switch active scheme, Apply | Stale plan rejected; no derived scheme |
+| S-stale-binding | Confirm, change any of the nine keyboard/mouse lists, Apply | Stale plan rejected |
+| S-stale-conflict | Confirm, introduce new external prefix occupant, Apply | New conflict rejected |
+| S-preserve | Apply with unrelated edits, mouse shortcut, explicit IDE deletion | Only nine keyboard lists replaced; source and other assignments unchanged |
+| S-return | Restart, then select original scheme | Derived scheme persists; original values restored by selecting original |
+| S-layout | Long/multiple shortcuts, translations, increased scale | Rows and confirmation buttons remain readable and reachable |
+
+Some stale-plan scenarios may require an independent test session or a second
+settings window. Record exactly how the intervening change was made. Automated
+fixtures cover concurrency boundaries separately and do not fill a real-UI row.
+
+## Six v1.6.0 upgrade profiles
+
+Use the official released v1.6.0 ZIP, verify its release-asset digest and prepare
+each case with `prepare --case CASE --native-mac --parent OBSERVED_KEYMAP_ID`.
+For `removed-ide`, supply `--removed-action ID` from an actual baseline collision
+dump. For `explicit-old`, supply `--old-copy KEYSTROKE --old-history KEYSTROKE`
+from its effective runtime bindings. The tool writes **seed XML**, not a record of IDE acceptance. Start v1.6.0,
+verify the selected keymap/values in UI and runtime export, quit cleanly, then
+take a config snapshot. Only that accepted baseline is ready for cloning.
+
+| Case | Baseline | Required candidate result before explicit restore |
+| --- | --- | --- |
+| pristine | Inherited defaults, no custom scheme | Only inherited defaults move to B |
+| unrelated-only | Derived scheme edits another action only | Plugin defaults follow inheritance; unrelated edit remains |
+| explicit-old | Explicit old Copy/History bindings | Explicit C/H choices remain; no automatic aliases added |
+| custom | Different Copy/History keys and a mouse binding | Custom keyboard and mouse shortcuts remain |
+| unassigned | Explicit empty Copy/History entries | Commands stay unassigned |
+| removed-ide | Explicitly remove observed conflicting IDE action | IDE removal remains before/after restore; no full reset |
+
+v1.6.0 declares History only on `$default` (`control alt H`), but IC 243's actual
+`Mac OS X 10.5+` runtime maps it to **`meta alt H`** through platform inheritance.
+The same dump maps Copy to `meta alt C`, while the IDE's CallHierarchy remains
+`control alt H`. Thus descriptor text alone does not establish the effective old
+binding or a collision. Use the observed values for each Rider/IDE lineage.
+
+```bash
+python3 scripts/shortcut-audit/audit.py snapshot BASELINE_PROFILE BEFORE_JSON
+python3 scripts/shortcut-audit/audit.py clone-upgrade \
+  --source BASELINE_PROFILE --output NEW_CANDIDATE_PROFILE \
+  --zip CANDIDATE_ZIP --sha256 CANDIDATE_SHA256 --commit INTEGRATED_MAIN_SHA
+```
+
+The clone copies only the baseline config and installs the candidate product ZIP
+in a new plugin directory; mutable system/cache/log directories are new. Preserve
+the original baseline. Run S-preserve/S-return in each case and compare exact
+source keymap XML and effective shortcuts before/after restore. Repeat the six
+cases across required macOS IC/IDEA/Rider, recording the selected lineage.
+
+For each fresh/candidate profile, record these introduction scenarios separately
+from shortcut restoration. A second project is a separate local fixture project.
+
+| Row | Scenario | Expected observation |
+| --- | --- | --- |
+| I-new | Fresh candidate profile, first valid project | One introduction; wording does not claim an upgrade |
+| I-upgrade | Each of the six accepted v1.6.0 baselines, first candidate project | One introduction describing actual current bindings |
+| I-custom | Explicit old/custom bindings, including long/markup-like display text | Bounded escaped display, no claim that defaults are active |
+| I-unassigned | Explicit empty Copy/History | Current unassigned state shown accurately |
+| I-projects | Open a second project immediately and after initial notification | No second introduction in the same application profile |
+| I-restart | Quit cleanly and restart with introduced state | No repeated introduction |
+| I-copy-notification | Disable success-copy notifications before first startup | Introduction policy remains independent |
+| I-group | Disable the IDE notification group in a fresh profile | Normal IDE notification controls remain respected |
+| I-settings | Introduction's settings button | Opens the nine-shortcut settings list |
+| I-keymap | Introduction's Keymap button | Opens IDE Keymap settings without changing assignments |
+| I-dismiss | Close/dismiss introduction | Balloon expires; no repeat on next project/restart |
+| I-disposed | Close originating project before queued display/action | No display/claim or settings access through a disposed project |
+| I-state | Inspect persisted state and service fixture evidence | Local `copySelectionShortcuts.xml` state, copied state/atomic claim and `RoamingType.DISABLED` accounted for separately |
+| I-sync | Dedicated test account/profile Settings Sync, if available | Record original/derived keymap synchronization independently from non-roaming introduction state |
+
+Settings Sync is exercised only with a dedicated test account/profile when
+available. If unavailable, record the missing environment and leave this
+scenario NOT RUN; never use a personal account or treat local restart as sync.
+
+## Evidence and operator handoff
+
+Each executed row needs: row ID, performer, UTC timestamp, main SHA, candidate
+ZIP SHA-256, plugin version, IDE product/build, OS/build/desktop, architecture,
+IME/input source, keymap ID/parent chain, baseline/profile identity, procedure,
+expected result, actual result, verdict, logs and required screenshots. Include
+clipboard bytes or an escaped exact value when relevant. Keep executable argv,
+exit codes, actual test counts and CI URLs/artifact identity alongside the run.
+Do not commit local profiles, logs or personal data to the product repository.
+
+If GUI access fails, provide the operator the prepared profile, candidate hash,
+native launcher command, project fixture and remaining row IDs. Ask for the
+actual result and screenshot/clipboard evidence for each pending row, including
+IME and modifier release details. Preserve the failure log and exact failed
+operation. Leave those rows BLOCKED/NOT RUN until evidence arrives; a fixture,
+Verifier result or success balloon alone is not a replacement.

--- a/docs/development/shortcut-audit-runbook.md
+++ b/docs/development/shortcut-audit-runbook.md
@@ -76,6 +76,51 @@ Only the nine exact product IDs are excluded when classifying external prefix
 occupancy. Dormant mappings remain visible with `registered=false`. Owner plugin
 IDs, bundled flags and the loaded plugin inventory distinguish contributions.
 
+### Comparing replacement prefixes
+
+The six original schema-2 probes are retained as the G/C/H baseline. They do
+not establish that another prefix is free. Start a **fresh observation profile**
+with `audit --stroke-inventory` or `launch-gui --stroke-inventory` to request a
+complete companion named `EXPORT.tsv.strokes.tsv` from the same EDT capture.
+The optional companion has its own schema 1 and binds the original export's
+filename and SHA-256. It includes the registered-ID snapshot, each keymap and
+ancestor's source IDs, and every effective shortcut list (including empty,
+mouse, dormant, single-stroke and two-stroke entries) for their union. Per-map
+and final counts are checked, as are the original nine/watched bindings and
+all six original probe occupancies and ownership fields. A missing companion,
+missing action/ancestor row or mismatched export is an error, never a zero.
+
+```bash
+python3 scripts/shortcut-audit/audit.py launch-gui \
+  --app IDE_APP --profile FRESH_OBSERVATION_PROFILE --project FIXTURE_PROJECT \
+  --stroke-inventory
+# Invoke Export CSC Keymap Audit in the GUI, then quit that owned IDE.
+python3 scripts/shortcut-audit/audit.py compare-prefixes \
+  --export IC_EXPORT.tsv --export IDEA_EXPORT.tsv --export RIDER_EXPORT.tsv \
+  --output NEW_PREFIX_COMPARISON.json
+```
+
+The default comparison covers A–Z and F1–F24 with both Ctrl+Alt+Shift and
+Meta+Alt+Shift. Repeated `--key J --key F13` narrows it explicitly. Every first
+stroke match counts, regardless of its second key or whether the action is
+currently registered. Only the exact nine product IDs are excluded from
+external conflicts; their occupancies remain separately listed. Results retain
+all source identities, loaded plugins, keymap chains, action IDs/owners and
+full shortcut lists, so a zero is bounded to the recorded combinations. A
+platform action may return duplicate shortcuts: the companion preserves every
+entry and its counts, while comparison reports one occupancy per identical
+stroke and records `occurrencesInApiList` rather than inflating conflicts. A
+candidate's availability on physical keyboards, Fn/media handling, macOS or
+desktop interception, input layout and Korean IME remain separate real-input
+requirements. F13–F24 may be unoccupied yet unavailable on ordinary keyboards.
+No candidate is selected or applied to the product by this tool.
+
+Preserve old harness directories, exports and accepted profiles unchanged.
+Use their pinned exporter revision for revalidation: a newer exporter correctly
+rejects their old source manifest. Collect replacement-prefix inventories with
+the new reviewed harness in separate profiles; never install it into a frozen
+v6 baseline or relabel old six-probe data as complete-inventory evidence.
+
 `build-harness` creates an immutable `manifest.json` beside the diagnostic JAR.
 It records the exact JAR SHA-256, plugin ID and Java/descriptor source hashes,
 plus the available Git revision and dirty-state metadata. Source hashes are the

--- a/docs/development/shortcut-audit-runbook.md
+++ b/docs/development/shortcut-audit-runbook.md
@@ -76,6 +76,19 @@ Only the nine exact product IDs are excluded when classifying external prefix
 occupancy. Dormant mappings remain visible with `registered=false`. Owner plugin
 IDs, bundled flags and the loaded plugin inventory distinguish contributions.
 
+`build-harness` creates an immutable `manifest.json` beside the diagnostic JAR.
+It records the exact JAR SHA-256, plugin ID and Java/descriptor source hashes,
+plus the available Git revision and dirty-state metadata. Source hashes are the
+binding to the reviewed exporter content; a revision alone does not identify
+uncommitted build inputs. Keep the entire `csc-keymap-audit` directory together.
+The runners reject a missing manifest, stale exporter sources, wrong plugin ID,
+modified JAR or unexpected files before launching. They record and revalidate
+the installed artifact after execution. Launch records, raw exports and baseline
+acceptance all carry the same JAR/manifest hashes. A legacy diagnostic JAR cannot
+be made current by copying it into a new profile. Rebuild from reviewed sources
+and regenerate observations after exporter changes; do not add manifests to old
+JARs or rewrite existing acceptance records.
+
 The headless application starter exports data after application startup. Because
 project startup or optional plugins can register additional actions, repeat the
 export in the GUI after the audit project finishes loading, using Find Action →
@@ -107,14 +120,15 @@ differ. Never label macOS-hosted keymap data as Windows/Linux runtime evidence.
 Output includes the exact launch argv and product identity (`audit-command.json`),
 `audit-console.log`, PID/start/exit records, the complete `keymaps.tsv` and
 `summary.json`. Schema 2 exports record profile/run/PID identity, open projects,
-initialized JSON parent chains, all nine command and watched-action bindings
+harness JAR/manifest hashes, initialized JSON parent chains, all nine command and watched-action bindings
 (including mouse shortcuts and explicit empty lists), and all six probe strokes.
 The parser rejects missing/duplicate rows, invalid schema/columns, mismatched
 completion counts, incomplete per-keymap bindings and missing occupancy for a
 recorded shortcut. A nonzero IDE exit also fails. Interrupted or failed launches
 terminate their own process group and save the exit/cleanup record. Old schema 1
 data requires `summarize --allow-legacy`; it is inspection-only and cannot certify
-parents or become baseline/candidate acceptance evidence. A complete export containing external G-prefix occupancy is evidence
+parents or become baseline/candidate acceptance evidence. A complete export
+containing external G-prefix occupancy is evidence
 of a conflict, not a passing audit. Report it for a product decision; do not
 choose replacement keys or unbind external actions.
 
@@ -123,7 +137,8 @@ plugin directory, then use `launch-gui --app IDE_APP --profile TEST_PROFILE
 --project FIXTURE_PROJECT`. The runner creates a unique `gui-run-UUID` directory,
 private VM options and `gui-command.json`; its VM options set the export location
 and profile/run identities. Save screenshots and accessibility text inside that
-same run directory. Use the GUI export action after the fixture project opens. The nine-key behavioral run should also be repeated without
+same run directory. Use the GUI export action after the fixture project opens.
+The nine-key behavioral run should also be repeated without
 the diagnostic harness. A harness action invocation is only a data export.
 
 ## Native GUI launch and input precautions
@@ -279,13 +294,15 @@ Acceptance checks that the GUI loaded v1.6.0 in the intended four profile paths,
 had the expected project and keymap open, exported complete bindings from the
 recorded PID/run within its lifetime, and exited normally. It verifies each seed's
 keyboard/mouse/empty/deletion contract and binds the raw export, launch records,
-PNG or native JPEG screenshot, accessibility text and unchanged exit config snapshot by hashes.
+PNG or native JPEG screenshot, accessibility text and unchanged exit config
+snapshot by hashes. It also requires the installed harness to match both the
+recorded artifact and the current exporter source hashes.
 The operator attests to what the screenshot and UI actually showed; these hashes
 provide integrity checks, not independent attestation against a fabricated set
 of artifacts. Unit tests use explicitly synthetic evidence, never real GUI PASS.
 
 Accepted baselines are frozen: the launcher refuses to reopen them, and cloning
-revalidates all evidence and current config/product hashes. Source and target
+revalidates all evidence and current config/product/harness hashes. Source and target
 must be disjoint canonical paths (neither equal nor an ancestor of the other),
 including symlink aliases. A target nested under the source is rejected before
 any writes. Preserve the accepted original and work only in a new sibling tree.

--- a/docs/development/shortcut-audit-runbook.md
+++ b/docs/development/shortcut-audit-runbook.md
@@ -153,6 +153,15 @@ A zero there means only that the selected modifier has no external first-stroke
 match in those recorded maps. It is not a product execution or physical-input
 verdict, and opposite-modifier entries are never discarded.
 
+If a product's `product-info.json` omits `javaExecutablePath`, inspect that
+distribution's bundled runtime and pass its absolute path to `audit` using
+`--java-executable`. The tool accepts only an executable inside the selected
+IDE home, resolves symlinks, and rejects overriding an existing metadata path.
+It records the explicit selection and executable hash in run evidence without
+altering product metadata. Runtime resolution fails before installing the
+diagnostic harness into a fresh profile. This option does not change licensing
+or initialization behavior; a runtime license rejection remains a blocked run.
+
 Preserve old harness directories, exports and accepted profiles unchanged.
 Use their pinned exporter revision for revalidation: a newer exporter correctly
 rejects their old source manifest. Collect replacement-prefix inventories with

--- a/docs/development/shortcut-audit-runbook.md
+++ b/docs/development/shortcut-audit-runbook.md
@@ -90,6 +90,19 @@ and final counts are checked, as are the original nine/watched bindings and
 all six original probe occupancies and ownership fields. A missing companion,
 missing action/ancestor row or mismatched export is an error, never a zero.
 
+Every companion action's `registered` flag must match the registered-ID snapshot
+in both directions, and its `(registered, owner, bundled)` tuple must be identical
+across keymaps, matching the exporter's per-action cache. The exporter resolves
+an action/stub and derives its descriptor through the stub or platform class
+lookup; absent actions therefore require both owner and bundled to be `unknown`.
+For registered actions, complete-evidence acceptance requires a known owner in
+the original `PLUGIN` inventory and the same bundled flag. Although the exporter
+can represent a missing descriptor as `unknown`, such a registered contribution
+cannot be attributed and is rejected for this audit. A registration snapshot
+disagreement is likewise rejected, never repaired or silently marked dormant.
+These checks apply to every effective action, including actions outside the
+original six probes.
+
 ```bash
 python3 scripts/shortcut-audit/audit.py launch-gui \
   --app IDE_APP --profile FRESH_OBSERVATION_PROFILE --project FIXTURE_PROJECT \

--- a/docs/development/shortcut-audit-runbook.md
+++ b/docs/development/shortcut-audit-runbook.md
@@ -105,15 +105,25 @@ keymaps. Run other host distributions separately if their bundled contributions
 differ. Never label macOS-hosted keymap data as Windows/Linux runtime evidence.
 
 Output includes the exact launch argv and product identity (`audit-command.json`),
-`audit-console.log`, the complete `keymaps.tsv` and `summary.json`. A nonzero IDE
-exit, absent completion marker, zero keymaps or missing product action is a
-failure. A complete export containing external G-prefix occupancy is evidence
+`audit-console.log`, PID/start/exit records, the complete `keymaps.tsv` and
+`summary.json`. Schema 2 exports record profile/run/PID identity, open projects,
+initialized JSON parent chains, all nine command and watched-action bindings
+(including mouse shortcuts and explicit empty lists), and all six probe strokes.
+The parser rejects missing/duplicate rows, invalid schema/columns, mismatched
+completion counts, incomplete per-keymap bindings and missing occupancy for a
+recorded shortcut. A nonzero IDE exit also fails. Interrupted or failed launches
+terminate their own process group and save the exit/cleanup record. Old schema 1
+data requires `summarize --allow-legacy`; it is inspection-only and cannot certify
+parents or become baseline/candidate acceptance evidence. A complete export containing external G-prefix occupancy is evidence
 of a conflict, not a passing audit. Report it for a product decision; do not
 choose replacement keys or unbind external actions.
 
-For GUI export, install only the candidate and the audit harness in a fresh
-test plugin directory, and add `csc.audit.output=EVIDENCE_DIRECTORY` to its
-`idea.properties`. The nine-key behavioral run should also be repeated without
+For GUI export, install only the product and the audit harness in a fresh test
+plugin directory, then use `launch-gui --app IDE_APP --profile TEST_PROFILE
+--project FIXTURE_PROJECT`. The runner creates a unique `gui-run-UUID` directory,
+private VM options and `gui-command.json`; its VM options set the export location
+and profile/run identities. Save screenshots and accessibility text inside that
+same run directory. Use the GUI export action after the fixture project opens. The nine-key behavioral run should also be repeated without
 the diagnostic harness. A harness action invocation is only a data export.
 
 ## Native GUI launch and input precautions
@@ -165,13 +175,13 @@ fixture path as `FILE`.
 | K-C | Prefix, release, C | Clipboard is exactly ` @FILE#L2 `; history/status update once |
 | K-R | Prefix, release, R | Clipboard is exactly ` @example.txt#L2 `, including leading/trailing spaces |
 | K-P | Prefix, release, P | Clipboard is exactly ` @FILE#L2 `, including leading/trailing spaces |
-| K-B | Prefix, release, B | Existing path/range plus fenced `beta` text; inspect full clipboard |
+| K-B | Prefix, release, B | Exact code payload `B` defined below; UTF-8 clipboard bytes match |
 | K-L | Prefix, release, L on clean committed text | Commit-pinned fixture URL with `#L2`; unchanged existing permalink publication contract |
 | K-L-dirty | Change line 2, run L, cancel; repeat and confirm | Cancel preserves clipboard; confirm uses captured HEAD/range; no duplicate write |
 | K-A | Seed a known clipboard value, prefix/release/A | One collection capture, clipboard/history/status unchanged |
-| K-H | Prepare history, close every editor, prefix/release/H | History opens; re-copy selected item produces its exact payload |
+| K-H | In a fresh profile, execute K-C once, close every editor, prefix/release/H | History opens with the C item; re-copy yields exactly ` @FILE#L2 ` |
 | K-O | Close every editor, prefix/release/O | Collection tool window opens with the saved capture |
-| K-F | With no editor, prefix/release/F | Existing combined collection payload copied once; compare preview/full clipboard |
+| K-F | Clear the test collection, K-A once, set collection Include Code off, close all editors, prefix/release/F | Exactly ` @FILE#L2 ` copied once; repeat with Include Code on and expect payload `B` |
 | K-release | Prefix with modifiers held, varied release timing, then letter | Record platform behavior and verify the documented all-released/plain-letter path |
 | K-Escape | Prefix, Escape, then type a sentinel | No product action; normal typing resumes |
 | K-timeout | Prefix, wait beyond observed platform timeout, then type | No stuck chord state or unintended product action; record actual timeout |
@@ -179,6 +189,20 @@ fixture path as `FILE`.
 | K-disabled | No selection/editor/project as applicable | Disabled editor actions do not copy; no-editor actions retain their contracts |
 | K-focus | Prefix, move focus between editor/tool window/settings/another app | No stale context action or trapped typing after cancellation |
 | K-indexing | Trigger while indexing; cancel and resume typing | Dumb-aware action behavior is preserved; no index dependency exception |
+
+The exact code payload `B`, expressed as a JSON string after replacing `FILE`
+with the absolute fixture path, is:
+
+```json
+" @FILE#L2 \n```text\nbeta\n```"
+```
+
+There is no trailing newline after the closing fence. K-F uses one capture to
+avoid duplicate-source snapshot labels. For a separate two-capture check at the
+same path/range, record each capture number and UTC timestamp and build the
+expected string as `[Snapshot #N · YYYY-MM-DDTHH:mm:ss.SSSZ]\n` plus that capture's
+formatted payload, joined with exactly `\n\n`. Compare against this independently
+constructed string; the UI preview alone is not an oracle.
 
 ## Settings matrix
 
@@ -218,8 +242,10 @@ each case with `prepare --case CASE --native-mac --parent OBSERVED_KEYMAP_ID`.
 For `removed-ide`, supply `--removed-action ID` from an actual baseline collision
 dump. For `explicit-old`, supply `--old-copy KEYSTROKE --old-history KEYSTROKE`
 from its effective runtime bindings. The tool writes **seed XML**, not a record of IDE acceptance. Start v1.6.0,
-verify the selected keymap/values in UI and runtime export, quit cleanly, then
-take a config snapshot. Only that accepted baseline is ready for cloning.
+verify the selected keymap/values in UI and runtime export, and quit cleanly.
+`launch-gui` records the config snapshot after process exit. Then explicitly
+record the observation with `accept-baseline` as below. Seed preparation or a
+boolean acceptance marker cannot authorize a clone.
 
 | Case | Baseline | Required candidate result before explicit restore |
 | --- | --- | --- |
@@ -237,11 +263,32 @@ The same dump maps Copy to `meta alt C`, while the IDE's CallHierarchy remains
 binding or a collision. Use the observed values for each Rider/IDE lineage.
 
 ```bash
-python3 scripts/shortcut-audit/audit.py snapshot BASELINE_PROFILE BEFORE_JSON
+python3 scripts/shortcut-audit/audit.py accept-baseline \
+  --profile BASELINE_PROFILE --run-directory BASELINE_PROFILE/gui-run-UUID \
+  --export BASELINE_PROFILE/gui-run-UUID/keymaps-gui-TIMESTAMP.tsv \
+  --observed-keymap OBSERVED_KEYMAP_ID --performer OPERATOR_NAME \
+  --notes OBSERVATION_DESCRIPTION --confirm-observed \
+  --gui-evidence BASELINE_PROFILE/gui-run-UUID/keymap.png \
+  --gui-evidence BASELINE_PROFILE/gui-run-UUID/keymap.txt
 python3 scripts/shortcut-audit/audit.py clone-upgrade \
   --source BASELINE_PROFILE --output NEW_CANDIDATE_PROFILE \
   --zip CANDIDATE_ZIP --sha256 CANDIDATE_SHA256 --commit INTEGRATED_MAIN_SHA
 ```
+
+Acceptance checks that the GUI loaded v1.6.0 in the intended four profile paths,
+had the expected project and keymap open, exported complete bindings from the
+recorded PID/run within its lifetime, and exited normally. It verifies each seed's
+keyboard/mouse/empty/deletion contract and binds the raw export, launch records,
+PNG or native JPEG screenshot, accessibility text and unchanged exit config snapshot by hashes.
+The operator attests to what the screenshot and UI actually showed; these hashes
+provide integrity checks, not independent attestation against a fabricated set
+of artifacts. Unit tests use explicitly synthetic evidence, never real GUI PASS.
+
+Accepted baselines are frozen: the launcher refuses to reopen them, and cloning
+revalidates all evidence and current config/product hashes. Source and target
+must be disjoint canonical paths (neither equal nor an ancestor of the other),
+including symlink aliases. A target nested under the source is rejected before
+any writes. Preserve the accepted original and work only in a new sibling tree.
 
 The clone copies only the baseline config and installs the candidate product ZIP
 in a new plugin directory; mutable system/cache/log directories are new. Preserve

--- a/docs/development/shortcut-audit-runbook.md
+++ b/docs/development/shortcut-audit-runbook.md
@@ -141,6 +141,17 @@ at commit `1909df4ec318fda5ebab33400ceca1e912fb7549` (the exact source hash is i
 until the rule and mirror are reviewed and the pin is updated. This intentionally
 includes unrelated changes; the tool must never guess compatibility.
 
+The policy source is one bounded bytes snapshot, capped at 16 KiB before and
+after reading. The same bytes supply both SHA-256 and UTF-8 policy parsing.
+Only regular files are accepted: final-entry symlinks, directories and special
+files are rejected before reading, with no-follow/nonblocking open flags guarding
+replacement races. The opened file's identity and size are checked again, and
+changes to size/timestamps during the read fail validation. Parent directory
+aliases are allowed; provenance labels the absolute lookup path and records
+the opened descriptor's device/inode and snapshot size, without resolving the
+path or rereading it after validation. Hosts lacking the required open flags
+are rejected. Use a preserved commit snapshot when a live worktree can change.
+
 The mirror walks the recorded keymap chain from self to ancestors. The first
 exact member of the source's `macKeymapIds` chooses Meta; the first `$default`
 chooses Ctrl. If neither occurs, it uses the recorded host OS, rejecting unknown

--- a/scripts/shortcut-audit/ExportKeymapAuditAction.java
+++ b/scripts/shortcut-audit/ExportKeymapAuditAction.java
@@ -3,11 +3,7 @@ package audit;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
 
 /** Optional GUI export after project/plugin initialization; never invokes product actions. */
 public final class ExportKeymapAuditAction extends DumbAwareAction {
@@ -15,12 +11,10 @@ public final class ExportKeymapAuditAction extends DumbAwareAction {
         try {
             String directory = System.getProperty("csc.audit.output");
             if (directory == null) throw new IllegalStateException("Set csc.audit.output to a test evidence directory");
-            var rows = new ArrayList<String>();
-            KeymapAuditStarter.collect(rows);
             // Keymaps are read on EDT. This bounded diagnostic writes only to the
             // explicit test evidence directory; it is never part of the product.
             Path output = Path.of(directory, "keymaps-gui-" + System.currentTimeMillis() + ".tsv");
-            Files.write(output, rows, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
+            KeymapAuditStarter.writeExport(output);
             System.out.println("CSC_KEYMAP_AUDIT_GUI_COMPLETE " + output);
         } catch (Exception error) {
             throw new IllegalStateException("Keymap audit failed", error);

--- a/scripts/shortcut-audit/ExportKeymapAuditAction.java
+++ b/scripts/shortcut-audit/ExportKeymapAuditAction.java
@@ -1,0 +1,29 @@
+package audit;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+
+/** Optional GUI export after project/plugin initialization; never invokes product actions. */
+public final class ExportKeymapAuditAction extends DumbAwareAction {
+    @Override public void actionPerformed(AnActionEvent event) {
+        try {
+            String directory = System.getProperty("csc.audit.output");
+            if (directory == null) throw new IllegalStateException("Set csc.audit.output to a test evidence directory");
+            var rows = new ArrayList<String>();
+            KeymapAuditStarter.collect(rows);
+            // Keymaps are read on EDT. This bounded diagnostic writes only to the
+            // explicit test evidence directory; it is never part of the product.
+            Path output = Path.of(directory, "keymaps-gui-" + System.currentTimeMillis() + ".tsv");
+            Files.write(output, rows, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
+            System.out.println("CSC_KEYMAP_AUDIT_GUI_COMPLETE " + output);
+        } catch (Exception error) {
+            throw new IllegalStateException("Keymap audit failed", error);
+        }
+    }
+}

--- a/scripts/shortcut-audit/KeymapAuditStarter.java
+++ b/scripts/shortcut-audit/KeymapAuditStarter.java
@@ -81,6 +81,8 @@ public final class KeymapAuditStarter implements ApplicationStarter {
         row(rows, "META", "profileId", System.getProperty("csc.audit.profileId"));
         row(rows, "META", "runId", System.getProperty("csc.audit.runId"));
         row(rows, "META", "processId", ProcessHandle.current().pid());
+        row(rows, "META", "harnessJarSha256", System.getProperty("csc.audit.harnessJarSha256"));
+        row(rows, "META", "harnessManifestSha256", System.getProperty("csc.audit.harnessManifestSha256"));
         row(rows, "META", "watchedActions", "[" + watched.stream().map(KeymapAuditStarter::jsonString)
             .collect(java.util.stream.Collectors.joining(",")) + "]");
         row(rows, "META", "projectRoots", "[" + Arrays.stream(ProjectManager.getInstance().getOpenProjects())

--- a/scripts/shortcut-audit/KeymapAuditStarter.java
+++ b/scripts/shortcut-audit/KeymapAuditStarter.java
@@ -1,0 +1,131 @@
+package audit;
+
+import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.ActionStubBase;
+import com.intellij.openapi.actionSystem.KeyboardShortcut;
+import com.intellij.openapi.actionSystem.Shortcut;
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ApplicationStarter;
+import com.intellij.openapi.extensions.PluginDescriptor;
+import com.intellij.openapi.keymap.Keymap;
+import com.intellij.openapi.keymap.ex.KeymapManagerEx;
+
+import javax.swing.KeyStroke;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/** A separate diagnostic plugin. Never packaged in the product ZIP. */
+public final class KeymapAuditStarter implements ApplicationStarter {
+    private static final String PREFIX = "CopySelectionContext.";
+    private static final List<String> COMMANDS = List.of(
+        "Copy", "ShowHistory", "AddToCollection", "ShowCollection", "CopyAllCollection",
+        "CopyRelativePath", "CopyAbsolutePath", "CopyWithCodeContent", "CopyGitPermalink"
+    );
+    private static final List<String> PROBES = List.of(
+        "control alt shift G", "meta alt shift G",
+        "control alt C", "meta alt C", "control alt H", "meta alt H"
+    );
+
+    @Override public String getCommandName() { return "csc-keymap-audit"; }
+    @Override public boolean isHeadless() { return true; }
+    @Override public int getRequiredModality() { return NOT_IN_EDT; }
+
+    @Override public void main(List<String> args) {
+        try {
+            if (args.size() != 2) throw new IllegalArgumentException("Expected output TSV path");
+            List<String> rows = new ArrayList<>();
+            ApplicationManager.getApplication().invokeAndWait(() -> collect(rows));
+            // Refuse to replace previous evidence. The runner supplies a fresh filename.
+            Files.write(Path.of(args.get(1)), rows, StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+            System.out.println("CSC_KEYMAP_AUDIT_COMPLETE rows=" + rows.size());
+            System.exit(0);
+        } catch (Throwable error) {
+            error.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    static void collect(List<String> rows) {
+        var manager = ActionManager.getInstance();
+        var keymaps = KeymapManagerEx.getInstanceEx();
+        var info = ApplicationInfo.getInstance();
+        row(rows, "META", "schema", "1");
+        row(rows, "META", "timeUtc", Instant.now());
+        row(rows, "META", "ide", info.getFullApplicationName());
+        row(rows, "META", "build", info.getBuild().asString());
+        row(rows, "META", "os", System.getProperty("os.name"), System.getProperty("os.version"), System.getProperty("os.arch"));
+        row(rows, "META", "activeKeymap", keymaps.getActiveKeymap().getName());
+        row(rows, "META", "headless", ApplicationManager.getApplication().isHeadlessEnvironment());
+        row(rows, "META", "registeredActionCount", manager.getActionIdList("").size());
+        for (String name : List.of("idea.config.path", "idea.system.path", "idea.plugins.path", "idea.log.path")) {
+            row(rows, "META", name, System.getProperty(name));
+        }
+        for (var plugin : PluginManagerCore.getLoadedPlugins()) {
+            row(rows, "PLUGIN", plugin.getPluginId(), plugin.getVersion(), plugin.isBundled(), plugin.getPluginPath());
+        }
+        for (String command : COMMANDS) {
+            String id = PREFIX + command;
+            var action = manager.getAction(id);
+            if (action == null) throw new IllegalStateException("Product action is not loaded: " + id);
+            row(rows, "COMMAND", id, action.getClass().getName());
+        }
+        var maps = new ArrayList<>(Arrays.asList(keymaps.getAllKeymaps()));
+        maps.sort(java.util.Comparator.comparing(Keymap::getName));
+        for (Keymap keymap : maps) {
+            Set<Keymap> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+            List<String> chain = new ArrayList<>();
+            for (Keymap node = keymap; node != null; node = node.getParent()) {
+                if (!visited.add(node)) throw new IllegalStateException("Cyclic keymap parent chain");
+                chain.add(node.getName());
+            }
+            row(rows, "KEYMAP", keymap.getName(), keymap.canModify(), String.join(" -> ", chain));
+            // Include dormant mappings, action aliases and inherited action IDs as well as
+            // registered actions. Keymap.getShortcuts supplies effective inherited values.
+            Set<String> ids = new TreeSet<>(manager.getActionIdList(""));
+            for (Keymap node = keymap; node != null; node = node.getParent()) ids.addAll(node.getActionIdList());
+            for (String command : COMMANDS) ids.add(PREFIX + command);
+            for (String id : ids) {
+                Shortcut[] shortcuts = keymap.getShortcuts(id);
+                if (COMMANDS.stream().anyMatch(command -> id.equals(PREFIX + command))) {
+                    row(rows, "BINDING", keymap.getName(), id, Arrays.toString(shortcuts));
+                }
+                for (Shortcut shortcut : shortcuts) {
+                    if (!(shortcut instanceof KeyboardShortcut keyboard)) continue;
+                    for (String probe : PROBES) {
+                        if (!keyboard.getFirstKeyStroke().equals(KeyStroke.getKeyStroke(probe))) continue;
+                        var action = manager.getActionOrStub(id);
+                        PluginDescriptor owner = action instanceof ActionStubBase stub ? stub.getPlugin()
+                            : action == null ? null
+                            : PluginManagerCore.getPluginDescriptorOrPlatformByClassName(action.getClass().getName());
+                        row(rows, "OCCUPANCY", keymap.getName(), probe, id,
+                            keyboard.getFirstKeyStroke(), keyboard.getSecondKeyStroke(),
+                            Arrays.toString(shortcuts), action != null,
+                            owner == null ? "unknown" : owner.getPluginId(),
+                            owner == null ? "unknown" : owner.isBundled());
+                    }
+                }
+            }
+        }
+        row(rows, "END", "keymaps", maps.size(), "commands", COMMANDS.size());
+    }
+
+    private static void row(List<String> rows, Object... cells) {
+        List<String> values = new ArrayList<>();
+        for (Object cell : cells) values.add(String.valueOf(cell).replace("\\", "\\\\")
+            .replace("\t", "\\t").replace("\r", "\\r").replace("\n", "\\n"));
+        rows.add(String.join("\t", values));
+    }
+}

--- a/scripts/shortcut-audit/KeymapAuditStarter.java
+++ b/scripts/shortcut-audit/KeymapAuditStarter.java
@@ -50,12 +50,8 @@ public final class KeymapAuditStarter implements ApplicationStarter {
     @Override public void main(List<String> args) {
         try {
             if (args.size() != 2) throw new IllegalArgumentException("Expected output TSV path");
-            List<String> rows = new ArrayList<>();
-            ApplicationManager.getApplication().invokeAndWait(() -> collect(rows));
-            // Refuse to replace previous evidence. The runner supplies a fresh filename.
-            Files.write(Path.of(args.get(1)), rows, StandardCharsets.UTF_8,
-                StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
-            System.out.println("CSC_KEYMAP_AUDIT_COMPLETE rows=" + rows.size());
+            writeExport(Path.of(args.get(1)));
+            System.out.println("CSC_KEYMAP_AUDIT_COMPLETE " + args.get(1));
             System.exit(0);
         } catch (Throwable error) {
             error.printStackTrace();
@@ -63,10 +59,36 @@ public final class KeymapAuditStarter implements ApplicationStarter {
         }
     }
 
-    static void collect(List<String> rows) {
+    static void writeExport(Path output) throws Exception {
+        List<String> rows = new ArrayList<>();
+        StrokeInventory inventory = Boolean.getBoolean("csc.audit.strokeInventory") ? new StrokeInventory() : null;
+        var application = ApplicationManager.getApplication();
+        if (application.isDispatchThread()) collect(rows, inventory);
+        else application.invokeAndWait(() -> collect(rows, inventory));
+        byte[] audit = (String.join("\n", rows) + "\n").getBytes(StandardCharsets.UTF_8);
+        Path companion = output.resolveSibling(output.getFileName() + ".strokes.tsv");
+        // Neither file is a replacement for older evidence. A missing companion
+        // after interruption cannot produce a prefix-comparison verdict.
+        if (Files.exists(output) || inventory != null && Files.exists(companion)) {
+            throw new IllegalStateException("Evidence path already exists");
+        }
+        Files.write(output, audit, StandardOpenOption.CREATE_NEW);
+        if (inventory != null) inventory.write(companion, output.getFileName().toString(), audit);
+    }
+
+    static void collect(List<String> rows, StrokeInventory inventory) {
         var manager = ActionManager.getInstance();
         var keymaps = KeymapManagerEx.getInstanceEx();
         var info = ApplicationInfo.getInstance();
+        // Initialize the nine product actions before taking the registered-ID
+        // snapshot used consistently by both exports and every keymap scan.
+        for (String command : COMMANDS) {
+            if (manager.getAction(PREFIX + command) == null) {
+                throw new IllegalStateException("Product action is not loaded: " + PREFIX + command);
+            }
+        }
+        Set<String> registered = new TreeSet<>(manager.getActionIdList(""));
+        if (inventory != null) inventory.registered(registered);
         Set<String> watched = new TreeSet<>(BASELINE_ACTIONS);
         String removedAction = System.getProperty("csc.audit.removedAction");
         if (removedAction != null && !removedAction.isBlank()) watched.add(removedAction);
@@ -77,7 +99,8 @@ public final class KeymapAuditStarter implements ApplicationStarter {
         row(rows, "META", "os", System.getProperty("os.name"), System.getProperty("os.version"), System.getProperty("os.arch"));
         row(rows, "META", "activeKeymap", keymaps.getActiveKeymap().getName());
         row(rows, "META", "headless", ApplicationManager.getApplication().isHeadlessEnvironment());
-        row(rows, "META", "registeredActionCount", manager.getActionIdList("").size());
+        row(rows, "META", "registeredActionCount", registered.size());
+        if (inventory != null) row(rows, "META", "strokeInventory", "complete-v1");
         row(rows, "META", "profileId", System.getProperty("csc.audit.profileId"));
         row(rows, "META", "runId", System.getProperty("csc.audit.runId"));
         row(rows, "META", "processId", ProcessHandle.current().pid());
@@ -116,12 +139,17 @@ public final class KeymapAuditStarter implements ApplicationStarter {
                 .map(KeymapAuditStarter::jsonString).collect(java.util.stream.Collectors.joining(",")) + "]");
             // Include dormant mappings, action aliases and inherited action IDs as well as
             // registered actions. Keymap.getShortcuts supplies effective inherited values.
-            Set<String> ids = new TreeSet<>(manager.getActionIdList(""));
-            for (Keymap node = keymap; node != null; node = node.getParent()) ids.addAll(node.getActionIdList());
+            Set<String> ids = new TreeSet<>(registered);
+            for (Keymap node = keymap; node != null; node = node.getParent()) {
+                Set<String> sourceIds = new TreeSet<>(node.getActionIdList());
+                ids.addAll(sourceIds);
+                if (inventory != null) inventory.source(keymap.getName(), node.getName(), sourceIds);
+            }
             for (String command : COMMANDS) ids.add(PREFIX + command);
             ids.addAll(watched);
             for (String id : ids) {
                 Shortcut[] shortcuts = keymap.getShortcuts(id);
+                if (inventory != null) inventory.action(keymap.getName(), id, shortcuts, manager);
                 if (watched.contains(id)
                     || COMMANDS.stream().anyMatch(command -> id.equals(PREFIX + command))) {
                     row(rows, "BINDING", keymap.getName(), id, shortcutsJson(shortcuts));
@@ -142,6 +170,7 @@ public final class KeymapAuditStarter implements ApplicationStarter {
                     }
                 }
             }
+            if (inventory != null) inventory.keymap(keymap.getName(), ids.size());
         }
         long bindings = rows.stream().filter(value -> value.startsWith("BINDING\t")).count();
         long occupancies = rows.stream().filter(value -> value.startsWith("OCCUPANCY\t")).count();
@@ -149,7 +178,7 @@ public final class KeymapAuditStarter implements ApplicationStarter {
             "bindings", bindings, "occupancies", occupancies, "rows", rows.size() + 1);
     }
 
-    private static String shortcutsJson(Shortcut[] shortcuts) {
+    static String shortcutsJson(Shortcut[] shortcuts) {
         List<String> values = new ArrayList<>();
         for (Shortcut shortcut : shortcuts) {
             if (shortcut instanceof KeyboardShortcut keyboard) {
@@ -165,7 +194,7 @@ public final class KeymapAuditStarter implements ApplicationStarter {
         return "[" + String.join(",", values) + "]";
     }
 
-    private static String jsonString(String value) {
+    static String jsonString(String value) {
         if (value == null) return "null";
         StringBuilder result = new StringBuilder("\"");
         for (char character : value.toCharArray()) {
@@ -176,7 +205,7 @@ public final class KeymapAuditStarter implements ApplicationStarter {
         return result.append('"').toString();
     }
 
-    private static void row(List<String> rows, Object... cells) {
+    static void row(List<String> rows, Object... cells) {
         List<String> values = new ArrayList<>();
         for (Object cell : cells) values.add(String.valueOf(cell).replace("\\", "\\\\")
             .replace("\t", "\\t").replace("\r", "\\r").replace("\n", "\\n"));

--- a/scripts/shortcut-audit/KeymapAuditStarter.java
+++ b/scripts/shortcut-audit/KeymapAuditStarter.java
@@ -4,6 +4,7 @@ import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.ActionStubBase;
 import com.intellij.openapi.actionSystem.KeyboardShortcut;
+import com.intellij.openapi.actionSystem.MouseShortcut;
 import com.intellij.openapi.actionSystem.Shortcut;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
@@ -11,6 +12,7 @@ import com.intellij.openapi.application.ApplicationStarter;
 import com.intellij.openapi.extensions.PluginDescriptor;
 import com.intellij.openapi.keymap.Keymap;
 import com.intellij.openapi.keymap.ex.KeymapManagerEx;
+import com.intellij.openapi.project.ProjectManager;
 
 import javax.swing.KeyStroke;
 import java.nio.charset.StandardCharsets;
@@ -37,6 +39,9 @@ public final class KeymapAuditStarter implements ApplicationStarter {
         "control alt shift G", "meta alt shift G",
         "control alt C", "meta alt C", "control alt H", "meta alt H"
     );
+    private static final Set<String> BASELINE_ACTIONS = Set.of(
+        "IntroduceConstant", "EditorToggleUseSoftWraps"
+    );
 
     @Override public String getCommandName() { return "csc-keymap-audit"; }
     @Override public boolean isHeadless() { return true; }
@@ -62,7 +67,10 @@ public final class KeymapAuditStarter implements ApplicationStarter {
         var manager = ActionManager.getInstance();
         var keymaps = KeymapManagerEx.getInstanceEx();
         var info = ApplicationInfo.getInstance();
-        row(rows, "META", "schema", "1");
+        Set<String> watched = new TreeSet<>(BASELINE_ACTIONS);
+        String removedAction = System.getProperty("csc.audit.removedAction");
+        if (removedAction != null && !removedAction.isBlank()) watched.add(removedAction);
+        row(rows, "META", "schema", "2");
         row(rows, "META", "timeUtc", Instant.now());
         row(rows, "META", "ide", info.getFullApplicationName());
         row(rows, "META", "build", info.getBuild().asString());
@@ -70,6 +78,14 @@ public final class KeymapAuditStarter implements ApplicationStarter {
         row(rows, "META", "activeKeymap", keymaps.getActiveKeymap().getName());
         row(rows, "META", "headless", ApplicationManager.getApplication().isHeadlessEnvironment());
         row(rows, "META", "registeredActionCount", manager.getActionIdList("").size());
+        row(rows, "META", "profileId", System.getProperty("csc.audit.profileId"));
+        row(rows, "META", "runId", System.getProperty("csc.audit.runId"));
+        row(rows, "META", "processId", ProcessHandle.current().pid());
+        row(rows, "META", "watchedActions", "[" + watched.stream().map(KeymapAuditStarter::jsonString)
+            .collect(java.util.stream.Collectors.joining(",")) + "]");
+        row(rows, "META", "projectRoots", "[" + Arrays.stream(ProjectManager.getInstance().getOpenProjects())
+            .map(project -> jsonString(project.getBasePath())).collect(java.util.stream.Collectors.joining(",")) + "]");
+        for (String probe : PROBES) row(rows, "PROBE", probe, KeyStroke.getKeyStroke(probe));
         for (String name : List.of("idea.config.path", "idea.system.path", "idea.plugins.path", "idea.log.path")) {
             row(rows, "META", name, System.getProperty(name));
         }
@@ -89,18 +105,24 @@ public final class KeymapAuditStarter implements ApplicationStarter {
             List<String> chain = new ArrayList<>();
             for (Keymap node = keymap; node != null; node = node.getParent()) {
                 if (!visited.add(node)) throw new IllegalStateException("Cyclic keymap parent chain");
+                // getParent alone does not initialize a lazy KeymapImpl. Reading
+                // shortcuts resolves the parent before following its next edge.
+                node.getShortcuts(PREFIX + "Copy");
                 chain.add(node.getName());
             }
-            row(rows, "KEYMAP", keymap.getName(), keymap.canModify(), String.join(" -> ", chain));
+            row(rows, "KEYMAP", keymap.getName(), keymap.canModify(), "[" + chain.stream()
+                .map(KeymapAuditStarter::jsonString).collect(java.util.stream.Collectors.joining(",")) + "]");
             // Include dormant mappings, action aliases and inherited action IDs as well as
             // registered actions. Keymap.getShortcuts supplies effective inherited values.
             Set<String> ids = new TreeSet<>(manager.getActionIdList(""));
             for (Keymap node = keymap; node != null; node = node.getParent()) ids.addAll(node.getActionIdList());
             for (String command : COMMANDS) ids.add(PREFIX + command);
+            ids.addAll(watched);
             for (String id : ids) {
                 Shortcut[] shortcuts = keymap.getShortcuts(id);
-                if (COMMANDS.stream().anyMatch(command -> id.equals(PREFIX + command))) {
-                    row(rows, "BINDING", keymap.getName(), id, Arrays.toString(shortcuts));
+                if (watched.contains(id)
+                    || COMMANDS.stream().anyMatch(command -> id.equals(PREFIX + command))) {
+                    row(rows, "BINDING", keymap.getName(), id, shortcutsJson(shortcuts));
                 }
                 for (Shortcut shortcut : shortcuts) {
                     if (!(shortcut instanceof KeyboardShortcut keyboard)) continue;
@@ -112,14 +134,44 @@ public final class KeymapAuditStarter implements ApplicationStarter {
                             : PluginManagerCore.getPluginDescriptorOrPlatformByClassName(action.getClass().getName());
                         row(rows, "OCCUPANCY", keymap.getName(), probe, id,
                             keyboard.getFirstKeyStroke(), keyboard.getSecondKeyStroke(),
-                            Arrays.toString(shortcuts), action != null,
+                            shortcutsJson(shortcuts), action != null,
                             owner == null ? "unknown" : owner.getPluginId(),
                             owner == null ? "unknown" : owner.isBundled());
                     }
                 }
             }
         }
-        row(rows, "END", "keymaps", maps.size(), "commands", COMMANDS.size());
+        long bindings = rows.stream().filter(value -> value.startsWith("BINDING\t")).count();
+        long occupancies = rows.stream().filter(value -> value.startsWith("OCCUPANCY\t")).count();
+        row(rows, "END", "keymaps", maps.size(), "commands", COMMANDS.size(),
+            "bindings", bindings, "occupancies", occupancies, "rows", rows.size() + 1);
+    }
+
+    private static String shortcutsJson(Shortcut[] shortcuts) {
+        List<String> values = new ArrayList<>();
+        for (Shortcut shortcut : shortcuts) {
+            if (shortcut instanceof KeyboardShortcut keyboard) {
+                values.add("{\"kind\":\"keyboard\",\"first\":" + jsonString(keyboard.getFirstKeyStroke().toString())
+                    + ",\"second\":" + jsonString(keyboard.getSecondKeyStroke() == null ? null : keyboard.getSecondKeyStroke().toString()) + "}");
+            } else if (shortcut instanceof MouseShortcut mouse) {
+                values.add("{\"kind\":\"mouse\",\"button\":" + mouse.getButton()
+                    + ",\"modifiers\":" + mouse.getModifiers() + ",\"clickCount\":" + mouse.getClickCount() + "}");
+            } else {
+                values.add("{\"kind\":\"other\",\"display\":" + jsonString(shortcut.toString()) + "}");
+            }
+        }
+        return "[" + String.join(",", values) + "]";
+    }
+
+    private static String jsonString(String value) {
+        if (value == null) return "null";
+        StringBuilder result = new StringBuilder("\"");
+        for (char character : value.toCharArray()) {
+            if (character == '"' || character == '\\') result.append('\\').append(character);
+            else if (character < 0x20) result.append(String.format("\\u%04x", (int) character));
+            else result.append(character);
+        }
+        return result.append('"').toString();
     }
 
     private static void row(List<String> rows, Object... cells) {

--- a/scripts/shortcut-audit/StrokeInventory.java
+++ b/scripts/shortcut-audit/StrokeInventory.java
@@ -1,0 +1,77 @@
+package audit;
+
+import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.ActionStubBase;
+import com.intellij.openapi.actionSystem.KeyboardShortcut;
+import com.intellij.openapi.actionSystem.Shortcut;
+import com.intellij.openapi.extensions.PluginDescriptor;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Optional complete effective shortcut inventory; the six schema-2 probes stay unchanged. */
+final class StrokeInventory {
+    private final List<String> rows = new ArrayList<>();
+    private final Map<String, Owner> owners = new HashMap<>();
+    private int registeredCount, sourceCount, actionCount, keymapCount, shortcutCount;
+    private int mapShortcuts, mapKeyboard;
+
+    void registered(Set<String> ids) {
+        registeredCount = ids.size();
+        for (String id : ids) KeymapAuditStarter.row(rows, "REGISTERED", id);
+    }
+
+    void source(String keymap, String ancestor, Set<String> ids) {
+        sourceCount++;
+        KeymapAuditStarter.row(rows, "SOURCE", keymap, ancestor, "[" + ids.stream()
+            .map(KeymapAuditStarter::jsonString).collect(java.util.stream.Collectors.joining(",")) + "]");
+    }
+
+    void action(String keymap, String id, Shortcut[] shortcuts, ActionManager manager) {
+        Owner owner = owners.computeIfAbsent(id, ignored -> {
+            var action = manager.getActionOrStub(id);
+            PluginDescriptor plugin = action instanceof ActionStubBase stub ? stub.getPlugin()
+                : action == null ? null
+                : PluginManagerCore.getPluginDescriptorOrPlatformByClassName(action.getClass().getName());
+            return new Owner(action != null, plugin == null ? "unknown" : plugin.getPluginId().getIdString(),
+                plugin == null ? "unknown" : Boolean.toString(plugin.isBundled()));
+        });
+        actionCount++;
+        mapShortcuts += shortcuts.length;
+        for (Shortcut shortcut : shortcuts) if (shortcut instanceof KeyboardShortcut) mapKeyboard++;
+        KeymapAuditStarter.row(rows, "ACTION", keymap, id, KeymapAuditStarter.shortcutsJson(shortcuts),
+            owner.registered, owner.plugin, owner.bundled);
+    }
+
+    void keymap(String name, int actions) {
+        keymapCount++;
+        shortcutCount += mapShortcuts;
+        KeymapAuditStarter.row(rows, "MAP", name, actions, mapShortcuts, mapKeyboard);
+        mapShortcuts = mapKeyboard = 0;
+    }
+
+    void write(Path output, String auditFile, byte[] auditBytes) throws Exception {
+        List<String> complete = new ArrayList<>();
+        KeymapAuditStarter.row(complete, "META", "schema", "1");
+        KeymapAuditStarter.row(complete, "META", "auditFile", auditFile);
+        KeymapAuditStarter.row(complete, "META", "auditSha256",
+            HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(auditBytes)));
+        complete.addAll(rows);
+        KeymapAuditStarter.row(complete, "END", "keymaps", keymapCount, "registered", registeredCount,
+            "sources", sourceCount, "actions", actionCount, "shortcuts", shortcutCount, "rows", complete.size() + 1);
+        Files.writeString(output, String.join("\n", complete) + "\n", StandardCharsets.UTF_8,
+            StandardOpenOption.CREATE_NEW);
+    }
+
+    private record Owner(boolean registered, String plugin, String bundled) {}
+}

--- a/scripts/shortcut-audit/audit.py
+++ b/scripts/shortcut-audit/audit.py
@@ -506,6 +506,8 @@ def launch_gui(args):
             stream.write("-Dcsc.audit.removedAction=" + metadata["removedAction"] + "\n")
         if getattr(args, "stroke_inventory", False):
             stream.write("-Dcsc.audit.strokeInventory=true\n")
+        if getattr(args, "all_os_keymaps", False):
+            stream.write("-Dkeymap.current.os.only=false\n")
     environment = os.environ.copy()
     variable = info["envVarBaseName"]
     environment[variable + "_PROPERTIES"] = str(root / "idea.properties")
@@ -513,6 +515,7 @@ def launch_gui(args):
     command = [str(launcher), str(Path(args.project).resolve())]
     context = run_context(root, metadata, run_id, "gui", info["buildNumber"], str(Path(args.project).resolve()))
     context["strokeInventory"] = bool(getattr(args, "stroke_inventory", False))
+    context["keymapOsFilterOverride"] = False if getattr(args, "all_os_keymaps", False) else None
     write_json(run_directory / "gui-command.json", {**context, "argv": command, "productInfo": info,
                                            "properties": str(root / "idea.properties"), "vmOptions": str(vmoptions)})
     run_process(command, root, run_directory, context, environment)
@@ -569,6 +572,8 @@ def main():
         gui.add_argument("--" + option, required=True)
     gui.add_argument("--stroke-inventory", action="store_true",
                      help="GUI export also writes a complete .strokes.tsv companion")
+    gui.add_argument("--all-os-keymaps", action="store_true",
+                     help="Explicit GUI-only keymap.current.os.only=false override; record loaded results separately")
     gui.set_defaults(run=launch_gui)
     compare = commands.add_parser("compare-prefixes")
     compare.add_argument("--export", dest="exports", action="append", required=True,

--- a/scripts/shortcut-audit/audit.py
+++ b/scripts/shortcut-audit/audit.py
@@ -11,17 +11,17 @@ import json
 import os
 from pathlib import Path
 import shutil
+import signal
 import subprocess
+import uuid
 from datetime import datetime, timezone
 import xml.etree.ElementTree as ET
 import zipfile
 
+from evidence import COMMANDS, COMMAND_IDS, PREFIX, PRODUCT_ID, parse_export, require
+
 
 HERE = Path(__file__).resolve().parent
-PRODUCT_ID = "com.github.hon454.copy-selection-context"
-PREFIX = "CopySelectionContext."
-COMMANDS = ["Copy", "ShowHistory", "AddToCollection", "ShowCollection", "CopyAllCollection",
-            "CopyRelativePath", "CopyAbsolutePath", "CopyWithCodeContent", "CopyGitPermalink"]
 CASES = ["pristine", "unrelated-only", "explicit-old", "custom", "unassigned", "removed-ide"]
 
 
@@ -72,9 +72,10 @@ def initialize(root):
 
 def profile_metadata(root, archive, version, **extra):
     write_json(root / "profile.json", {
-        "schema": 1, "createdUtc": datetime.now(timezone.utc).isoformat(),
+        "schema": 2, "profileId": str(uuid.uuid4()), "createdUtc": datetime.now(timezone.utc).isoformat(),
         "profile": str(root), "productZip": str(archive), "productSha256": digest(archive),
-        "productVersion": version, "state": "prepared-not-launched", **extra,
+        "productVersion": version, "productFiles": tree_snapshot(root, "plugins"),
+        "state": "prepared-not-launched", **extra,
     })
 
 
@@ -123,16 +124,15 @@ def prepare(args):
         seed_keymap(root, args.case, args.parent, args.native_mac, args.removed_action,
                     args.old_copy, args.old_history)
     profile_metadata(root, archive, version, case=args.case, parent=args.parent,
-                     removedAction=args.removed_action, oldCopy=args.old_copy, oldHistory=args.old_history)
+                     nativeMac=args.native_mac, removedAction=args.removed_action,
+                     oldCopy=args.old_copy, oldHistory=args.old_history)
 
 
 def clone_upgrade(args):
     source, target = Path(args.source).resolve(), Path(args.output).resolve()
-    original = json.loads((source / "profile.json").read_text())
-    if original["productVersion"] != "1.6.0":
-        raise ValueError("Source is not a prepared v1.6.0 baseline")
-    if (source / "config/.lock").exists():
-        raise ValueError("Stop the baseline IDE before cloning")
+    require(source != target and source not in target.parents and target not in source.parents,
+            "source and target must be disjoint canonical paths")
+    validate_acceptance(source)
     archive = Path(args.zip).resolve()
     if digest(archive) != args.sha256:
         raise ValueError("Candidate ZIP digest mismatch")
@@ -144,8 +144,207 @@ def clone_upgrade(args):
 
 
 def config_snapshot(root):
-    return {str(path.relative_to(root)): digest(path)
-            for path in sorted((root / "config").rglob("*")) if path.is_file()}
+    return tree_snapshot(root, "config")
+
+
+def tree_snapshot(root, directory):
+    result = {}
+    base = root / directory
+    require(base.is_dir() and not base.is_symlink(), "invalid profile directory " + directory)
+    for path in sorted(base.rglob("*")):
+        require(not path.is_symlink(), "profile contains a symlink: " + str(path))
+        if path.is_file():
+            result[str(path.relative_to(root))] = digest(path)
+    return result
+
+
+def load_profile(root):
+    metadata = json.loads((root / "profile.json").read_text())
+    require(metadata.get("schema") == 2, "profile must be prepared by the current tool")
+    require(metadata.get("profile") == str(root), "profile identity/path mismatch")
+    uuid.UUID(metadata["profileId"])
+    require(metadata.get("state") == "prepared-not-launched", "invalid immutable preparation record")
+    files = metadata.get("productFiles")
+    require(isinstance(files, dict) and bool(files), "missing installed product manifest")
+    for name, expected in files.items():
+        path = contained_file(root, name)
+        require(name.startswith("plugins/") and digest(path) == expected, "installed product changed")
+    return metadata
+
+
+def contained_file(root, name):
+    path = root / name
+    resolved = path.resolve()
+    require(not Path(name).is_absolute() and root in resolved.parents and path.is_file(), "evidence path escapes profile or is missing")
+    for node in [path, *path.parents]:
+        if node == root:
+            break
+        require(not node.is_symlink(), "symlink evidence is not accepted")
+    return resolved
+
+
+def ensure_closed(root):
+    lock = root / "config/.lock"
+    require(not lock.exists() and not lock.is_symlink(), "stop the profile IDE first")
+    for run in root.glob("gui-run-*"):
+        require(run.is_dir() and not run.is_symlink(), "invalid GUI run directory")
+        require(not (run / "process-start.json").exists() or (run / "process-result.json").exists(), "unfinished GUI launch record")
+
+
+def run_process(command, root, directory, context, environment=None, timeout=None, log_name="gui-console.log"):
+    """Own the launched process group and always record exit/cleanup evidence."""
+    started = datetime.now(timezone.utc).isoformat()
+    process, interrupted = None, False
+    with open(directory / log_name, "x") as log:
+        try:
+            process = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT,
+                                       env=environment, start_new_session=True)
+            write_json(directory / "process-start.json", {**context, "pid": process.pid, "startedUtc": started})
+            print(f"Started test IDE pid={process.pid}, profile={root}, evidence={directory}", flush=True)
+            process.wait(timeout=timeout)
+            if process.returncode:
+                raise RuntimeError(f"IDE exited {process.returncode}; see {directory / log_name}")
+        except BaseException:
+            interrupted = True
+            if process is not None:
+                try:
+                    os.killpg(process.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
+                # A launcher can exit before one of its children. Clean the
+                # owned group even when the direct process has already ended.
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                process.wait(timeout=5)
+            raise
+        finally:
+            if process is not None:
+                write_json(directory / "process-result.json", {**context, "pid": process.pid,
+                    "startedUtc": started, "finishedUtc": datetime.now(timezone.utc).isoformat(),
+                    "exitCode": process.poll(), "interrupted": interrupted,
+                    "configSnapshot": config_snapshot(root)})
+
+
+def run_context(root, metadata, run_id, mode, build, project=None):
+    return {"schema": 1, "runId": run_id, "profileId": metadata["profileId"], "profile": str(root),
+            "profileSha256": digest(root / "profile.json"), "productSha256": metadata["productSha256"],
+            "mode": mode, "ideBuild": build, "project": project}
+
+
+def acceptance_proof(root, run_name, export_name, gui_names, observed_keymap):
+    metadata = load_profile(root)
+    require(metadata.get("productVersion") == "1.6.0" and metadata.get("case") in CASES, "not a released-version baseline case")
+    ensure_closed(root)
+    directory = root / run_name
+    require(directory.resolve().parent == root and directory.name.startswith("gui-run-") and not directory.is_symlink(), "invalid GUI run directory")
+    start_path = contained_file(root, run_name + "/process-start.json")
+    end_path = contained_file(root, run_name + "/process-result.json")
+    command_path = contained_file(root, run_name + "/gui-command.json")
+    start, end, command = [json.loads(path.read_text()) for path in [start_path, end_path, command_path]]
+    require(start.get("schema") == 1 and end.get("schema") == 1 and start.get("mode") == end.get("mode") == "gui", "not a GUI launch")
+    require(type(start.get("pid")) is int and start["pid"] > 0 and start["pid"] == end.get("pid"), "PID evidence mismatch")
+    require(type(end.get("exitCode")) is int and end["exitCode"] == 0 and end.get("interrupted") is False, "GUI did not exit cleanly")
+    for key in ["runId", "profileId", "profile", "profileSha256", "productSha256", "ideBuild", "project"]:
+        require(start.get(key) is not None and start.get(key) == end.get(key) == command.get(key), "launch identity mismatch: " + key)
+    require(start["profileId"] == metadata["profileId"] and start["profile"] == str(root)
+            and start["profileSha256"] == digest(root / "profile.json")
+            and start["productSha256"] == metadata["productSha256"], "launch/profile mismatch")
+    uuid.UUID(start["runId"])
+    require(directory.name == "gui-run-" + start["runId"], "GUI run directory identity mismatch")
+    export_path = contained_file(root, export_name)
+    require(export_path.parent == directory.resolve(), "export belongs to another run")
+    data = parse_export(export_path)
+    meta = data["metadata"]
+    require(meta["headless"] == "false" and meta["profileId"] == start["profileId"]
+            and meta["runId"] == start["runId"] and int(meta["processId"]) == start["pid"], "export is not from this GUI process")
+    require(meta["build"].split("-", 1)[-1] == start["ideBuild"], "IDE build mismatch")
+    require(data["plugins"][PRODUCT_ID][2] == "1.6.0", "GUI did not load v1.6.0")
+    for name in ["config", "system", "plugins", "log"]:
+        require(Path(meta["idea." + name + ".path"]).resolve() == root / name, "GUI used other profile paths")
+    require(start["project"] in json.loads(meta["projectRoots"]), "expected project was not open")
+    stamp = lambda value: datetime.fromisoformat(value.replace("Z", "+00:00"))
+    require(stamp(start["startedUtc"]) <= stamp(meta["timeUtc"]) <= stamp(end["finishedUtc"]), "export outside GUI process lifetime")
+    expected_map = metadata["parent"] if metadata["case"] == "pristine" else "CSC Audit " + metadata["case"]
+    require(observed_keymap == meta["activeKeymap"] == expected_map, "active keymap did not accept the seed")
+    validate_seed_bindings(metadata, data)
+    require(config_snapshot(root) == end.get("configSnapshot"), "baseline config changed after clean exit")
+    require(bool(gui_names), "missing GUI observation evidence")
+    gui = [contained_file(root, name) for name in gui_names]
+    require(all(path.parent == directory.resolve() and path.stat().st_size > 0 for path in gui), "GUI evidence belongs to another run or is empty")
+    def is_screenshot(path):
+        with open(path, "rb") as stream:
+            signature = stream.read(8)
+        return (path.suffix.lower() == ".png" and signature == b"\x89PNG\r\n\x1a\n"
+                or path.suffix.lower() in {".jpg", ".jpeg"} and signature.startswith(b"\xff\xd8\xff"))
+    require(any(is_screenshot(path) for path in gui)
+            and any(path.suffix == ".txt" for path in gui), "both screenshot and accessibility text are required")
+    files = [start_path, end_path, command_path, export_path, *gui]
+    return {"profileId": metadata["profileId"], "runId": start["runId"], "keymap": observed_keymap,
+            "files": {str(path.relative_to(root)): digest(path) for path in files},
+            "configSnapshot": config_snapshot(root), "finishedUtc": end["finishedUtc"]}
+
+
+def accept_baseline(args):
+    root = Path(args.profile).resolve()
+    require(args.confirm_observed and args.performer.strip() and args.notes.strip(), "explicit operator observation is required")
+    run_name = str(Path(args.run_directory).resolve().relative_to(root))
+    export_name = str(Path(args.export).resolve().relative_to(root))
+    gui_names = [str(Path(path).resolve().relative_to(root)) for path in args.gui_evidence]
+    proof = acceptance_proof(root, run_name, export_name, gui_names, args.observed_keymap)
+    write_json(root / "acceptance.json", {"schema": 1, "state": "gui-accepted",
+        "performer": args.performer, "notes": args.notes, "acceptedUtc": datetime.now(timezone.utc).isoformat(),
+        "runDirectory": run_name, "export": export_name, "guiEvidence": gui_names,
+        "observedKeymap": args.observed_keymap, "proof": proof})
+
+
+def validate_acceptance(root):
+    record = json.loads(contained_file(root, "acceptance.json").read_text())
+    require(record.get("schema") == 1 and record.get("state") == "gui-accepted"
+            and isinstance(record.get("performer"), str) and bool(record["performer"].strip())
+            and isinstance(record.get("notes"), str) and bool(record["notes"].strip()), "missing explicit baseline acceptance")
+    proof = acceptance_proof(root, record["runDirectory"], record["export"], record["guiEvidence"], record["observedKeymap"])
+    require(record.get("proof") == proof, "acceptance evidence changed or marker is incomplete")
+
+
+def validate_seed_bindings(metadata, data):
+    keymap = data["metadata"]["activeKeymap"]
+    values = lambda action, scheme=keymap: json.loads(data["bindings"][(scheme, action)][3])
+    for action in COMMAND_IDS - {PREFIX + "Copy", PREFIX + "ShowHistory"}:
+        require(values(action) == [], "v1.6.0 seed unexpectedly binds " + action)
+    tokens = lambda stroke: sorted(stroke.replace("control", "ctrl").split()
+                                   + ([] if any(word in stroke.split() for word in ["pressed", "released", "typed"]) else ["pressed"]))
+    def single_keyboard(items, expected):
+        return len(items) == 1 and items[0]["kind"] == "keyboard" and items[0]["second"] is None and tokens(items[0]["first"]) == tokens(expected)
+    case = metadata["case"]
+    for command, key in [("Copy", "C"), ("ShowHistory", "H")]:
+        items = values(PREFIX + command)
+        if case == "unassigned":
+            require(items == [], "explicit unassigned binding was not accepted")
+        elif case == "explicit-old":
+            expected = metadata["oldCopy" if command == "Copy" else "oldHistory"]
+            require(single_keyboard(items, expected), "explicit legacy binding was not accepted")
+        elif case == "custom":
+            keyboard = [item for item in items if item["kind"] == "keyboard"]
+            modifier = "meta" if metadata["nativeMac"] else "control"
+            require(single_keyboard(keyboard, modifier + " shift F" + ("11" if key == "C" else "12")), "custom keyboard binding was not accepted")
+            other = [item for item in items if item["kind"] != "keyboard"]
+            expected_mouse = (not other if command == "ShowHistory" else len(other) == 1
+                              and other[0]["kind"] == "mouse" and other[0]["button"] == 2
+                              and other[0]["clickCount"] == 1 and other[0]["modifiers"] in {2, 128, 130})
+            require(expected_mouse, "custom mouse binding was not accepted")
+        else:
+            require(items == values(PREFIX + command, metadata["parent"]), "inherited binding changed in seed")
+    if case == "unrelated-only":
+        require(single_keyboard(values("EditorToggleUseSoftWraps"), "control alt shift F9"), "unrelated edit was not accepted")
+    if case == "removed-ide":
+        action = metadata["removedAction"]
+        require(values(action) == [] and bool(values(action, metadata["parent"])), "IDE removal was not accepted or parent was already unassigned")
 
 
 def build(args):
@@ -167,9 +366,10 @@ def build(args):
 
 def audit(args):
     home, root = Path(args.ide_home).resolve(), Path(args.profile).resolve()
-    metadata = json.loads((root / "profile.json").read_text())
-    if metadata["profile"] != str(root):
-        raise ValueError("Profile path changed; create or clone a profile explicitly")
+    metadata = load_profile(root)
+    ensure_closed(root)
+    require(not (root / "acceptance.json").exists(), "accepted baselines are immutable; use a clone")
+    run_id = str(uuid.uuid4())
     probe = Path(args.harness).resolve()
     shutil.copytree(probe, root / "plugins/csc-keymap-audit", dirs_exist_ok=False)
     product_info_path = home / "Resources/product-info.json"
@@ -186,64 +386,61 @@ def audit(args):
            .replace("$APP_PACKAGE", str(home.parent)).replace("$IDE_HOME", str(home))
            for item in launch["additionalJvmArguments"]]
     command = [str(java), "-Xms128m", "-Xmx1536m", *jvm, "-Djava.awt.headless=true",
+               f"-Dcsc.audit.profileId={metadata['profileId']}", f"-Dcsc.audit.runId={run_id}",
                f"-Didea.home.path={home}", f"-Didea.properties.file={root / 'idea.properties'}",
                f"-XX:ErrorFile={root / 'log/hs_err_%p.log'}", f"-XX:HeapDumpPath={root / 'log/heap.hprof'}"]
     command += [f"-Didea.{name}.path={root / name}" for name in ["config", "system", "plugins", "log"]]
+    if metadata.get("removedAction"):
+        command.append("-Dcsc.audit.removedAction=" + metadata["removedAction"])
     command += ["-cp", classpath, "com.intellij.idea.Main", "csc-keymap-audit", str(root / "keymaps.tsv")]
-    write_json(root / "audit-command.json", {"argv": command, "productInfo": info, "profile": metadata})
-    with open(root / "audit-console.log", "x") as log:
-        result = subprocess.run(command, stdout=log, stderr=subprocess.STDOUT, timeout=args.timeout)
-    if result.returncode:
-        raise RuntimeError(f"IDE exited {result.returncode}; see {root / 'audit-console.log'}")
+    context = run_context(root, metadata, run_id, "headless", info["buildNumber"])
+    write_json(root / "audit-command.json", {**context, "argv": command, "productInfo": info})
+    run_process(command, root, root, context, timeout=args.timeout, log_name="audit-console.log")
     summarize(root / "keymaps.tsv", root / "summary.json")
 
 
 def launch_gui(args):
     app, root = Path(args.app).resolve(), Path(args.profile).resolve()
-    metadata = json.loads((root / "profile.json").read_text())
-    if metadata["profile"] != str(root):
-        raise ValueError("Profile path changed; create or clone it explicitly")
+    metadata = load_profile(root)
+    ensure_closed(root)
+    require(not (root / "acceptance.json").exists(), "accepted baselines are immutable; use a clone")
+    run_id = str(uuid.uuid4())
     info_path = app / "Contents/Resources/product-info.json"
     info = json.loads(info_path.read_text())
     launch = next(item for item in info["launch"] if item["os"] == "macOS" and item["arch"] == "aarch64")
     launcher = (info_path.parent / launch["launcherPath"]).resolve()
     original_options = (info_path.parent / launch["vmOptionsFilePath"]).read_text()
-    run_directory = root / ("gui-run-" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ"))
+    run_directory = root / ("gui-run-" + run_id)
     run_directory.mkdir()
     vmoptions = run_directory / "gui.vmoptions"
     with open(vmoptions, "x") as stream:
         stream.write(original_options + f"\n-XX:ErrorFile={root / 'log/hs_err_%p.log'}\n"
                      + f"-XX:HeapDumpPath={root / 'log/heap.hprof'}\n"
-                     + f"-Dcsc.audit.output={root}\n")
+                     + f"-Dcsc.audit.output={run_directory}\n"
+                     + f"-Dcsc.audit.profileId={metadata['profileId']}\n-Dcsc.audit.runId={run_id}\n")
+        if metadata.get("removedAction"):
+            stream.write("-Dcsc.audit.removedAction=" + metadata["removedAction"] + "\n")
     environment = os.environ.copy()
     variable = info["envVarBaseName"]
     environment[variable + "_PROPERTIES"] = str(root / "idea.properties")
     environment[variable + "_VM_OPTIONS"] = str(vmoptions)
     command = [str(launcher), str(Path(args.project).resolve())]
-    write_json(run_directory / "gui-command.json", {"argv": command, "productInfo": info, "profile": metadata,
+    context = run_context(root, metadata, run_id, "gui", info["buildNumber"], str(Path(args.project).resolve()))
+    write_json(run_directory / "gui-command.json", {**context, "argv": command, "productInfo": info,
                                            "properties": str(root / "idea.properties"), "vmOptions": str(vmoptions)})
-    with open(run_directory / "gui-console.log", "x") as log:
-        process = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, env=environment)
-        print(f"Started test IDE pid={process.pid}, profile={root}", flush=True)
-        result = process.wait()
-    if result:
-        raise RuntimeError(f"IDE exited {result}; see {run_directory / 'gui-console.log'}")
+    run_process(command, root, run_directory, context, environment)
 
 
-def summarize(source, target):
-    with source.open(encoding="utf-8") as stream:
-        rows = [line.rstrip("\n").split("\t") for line in stream]
-    commands = [row[1] for row in rows if row[0] == "COMMAND"]
-    keymaps = [row for row in rows if row[0] == "KEYMAP"]
-    if not rows or rows[-1][0] != "END" or set(commands) != {PREFIX + name for name in COMMANDS} or not keymaps:
-        raise ValueError("Incomplete runtime evidence (missing END, keymaps or product actions)")
-    occupancy = [row for row in rows if row[0] == "OCCUPANCY"]
-    external = [row for row in occupancy if row[2].endswith("shift G") and row[3] not in commands]
+def summarize(source, target, allow_legacy=False):
+    data = parse_export(source, allow_legacy)
+    commands, keymaps, occupancy = data["commands"], data["keymaps"], data["occupancies"]
+    external = [row for row in occupancy if row[2].endswith("shift G") and row[3] not in COMMAND_IDS]
     write_json(target, {"sourceSha256": digest(source), "keymapCount": len(keymaps),
-                       "commandCount": len(commands), "keymaps": keymaps,
+                       "commandCount": len(commands), "keymaps": list(keymaps.values()), "bindingCount": len(data["bindings"]),
+                       "legacyInspectionOnly": data["legacyInspectionOnly"],
                        "externalPrefixOccupancy": external,
                        "oldCHOccupancy": [row for row in occupancy if not row[2].endswith("shift G")],
-                       "note": "Loaded effective keymap data only; no physical key, GUI, OS or IME verdict"})
+                       "note": "Data inspection only, not a pass verdict. Legacy exports require regeneration and cannot be accepted as baselines; no physical key, GUI, OS or IME verdict."})
     print(f"{len(keymaps)} keymaps, {len(commands)} product actions, {len(external)} external prefix occupancies")
 
 
@@ -278,10 +475,17 @@ def main():
     for option in ["app", "profile", "project"]:
         gui.add_argument("--" + option, required=True)
     gui.set_defaults(run=launch_gui)
+    accept = commands.add_parser("accept-baseline")
+    for option in ["profile", "run-directory", "export", "observed-keymap", "performer", "notes"]:
+        accept.add_argument("--" + option, required=True)
+    accept.add_argument("--gui-evidence", action="append", required=True)
+    accept.add_argument("--confirm-observed", action="store_true")
+    accept.set_defaults(run=accept_baseline)
     report = commands.add_parser("summarize")
     report.add_argument("source", type=Path)
     report.add_argument("output", type=Path)
-    report.set_defaults(run=lambda args: summarize(args.source, args.output))
+    report.add_argument("--allow-legacy", action="store_true", help="Inspect old data without accepting it as complete evidence")
+    report.set_defaults(run=lambda args: summarize(args.source, args.output, args.allow_legacy))
     snap = commands.add_parser("snapshot")
     snap.add_argument("profile", type=Path)
     snap.add_argument("output", type=Path)

--- a/scripts/shortcut-audit/audit.py
+++ b/scripts/shortcut-audit/audit.py
@@ -559,9 +559,12 @@ def main():
     compare.add_argument("--export", dest="exports", action="append", required=True,
                          help="Schema-2 export with a matching complete inventory companion; repeat for IDEs")
     compare.add_argument("--key", dest="keys", action="append",
-                         help="Candidate A-Z or F1-F24; defaults to all 50 keys with Ctrl/Meta+Alt+Shift")
+                         help="A-Z, F1-F24 or Swing punctuation name (e.g. SEMICOLON); defaults to all 61 keys")
     compare.add_argument("--output", required=True)
-    compare.set_defaults(run=lambda args: write_json(Path(args.output), compare_prefixes(args.exports, args.keys)))
+    compare.add_argument("--defaults-source",
+                         help="Source-pinned CopySelectionShortcuts.kt; adds product-selected modifier analysis")
+    compare.set_defaults(run=lambda args: write_json(Path(args.output), compare_prefixes(
+        args.exports, args.keys, args.defaults_source)))
     accept = commands.add_parser("accept-baseline")
     for option in ["profile", "run-directory", "export", "observed-keymap", "performer", "notes"]:
         accept.add_argument("--" + option, required=True)

--- a/scripts/shortcut-audit/audit.py
+++ b/scripts/shortcut-audit/audit.py
@@ -23,6 +23,8 @@ from evidence import COMMANDS, COMMAND_IDS, PREFIX, PRODUCT_ID, parse_export, re
 
 HERE = Path(__file__).resolve().parent
 CASES = ["pristine", "unrelated-only", "explicit-old", "custom", "unassigned", "removed-ide"]
+HARNESS_ID = PRODUCT_ID + ".audit"
+HARNESS_JAR = "lib/csc-keymap-audit.jar"
 
 
 def digest(path):
@@ -183,6 +185,37 @@ def contained_file(root, name):
     return resolved
 
 
+def exporter_sources():
+    return {path.name: digest(path) for path in sorted([*HERE.glob("*.java"), HERE / "plugin.xml"])}
+
+
+def validate_harness(directory):
+    """Accept only the exact diagnostic artifact built from these exporter sources."""
+    manifest_path = contained_file(directory, "manifest.json")
+    manifest = json.loads(manifest_path.read_text())
+    require(manifest.get("schema") == 1 and manifest.get("pluginId") == HARNESS_ID,
+            "missing or wrong harness manifest identity")
+    require(manifest.get("sources") == exporter_sources(), "stale harness exporter sources; rebuild the harness")
+    jar = contained_file(directory, HARNESS_JAR)
+    require(manifest.get("jarSha256") == digest(jar), "harness JAR changed")
+    files = tree_snapshot(directory, ".")
+    require(set(files) == {"manifest.json", HARNESS_JAR}, "unexpected harness files")
+    with zipfile.ZipFile(jar) as archive:
+        descriptor = archive.read("META-INF/plugin.xml")
+        require(ET.fromstring(descriptor).findtext("id") == HARNESS_ID, "wrong harness plugin ID")
+        require(hashlib.sha256(descriptor).hexdigest() == manifest["sources"]["plugin.xml"],
+                "harness descriptor differs from reviewed source")
+    return {"pluginId": HARNESS_ID, "directory": str(directory),
+            "jarSha256": manifest["jarSha256"], "manifestSha256": digest(manifest_path),
+            "sources": manifest["sources"], "sourceRevision": manifest.get("sourceRevision"),
+            "sourceTreeDirty": manifest.get("sourceTreeDirty")}
+
+
+def harness_properties(identity):
+    return ["-Dcsc.audit.harnessJarSha256=" + identity["jarSha256"],
+            "-Dcsc.audit.harnessManifestSha256=" + identity["manifestSha256"]]
+
+
 def ensure_closed(root):
     lock = root / "config/.lock"
     require(not lock.exists() and not lock.is_symlink(), "stop the profile IDE first")
@@ -234,7 +267,8 @@ def run_process(command, root, directory, context, environment=None, timeout=Non
 def run_context(root, metadata, run_id, mode, build, project=None):
     return {"schema": 1, "runId": run_id, "profileId": metadata["profileId"], "profile": str(root),
             "profileSha256": digest(root / "profile.json"), "productSha256": metadata["productSha256"],
-            "mode": mode, "ideBuild": build, "project": project}
+            "mode": mode, "ideBuild": build, "project": project,
+            "harness": validate_harness(root / "plugins/csc-keymap-audit")}
 
 
 def acceptance_proof(root, run_name, export_name, gui_names, observed_keymap):
@@ -250,19 +284,26 @@ def acceptance_proof(root, run_name, export_name, gui_names, observed_keymap):
     require(start.get("schema") == 1 and end.get("schema") == 1 and start.get("mode") == end.get("mode") == "gui", "not a GUI launch")
     require(type(start.get("pid")) is int and start["pid"] > 0 and start["pid"] == end.get("pid"), "PID evidence mismatch")
     require(type(end.get("exitCode")) is int and end["exitCode"] == 0 and end.get("interrupted") is False, "GUI did not exit cleanly")
-    for key in ["runId", "profileId", "profile", "profileSha256", "productSha256", "ideBuild", "project"]:
+    for key in ["runId", "profileId", "profile", "profileSha256", "productSha256", "ideBuild", "project", "harness"]:
         require(start.get(key) is not None and start.get(key) == end.get(key) == command.get(key), "launch identity mismatch: " + key)
     require(start["profileId"] == metadata["profileId"] and start["profile"] == str(root)
             and start["profileSha256"] == digest(root / "profile.json")
             and start["productSha256"] == metadata["productSha256"], "launch/profile mismatch")
     uuid.UUID(start["runId"])
     require(directory.name == "gui-run-" + start["runId"], "GUI run directory identity mismatch")
+    harness = validate_harness(root / "plugins/csc-keymap-audit")
+    require(start["harness"] == harness, "installed harness differs from GUI launch")
     export_path = contained_file(root, export_name)
     require(export_path.parent == directory.resolve(), "export belongs to another run")
     data = parse_export(export_path)
     meta = data["metadata"]
     require(meta["headless"] == "false" and meta["profileId"] == start["profileId"]
             and meta["runId"] == start["runId"] and int(meta["processId"]) == start["pid"], "export is not from this GUI process")
+    require(meta["harnessJarSha256"] == harness["jarSha256"]
+            and meta["harnessManifestSha256"] == harness["manifestSha256"], "export harness identity mismatch")
+    require(HARNESS_ID in data["plugins"]
+            and Path(data["plugins"][HARNESS_ID][4]).resolve() == Path(harness["directory"]),
+            "GUI loaded the harness from another directory")
     require(meta["build"].split("-", 1)[-1] == start["ideBuild"], "IDE build mismatch")
     require(data["plugins"][PRODUCT_ID][2] == "1.6.0", "GUI did not load v1.6.0")
     for name in ["config", "system", "plugins", "log"]:
@@ -286,6 +327,7 @@ def acceptance_proof(root, run_name, export_name, gui_names, observed_keymap):
             and any(path.suffix == ".txt" for path in gui), "both screenshot and accessibility text are required")
     files = [start_path, end_path, command_path, export_path, *gui]
     return {"profileId": metadata["profileId"], "runId": start["runId"], "keymap": observed_keymap,
+            "harness": harness,
             "files": {str(path.relative_to(root)): digest(path) for path in files},
             "configSnapshot": config_snapshot(root), "finishedUtc": end["finishedUtc"]}
 
@@ -349,6 +391,7 @@ def validate_seed_bindings(metadata, data):
 
 def build(args):
     home, output = Path(args.ide_home).resolve(), Path(args.output).resolve()
+    sources = exporter_sources()
     output.mkdir(parents=True, exist_ok=False)
     classes = output / "classes"
     classes.mkdir()
@@ -361,6 +404,17 @@ def build(args):
         archive.write(HERE / "plugin.xml", "META-INF/plugin.xml")
         for path in classes.rglob("*.class"):
             archive.write(path, str(path.relative_to(classes)))
+    revision = subprocess.run(["git", "-C", str(HERE), "rev-parse", "HEAD"],
+                              capture_output=True, text=True)
+    status = subprocess.run(["git", "-C", str(HERE), "status", "--porcelain", "--", "."],
+                            capture_output=True, text=True)
+    require(sources == exporter_sources(), "exporter sources changed while compiling")
+    directory = jar.parent.parent
+    write_json(directory / "manifest.json", {"schema": 1, "pluginId": HARNESS_ID,
+        "createdUtc": datetime.now(timezone.utc).isoformat(), "jarSha256": digest(jar), "sources": sources,
+        "sourceRevision": revision.stdout.strip() if revision.returncode == 0 else None,
+        "sourceTreeDirty": bool(status.stdout.strip()) if status.returncode == 0 else None})
+    validate_harness(directory)
     print(jar)
 
 
@@ -371,7 +425,9 @@ def audit(args):
     require(not (root / "acceptance.json").exists(), "accepted baselines are immutable; use a clone")
     run_id = str(uuid.uuid4())
     probe = Path(args.harness).resolve()
+    validate_harness(probe)
     shutil.copytree(probe, root / "plugins/csc-keymap-audit", dirs_exist_ok=False)
+    harness = validate_harness(root / "plugins/csc-keymap-audit")
     product_info_path = home / "Resources/product-info.json"
     if not product_info_path.exists():
         product_info_path = home / "product-info.json"
@@ -390,12 +446,19 @@ def audit(args):
                f"-Didea.home.path={home}", f"-Didea.properties.file={root / 'idea.properties'}",
                f"-XX:ErrorFile={root / 'log/hs_err_%p.log'}", f"-XX:HeapDumpPath={root / 'log/heap.hprof'}"]
     command += [f"-Didea.{name}.path={root / name}" for name in ["config", "system", "plugins", "log"]]
+    command += harness_properties(harness)
     if metadata.get("removedAction"):
         command.append("-Dcsc.audit.removedAction=" + metadata["removedAction"])
     command += ["-cp", classpath, "com.intellij.idea.Main", "csc-keymap-audit", str(root / "keymaps.tsv")]
     context = run_context(root, metadata, run_id, "headless", info["buildNumber"])
     write_json(root / "audit-command.json", {**context, "argv": command, "productInfo": info})
     run_process(command, root, root, context, timeout=args.timeout, log_name="audit-console.log")
+    require(context["harness"] == validate_harness(root / "plugins/csc-keymap-audit"),
+            "harness changed during audit")
+    exported = parse_export(root / "keymaps.tsv")["metadata"]
+    require(exported["harnessJarSha256"] == context["harness"]["jarSha256"]
+            and exported["harnessManifestSha256"] == context["harness"]["manifestSha256"],
+            "audit export harness identity mismatch")
     summarize(root / "keymaps.tsv", root / "summary.json")
 
 
@@ -404,6 +467,7 @@ def launch_gui(args):
     metadata = load_profile(root)
     ensure_closed(root)
     require(not (root / "acceptance.json").exists(), "accepted baselines are immutable; use a clone")
+    harness = validate_harness(root / "plugins/csc-keymap-audit")
     run_id = str(uuid.uuid4())
     info_path = app / "Contents/Resources/product-info.json"
     info = json.loads(info_path.read_text())
@@ -417,7 +481,8 @@ def launch_gui(args):
         stream.write(original_options + f"\n-XX:ErrorFile={root / 'log/hs_err_%p.log'}\n"
                      + f"-XX:HeapDumpPath={root / 'log/heap.hprof'}\n"
                      + f"-Dcsc.audit.output={run_directory}\n"
-                     + f"-Dcsc.audit.profileId={metadata['profileId']}\n-Dcsc.audit.runId={run_id}\n")
+                     + f"-Dcsc.audit.profileId={metadata['profileId']}\n-Dcsc.audit.runId={run_id}\n"
+                     + "\n".join(harness_properties(harness)) + "\n")
         if metadata.get("removedAction"):
             stream.write("-Dcsc.audit.removedAction=" + metadata["removedAction"] + "\n")
     environment = os.environ.copy()
@@ -429,6 +494,8 @@ def launch_gui(args):
     write_json(run_directory / "gui-command.json", {**context, "argv": command, "productInfo": info,
                                            "properties": str(root / "idea.properties"), "vmOptions": str(vmoptions)})
     run_process(command, root, run_directory, context, environment)
+    require(context["harness"] == validate_harness(root / "plugins/csc-keymap-audit"),
+            "harness changed during GUI run")
 
 
 def summarize(source, target, allow_legacy=False):

--- a/scripts/shortcut-audit/audit.py
+++ b/scripts/shortcut-audit/audit.py
@@ -19,6 +19,7 @@ import xml.etree.ElementTree as ET
 import zipfile
 
 from evidence import COMMANDS, COMMAND_IDS, PREFIX, PRODUCT_ID, parse_export, require
+from strokes import compare_prefixes, parse_inventory
 
 
 HERE = Path(__file__).resolve().parent
@@ -447,10 +448,13 @@ def audit(args):
                f"-XX:ErrorFile={root / 'log/hs_err_%p.log'}", f"-XX:HeapDumpPath={root / 'log/heap.hprof'}"]
     command += [f"-Didea.{name}.path={root / name}" for name in ["config", "system", "plugins", "log"]]
     command += harness_properties(harness)
+    if getattr(args, "stroke_inventory", False):
+        command.append("-Dcsc.audit.strokeInventory=true")
     if metadata.get("removedAction"):
         command.append("-Dcsc.audit.removedAction=" + metadata["removedAction"])
     command += ["-cp", classpath, "com.intellij.idea.Main", "csc-keymap-audit", str(root / "keymaps.tsv")]
     context = run_context(root, metadata, run_id, "headless", info["buildNumber"])
+    context["strokeInventory"] = bool(getattr(args, "stroke_inventory", False))
     write_json(root / "audit-command.json", {**context, "argv": command, "productInfo": info})
     run_process(command, root, root, context, timeout=args.timeout, log_name="audit-console.log")
     require(context["harness"] == validate_harness(root / "plugins/csc-keymap-audit"),
@@ -460,6 +464,8 @@ def audit(args):
             and exported["harnessManifestSha256"] == context["harness"]["manifestSha256"],
             "audit export harness identity mismatch")
     summarize(root / "keymaps.tsv", root / "summary.json")
+    if context["strokeInventory"]:
+        parse_inventory(root / "keymaps.tsv")
 
 
 def launch_gui(args):
@@ -485,12 +491,15 @@ def launch_gui(args):
                      + "\n".join(harness_properties(harness)) + "\n")
         if metadata.get("removedAction"):
             stream.write("-Dcsc.audit.removedAction=" + metadata["removedAction"] + "\n")
+        if getattr(args, "stroke_inventory", False):
+            stream.write("-Dcsc.audit.strokeInventory=true\n")
     environment = os.environ.copy()
     variable = info["envVarBaseName"]
     environment[variable + "_PROPERTIES"] = str(root / "idea.properties")
     environment[variable + "_VM_OPTIONS"] = str(vmoptions)
     command = [str(launcher), str(Path(args.project).resolve())]
     context = run_context(root, metadata, run_id, "gui", info["buildNumber"], str(Path(args.project).resolve()))
+    context["strokeInventory"] = bool(getattr(args, "stroke_inventory", False))
     write_json(run_directory / "gui-command.json", {**context, "argv": command, "productInfo": info,
                                            "properties": str(root / "idea.properties"), "vmOptions": str(vmoptions)})
     run_process(command, root, run_directory, context, environment)
@@ -537,11 +546,22 @@ def main():
     for option in ["ide-home", "profile", "harness"]:
         collect.add_argument("--" + option, required=True)
     collect.add_argument("--timeout", type=int, default=120)
+    collect.add_argument("--stroke-inventory", action="store_true",
+                         help="Also export all effective shortcuts for prefix comparison")
     collect.set_defaults(run=audit)
     gui = commands.add_parser("launch-gui")
     for option in ["app", "profile", "project"]:
         gui.add_argument("--" + option, required=True)
+    gui.add_argument("--stroke-inventory", action="store_true",
+                     help="GUI export also writes a complete .strokes.tsv companion")
     gui.set_defaults(run=launch_gui)
+    compare = commands.add_parser("compare-prefixes")
+    compare.add_argument("--export", dest="exports", action="append", required=True,
+                         help="Schema-2 export with a matching complete inventory companion; repeat for IDEs")
+    compare.add_argument("--key", dest="keys", action="append",
+                         help="Candidate A-Z or F1-F24; defaults to all 50 keys with Ctrl/Meta+Alt+Shift")
+    compare.add_argument("--output", required=True)
+    compare.set_defaults(run=lambda args: write_json(Path(args.output), compare_prefixes(args.exports, args.keys)))
     accept = commands.add_parser("accept-baseline")
     for option in ["profile", "run-directory", "export", "observed-keymap", "performer", "notes"]:
         accept.add_argument("--" + option, required=True)

--- a/scripts/shortcut-audit/audit.py
+++ b/scripts/shortcut-audit/audit.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Prepare isolated profiles and run a separate, read-only IntelliJ keymap probe.
+
+No network, personal IDE profile discovery, IDE installation, or product build.
+Every new profile/output must have a previously unused path.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+from datetime import datetime, timezone
+import xml.etree.ElementTree as ET
+import zipfile
+
+
+HERE = Path(__file__).resolve().parent
+PRODUCT_ID = "com.github.hon454.copy-selection-context"
+PREFIX = "CopySelectionContext."
+COMMANDS = ["Copy", "ShowHistory", "AddToCollection", "ShowCollection", "CopyAllCollection",
+            "CopyRelativePath", "CopyAbsolutePath", "CopyWithCodeContent", "CopyGitPermalink"]
+CASES = ["pristine", "unrelated-only", "explicit-old", "custom", "unassigned", "removed-ide"]
+
+
+def digest(path):
+    checksum = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            checksum.update(chunk)
+    return checksum.hexdigest()
+
+
+def write_json(path, data):
+    with open(path, "x", encoding="utf-8") as stream:
+        json.dump(data, stream, ensure_ascii=False, indent=2)
+        stream.write("\n")
+
+
+def unpack_product(archive, destination):
+    with zipfile.ZipFile(archive) as source:
+        entries = source.infolist()
+        if any(Path(entry.filename).is_absolute() or ".." in Path(entry.filename).parts
+               or (entry.external_attr >> 16) & 0o170000 == 0o120000 for entry in entries):
+            raise ValueError("Unsafe ZIP member")
+        if sum(entry.file_size for entry in entries) > 100 * 1024 * 1024:
+            raise ValueError("Unexpectedly large product ZIP")
+        descriptors = []
+        import io
+        for entry in entries:
+            if entry.filename.endswith(".jar"):
+                with zipfile.ZipFile(io.BytesIO(source.read(entry))) as jar:
+                    if "META-INF/plugin.xml" in jar.namelist():
+                        descriptors.append(ET.fromstring(jar.read("META-INF/plugin.xml")))
+        product = [item for item in descriptors if item.findtext("id") == PRODUCT_ID]
+        if len(product) != 1:
+            raise ValueError("ZIP must contain exactly one product descriptor")
+        source.extractall(destination)
+        return product[0].findtext("version")
+
+
+def initialize(root):
+    root.mkdir(parents=True, exist_ok=False)
+    for name in ["config", "system", "plugins", "log"]:
+        (root / name).mkdir()
+    (root / "idea.properties").write_text("".join(
+        f"idea.{name}.path={root / name}\n" for name in ["config", "system", "plugins", "log"]
+    ), encoding="utf-8")
+
+
+def profile_metadata(root, archive, version, **extra):
+    write_json(root / "profile.json", {
+        "schema": 1, "createdUtc": datetime.now(timezone.utc).isoformat(),
+        "profile": str(root), "productZip": str(archive), "productSha256": digest(archive),
+        "productVersion": version, "state": "prepared-not-launched", **extra,
+    })
+
+
+def write_xml(path, element):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ET.indent(element)
+    ET.ElementTree(element).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def seed_keymap(root, case, parent, native_mac, removed_action, old_copy=None, old_history=None):
+    name = parent if case == "pristine" else "CSC Audit " + case
+    options = ET.Element("application")
+    ET.SubElement(ET.SubElement(options, "component", name="KeymapManager"), "active_keymap", name=name)
+    write_xml(root / "config/options/keymap.xml", options)
+    if case == "pristine":
+        return
+    keymap = ET.Element("keymap", version="1", name=name, parent=parent)
+    modifier = "meta" if native_mac else "control"
+    if case == "unrelated-only":
+        action = ET.SubElement(keymap, "action", id="EditorToggleUseSoftWraps")
+        ET.SubElement(action, "keyboard-shortcut", {"first-keystroke": "control alt shift F9"})
+    elif case in ["explicit-old", "custom", "unassigned"]:
+        for command, key in [("Copy", "C"), ("ShowHistory", "H")]:
+            action = ET.SubElement(keymap, "action", id=PREFIX + command)
+            if case != "unassigned":
+                # Use observed effective values: native Mac keymaps can transform
+                # inherited descriptor shortcuts (including v1.6.0 History).
+                shortcut = (old_copy if command == "Copy" else old_history) if case == "explicit-old" else f"{modifier} shift F{11 if key == 'C' else 12}"
+                ET.SubElement(action, "keyboard-shortcut", {"first-keystroke": shortcut})
+        if case == "custom":
+            ET.SubElement(keymap.find("action"), "mouse-shortcut", keystroke="control button2")
+    elif case == "removed-ide":
+        ET.SubElement(keymap, "action", id=removed_action)
+    write_xml(root / "config/keymaps/audit.xml", keymap)
+
+
+def prepare(args):
+    root, archive = Path(args.output).resolve(), Path(args.zip).resolve()
+    if digest(archive) != args.sha256:
+        raise ValueError("Product ZIP digest mismatch")
+    initialize(root)
+    version = unpack_product(archive, root / "plugins")
+    if args.case and version != "1.6.0":
+        raise ValueError("Upgrade baseline cases require the released v1.6.0 ZIP")
+    if args.case:
+        seed_keymap(root, args.case, args.parent, args.native_mac, args.removed_action,
+                    args.old_copy, args.old_history)
+    profile_metadata(root, archive, version, case=args.case, parent=args.parent,
+                     removedAction=args.removed_action, oldCopy=args.old_copy, oldHistory=args.old_history)
+
+
+def clone_upgrade(args):
+    source, target = Path(args.source).resolve(), Path(args.output).resolve()
+    original = json.loads((source / "profile.json").read_text())
+    if original["productVersion"] != "1.6.0":
+        raise ValueError("Source is not a prepared v1.6.0 baseline")
+    if (source / "config/.lock").exists():
+        raise ValueError("Stop the baseline IDE before cloning")
+    archive = Path(args.zip).resolve()
+    if digest(archive) != args.sha256:
+        raise ValueError("Candidate ZIP digest mismatch")
+    initialize(target)
+    shutil.copytree(source / "config", target / "config", dirs_exist_ok=True)
+    version = unpack_product(archive, target / "plugins")
+    profile_metadata(target, archive, version, baseline=str(source),
+                     baselineConfig=config_snapshot(source), candidateSha=args.commit)
+
+
+def config_snapshot(root):
+    return {str(path.relative_to(root)): digest(path)
+            for path in sorted((root / "config").rglob("*")) if path.is_file()}
+
+
+def build(args):
+    home, output = Path(args.ide_home).resolve(), Path(args.output).resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    classes = output / "classes"
+    classes.mkdir()
+    subprocess.run([str(Path(args.jdk) / "bin/javac"), "--release", "21", "-encoding", "UTF-8",
+                    "-cp", str(home / "lib/*"), "-d", str(classes),
+                    *[str(path) for path in sorted(HERE.glob("*.java"))]], check=True)
+    jar = output / "csc-keymap-audit/lib/csc-keymap-audit.jar"
+    jar.parent.mkdir(parents=True)
+    with zipfile.ZipFile(jar, "x", zipfile.ZIP_DEFLATED) as archive:
+        archive.write(HERE / "plugin.xml", "META-INF/plugin.xml")
+        for path in classes.rglob("*.class"):
+            archive.write(path, str(path.relative_to(classes)))
+    print(jar)
+
+
+def audit(args):
+    home, root = Path(args.ide_home).resolve(), Path(args.profile).resolve()
+    metadata = json.loads((root / "profile.json").read_text())
+    if metadata["profile"] != str(root):
+        raise ValueError("Profile path changed; create or clone a profile explicitly")
+    probe = Path(args.harness).resolve()
+    shutil.copytree(probe, root / "plugins/csc-keymap-audit", dirs_exist_ok=False)
+    product_info_path = home / "Resources/product-info.json"
+    if not product_info_path.exists():
+        product_info_path = home / "product-info.json"
+    info = json.loads(product_info_path.read_text())
+    launch = next(item for item in info["launch"] if item["os"] == "macOS" and item["arch"] == "aarch64")
+    # Resolve product-info-relative paths; do not guess native/JBR names.
+    java = (product_info_path.parent / launch["javaExecutablePath"]).resolve()
+    classpath = os.pathsep.join(str(home / "lib" / name) for name in launch["bootClassPathJarNames"])
+    # Gradle's cached transform is the Contents directory itself, without an
+    # enclosing .app. Resolve that form before the general bundle placeholder.
+    jvm = [item.replace("$APP_PACKAGE/Contents", str(home))
+           .replace("$APP_PACKAGE", str(home.parent)).replace("$IDE_HOME", str(home))
+           for item in launch["additionalJvmArguments"]]
+    command = [str(java), "-Xms128m", "-Xmx1536m", *jvm, "-Djava.awt.headless=true",
+               f"-Didea.home.path={home}", f"-Didea.properties.file={root / 'idea.properties'}",
+               f"-XX:ErrorFile={root / 'log/hs_err_%p.log'}", f"-XX:HeapDumpPath={root / 'log/heap.hprof'}"]
+    command += [f"-Didea.{name}.path={root / name}" for name in ["config", "system", "plugins", "log"]]
+    command += ["-cp", classpath, "com.intellij.idea.Main", "csc-keymap-audit", str(root / "keymaps.tsv")]
+    write_json(root / "audit-command.json", {"argv": command, "productInfo": info, "profile": metadata})
+    with open(root / "audit-console.log", "x") as log:
+        result = subprocess.run(command, stdout=log, stderr=subprocess.STDOUT, timeout=args.timeout)
+    if result.returncode:
+        raise RuntimeError(f"IDE exited {result.returncode}; see {root / 'audit-console.log'}")
+    summarize(root / "keymaps.tsv", root / "summary.json")
+
+
+def launch_gui(args):
+    app, root = Path(args.app).resolve(), Path(args.profile).resolve()
+    metadata = json.loads((root / "profile.json").read_text())
+    if metadata["profile"] != str(root):
+        raise ValueError("Profile path changed; create or clone it explicitly")
+    info_path = app / "Contents/Resources/product-info.json"
+    info = json.loads(info_path.read_text())
+    launch = next(item for item in info["launch"] if item["os"] == "macOS" and item["arch"] == "aarch64")
+    launcher = (info_path.parent / launch["launcherPath"]).resolve()
+    original_options = (info_path.parent / launch["vmOptionsFilePath"]).read_text()
+    run_directory = root / ("gui-run-" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ"))
+    run_directory.mkdir()
+    vmoptions = run_directory / "gui.vmoptions"
+    with open(vmoptions, "x") as stream:
+        stream.write(original_options + f"\n-XX:ErrorFile={root / 'log/hs_err_%p.log'}\n"
+                     + f"-XX:HeapDumpPath={root / 'log/heap.hprof'}\n"
+                     + f"-Dcsc.audit.output={root}\n")
+    environment = os.environ.copy()
+    variable = info["envVarBaseName"]
+    environment[variable + "_PROPERTIES"] = str(root / "idea.properties")
+    environment[variable + "_VM_OPTIONS"] = str(vmoptions)
+    command = [str(launcher), str(Path(args.project).resolve())]
+    write_json(run_directory / "gui-command.json", {"argv": command, "productInfo": info, "profile": metadata,
+                                           "properties": str(root / "idea.properties"), "vmOptions": str(vmoptions)})
+    with open(run_directory / "gui-console.log", "x") as log:
+        process = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, env=environment)
+        print(f"Started test IDE pid={process.pid}, profile={root}", flush=True)
+        result = process.wait()
+    if result:
+        raise RuntimeError(f"IDE exited {result}; see {run_directory / 'gui-console.log'}")
+
+
+def summarize(source, target):
+    with source.open(encoding="utf-8") as stream:
+        rows = [line.rstrip("\n").split("\t") for line in stream]
+    commands = [row[1] for row in rows if row[0] == "COMMAND"]
+    keymaps = [row for row in rows if row[0] == "KEYMAP"]
+    if not rows or rows[-1][0] != "END" or set(commands) != {PREFIX + name for name in COMMANDS} or not keymaps:
+        raise ValueError("Incomplete runtime evidence (missing END, keymaps or product actions)")
+    occupancy = [row for row in rows if row[0] == "OCCUPANCY"]
+    external = [row for row in occupancy if row[2].endswith("shift G") and row[3] not in commands]
+    write_json(target, {"sourceSha256": digest(source), "keymapCount": len(keymaps),
+                       "commandCount": len(commands), "keymaps": keymaps,
+                       "externalPrefixOccupancy": external,
+                       "oldCHOccupancy": [row for row in occupancy if not row[2].endswith("shift G")],
+                       "note": "Loaded effective keymap data only; no physical key, GUI, OS or IME verdict"})
+    print(f"{len(keymaps)} keymaps, {len(commands)} product actions, {len(external)} external prefix occupancies")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    make = commands.add_parser("prepare")
+    make.add_argument("--output", required=True)
+    make.add_argument("--zip", required=True)
+    make.add_argument("--sha256", required=True)
+    make.add_argument("--case", choices=CASES)
+    make.add_argument("--parent", default="Mac OS X 10.5+")
+    make.add_argument("--native-mac", action="store_true")
+    make.add_argument("--removed-action")
+    make.add_argument("--old-copy", help="Observed effective v1.6.0 Copy keystroke")
+    make.add_argument("--old-history", help="Observed effective v1.6.0 History keystroke")
+    make.set_defaults(run=prepare)
+    clone = commands.add_parser("clone-upgrade")
+    for option in ["source", "output", "zip", "sha256", "commit"]:
+        clone.add_argument("--" + option, required=True)
+    clone.set_defaults(run=clone_upgrade)
+    compile_command = commands.add_parser("build-harness")
+    for option in ["ide-home", "jdk", "output"]:
+        compile_command.add_argument("--" + option, required=True)
+    compile_command.set_defaults(run=build)
+    collect = commands.add_parser("audit")
+    for option in ["ide-home", "profile", "harness"]:
+        collect.add_argument("--" + option, required=True)
+    collect.add_argument("--timeout", type=int, default=120)
+    collect.set_defaults(run=audit)
+    gui = commands.add_parser("launch-gui")
+    for option in ["app", "profile", "project"]:
+        gui.add_argument("--" + option, required=True)
+    gui.set_defaults(run=launch_gui)
+    report = commands.add_parser("summarize")
+    report.add_argument("source", type=Path)
+    report.add_argument("output", type=Path)
+    report.set_defaults(run=lambda args: summarize(args.source, args.output))
+    snap = commands.add_parser("snapshot")
+    snap.add_argument("profile", type=Path)
+    snap.add_argument("output", type=Path)
+    snap.set_defaults(run=lambda args: write_json(args.output, config_snapshot(args.profile)))
+    args = parser.parse_args()
+    if args.command == "prepare" and args.case == "removed-ide" and not args.removed_action:
+        parser.error("removed-ide requires --removed-action from an observed baseline keymap dump")
+    if args.command == "prepare" and args.case == "explicit-old" and not (args.old_copy and args.old_history):
+        parser.error("explicit-old requires --old-copy and --old-history from an observed baseline keymap dump")
+    args.run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/shortcut-audit/audit.py
+++ b/scripts/shortcut-audit/audit.py
@@ -419,6 +419,18 @@ def build(args):
     print(jar)
 
 
+def headless_java(home, product_info_path, launch, explicit=None):
+    declared = launch.get("javaExecutablePath")
+    require(not (declared and explicit), "product metadata already declares Java; an override is not allowed")
+    require(bool(declared) or bool(explicit),
+            "product metadata omits Java; supply --java-executable after inspecting the bundled runtime")
+    require(not explicit or Path(explicit).is_absolute(), "explicit Java path must be absolute")
+    java = (product_info_path.parent / declared if declared else Path(explicit)).resolve()
+    require(java.is_relative_to(home.resolve()) and java.is_file() and os.access(java, os.X_OK),
+            "Java must be an executable file within the selected IDE home")
+    return java, "product-info" if declared else "explicit-bundled-runtime"
+
+
 def audit(args):
     home, root = Path(args.ide_home).resolve(), Path(args.profile).resolve()
     metadata = load_profile(root)
@@ -427,15 +439,15 @@ def audit(args):
     run_id = str(uuid.uuid4())
     probe = Path(args.harness).resolve()
     validate_harness(probe)
-    shutil.copytree(probe, root / "plugins/csc-keymap-audit", dirs_exist_ok=False)
-    harness = validate_harness(root / "plugins/csc-keymap-audit")
     product_info_path = home / "Resources/product-info.json"
     if not product_info_path.exists():
         product_info_path = home / "product-info.json"
     info = json.loads(product_info_path.read_text())
     launch = next(item for item in info["launch"] if item["os"] == "macOS" and item["arch"] == "aarch64")
-    # Resolve product-info-relative paths; do not guess native/JBR names.
-    java = (product_info_path.parent / launch["javaExecutablePath"]).resolve()
+    # Resolve metadata or an explicitly inspected bundled runtime; never guess.
+    java, java_source = headless_java(home, product_info_path, launch, getattr(args, "java_executable", None))
+    shutil.copytree(probe, root / "plugins/csc-keymap-audit", dirs_exist_ok=False)
+    harness = validate_harness(root / "plugins/csc-keymap-audit")
     classpath = os.pathsep.join(str(home / "lib" / name) for name in launch["bootClassPathJarNames"])
     # Gradle's cached transform is the Contents directory itself, without an
     # enclosing .app. Resolve that form before the general bundle placeholder.
@@ -455,6 +467,7 @@ def audit(args):
     command += ["-cp", classpath, "com.intellij.idea.Main", "csc-keymap-audit", str(root / "keymaps.tsv")]
     context = run_context(root, metadata, run_id, "headless", info["buildNumber"])
     context["strokeInventory"] = bool(getattr(args, "stroke_inventory", False))
+    context["javaSelection"] = {"source": java_source, "path": str(java), "sha256": digest(java)}
     write_json(root / "audit-command.json", {**context, "argv": command, "productInfo": info})
     run_process(command, root, root, context, timeout=args.timeout, log_name="audit-console.log")
     require(context["harness"] == validate_harness(root / "plugins/csc-keymap-audit"),
@@ -546,6 +559,8 @@ def main():
     for option in ["ide-home", "profile", "harness"]:
         collect.add_argument("--" + option, required=True)
     collect.add_argument("--timeout", type=int, default=120)
+    collect.add_argument("--java-executable",
+                         help="Inspected bundled Java path, only when product-info omits javaExecutablePath")
     collect.add_argument("--stroke-inventory", action="store_true",
                          help="Also export all effective shortcuts for prefix comparison")
     collect.set_defaults(run=audit)

--- a/scripts/shortcut-audit/evidence.py
+++ b/scripts/shortcut-audit/evidence.py
@@ -1,0 +1,160 @@
+"""Strict parser for complete keymap export evidence, independent of IDE APIs."""
+
+import json
+from datetime import datetime
+
+PRODUCT_ID = "com.github.hon454.copy-selection-context"
+PREFIX = "CopySelectionContext."
+COMMANDS = ["Copy", "ShowHistory", "AddToCollection", "ShowCollection", "CopyAllCollection",
+            "CopyRelativePath", "CopyAbsolutePath", "CopyWithCodeContent", "CopyGitPermalink"]
+COMMAND_IDS = {PREFIX + name for name in COMMANDS}
+WATCHED_IDS = {"IntroduceConstant", "EditorToggleUseSoftWraps"}
+PROBES = {"control alt shift G", "meta alt shift G", "control alt C", "meta alt C", "control alt H", "meta alt H"}
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError("Invalid audit evidence: " + message)
+
+
+def unescape(cell):
+    output, index = [], 0
+    escapes = {"\\": "\\", "t": "\t", "r": "\r", "n": "\n"}
+    while index < len(cell):
+        if cell[index] == "\\":
+            index += 1
+            require(index < len(cell) and cell[index] in escapes, "invalid TSV escape")
+            output.append(escapes[cell[index]])
+        else:
+            output.append(cell[index])
+        index += 1
+    return "".join(output)
+
+
+def shortcuts(value):
+    items = json.loads(value)
+    require(isinstance(items, list), "shortcuts must be a JSON array")
+    for item in items:
+        require(isinstance(item, dict), "shortcut must be an object")
+        if item.get("kind") == "keyboard":
+            require(set(item) == {"kind", "first", "second"}, "keyboard shortcut fields")
+            require(isinstance(item["first"], str) and bool(item["first"]), "empty first stroke")
+            require(item["second"] is None or isinstance(item["second"], str) and bool(item["second"]), "second stroke")
+        elif item.get("kind") == "mouse":
+            require(set(item) == {"kind", "button", "modifiers", "clickCount"}
+                    and all(type(item[key]) is int for key in ["button", "modifiers", "clickCount"]), "mouse shortcut fields")
+        else:
+            require(set(item) == {"kind", "display"} and item["kind"] == "other"
+                    and isinstance(item["display"], str) and bool(item["display"]), "non-keyboard shortcut fields")
+    require(len({json.dumps(item, sort_keys=True) for item in items}) == len(items), "duplicate shortcut")
+    return items
+
+
+def parse_export(source, allow_legacy=False):
+    require(source.stat().st_size <= 100 * 1024 * 1024, "export exceeds 100 MiB")
+    rows = [[unescape(cell) for cell in line.split("\t")]
+            for line in source.read_text(encoding="utf-8").splitlines()]
+    require(bool(rows) and all(row[0] for row in rows), "empty export/row")
+    require(sum(row[0] == "END" for row in rows) == 1 and rows[-1][0] == "END", "missing/duplicate/non-final END")
+    meta, commands, maps, bindings, plugins, probes = {}, {}, {}, {}, {}, {}
+    occupancy = []
+    sizes = {"COMMAND": 3, "KEYMAP": 4, "BINDING": 4, "PLUGIN": 5, "PROBE": 3, "OCCUPANCY": 10}
+    for row in rows[:-1]:
+        kind = row[0]
+        if kind == "META":
+            require(len(row) >= 3, "META column count")
+            require(len(row) == (5 if row[1] == "os" else 3), "META column count")
+            require(row[1] not in meta, "duplicate META " + row[1])
+            meta[row[1]] = row[2:] if row[1] == "os" else row[2]
+            continue
+        require(kind in sizes and len(row) == sizes[kind], "unknown row or column count: " + kind)
+        if kind == "OCCUPANCY":
+            occupancy.append(row)
+            continue
+        target = {"COMMAND": commands, "KEYMAP": maps, "BINDING": bindings, "PLUGIN": plugins, "PROBE": probes}[kind]
+        key = tuple(row[1:3]) if kind == "BINDING" else row[1]
+        require(key not in target, "duplicate " + kind + " " + str(key))
+        require(bool(row[1]), "empty " + kind + " identity")
+        target[key] = row
+    required_meta = {"schema", "timeUtc", "ide", "build", "os", "activeKeymap", "headless", "registeredActionCount",
+                     "idea.config.path", "idea.system.path", "idea.plugins.path", "idea.log.path"}
+    require(required_meta <= set(meta), "missing metadata")
+    require(meta["schema"] in {"1", "2"}, "unsupported schema")
+    legacy = meta["schema"] == "1"
+    require(not legacy or allow_legacy, "legacy export requires explicit inspection; regenerate for acceptance")
+    require(meta["headless"] in {"true", "false"}, "invalid headless value")
+    require(int(meta["registeredActionCount"]) >= len(COMMAND_IDS), "registered action count")
+    require(datetime.fromisoformat(meta["timeUtc"].replace("Z", "+00:00")).tzinfo is not None, "timestamp needs timezone")
+    require(set(commands) == COMMAND_IDS and all(row[2] for row in commands.values()), "missing/extra product commands")
+    require(bool(maps) and meta["activeKeymap"] in maps, "zero keymaps or missing active scheme")
+    require(PRODUCT_ID in plugins and bool(plugins[PRODUCT_ID][2]), "product plugin not loaded")
+    require(all(row[3] in {"true", "false"} for row in plugins.values()), "plugin bundled value")
+    for name, row in maps.items():
+        require(row[2] in {"true", "false"}, "keymap mutable value")
+        if not legacy:
+            chain = json.loads(row[3])
+            require(isinstance(chain, list) and chain and all(isinstance(item, str) and item for item in chain)
+                    and chain[0] == name and len(set(chain)) == len(chain), "invalid/cyclic parent chain")
+    required_ids = COMMAND_IDS | WATCHED_IDS
+    if legacy:
+        # Old files may be structurally inspected, but cannot certify parent
+        # initialization or be used as GUI acceptance/candidate evidence.
+        observed_ids = {key[1] for key in bindings}
+        require(observed_ids in (COMMAND_IDS, required_ids), "legacy binding ID set")
+        required_ids = observed_ids
+    else:
+        require("watchedActions" in meta, "missing watched action IDs")
+        watched = json.loads(meta["watchedActions"])
+        require(isinstance(watched, list) and all(isinstance(item, str) and item for item in watched)
+                and len(set(watched)) == len(watched) and WATCHED_IDS <= set(watched), "watched action IDs")
+        required_ids = COMMAND_IDS | set(watched)
+    require(set(bindings) == {(name, action) for name in maps for action in required_ids},
+            "missing/extra per-keymap bindings")
+    if legacy:
+        require(len(rows[-1]) == 5 and rows[-1][1::2] == ["keymaps", "commands"], "legacy END fields")
+        expected_counts = [len(maps), len(commands)]
+    else:
+        require({"profileId", "runId", "processId", "projectRoots"} <= set(meta), "missing run identity")
+        require(all(meta[key] not in {"", "null"} for key in ["profileId", "runId", "processId"]), "empty run identity")
+        require(int(meta["processId"]) > 0, "process ID")
+        roots = json.loads(meta["projectRoots"])
+        require(isinstance(roots, list) and all(item is None or isinstance(item, str) for item in roots), "project roots")
+        require(set(probes) == PROBES, "missing/extra probes")
+        for name, row in probes.items():
+            require(sorted(row[2].split()) == sorted(name.replace("control", "ctrl").split() + ["pressed"]), "probe stroke mismatch")
+        require(len(rows[-1]) == 11 and rows[-1][1::2] == ["keymaps", "commands", "bindings", "occupancies", "rows"], "END fields")
+        expected_counts = [len(maps), len(commands), len(bindings), len(occupancy), len(rows)]
+    require([int(value) for value in rows[-1][2::2]] == expected_counts, "END counts do not match actual rows")
+    seen, groups = set(), {}
+    for row in occupancy:
+        _, keymap, probe, action, first, second, all_shortcuts, registered, owner, bundled = row
+        require(keymap in maps and probe in PROBES and bool(action), "occupancy identity")
+        require(registered in {"true", "false"} and bundled in {"true", "false", "unknown"} and bool(owner), "occupancy ownership")
+        key = (keymap, probe, action, first, second)
+        require(key not in seen, "duplicate occupancy")
+        seen.add(key)
+        if legacy:
+            continue
+        require(first == probes[probe][2], "occupancy first stroke mismatch")
+        items = shortcuts(all_shortcuts)
+        require({"kind": "keyboard", "first": first, "second": None if second == "null" else second} in items,
+                "occupancy does not match its shortcut list")
+        group = (keymap, action)
+        require(group not in groups or groups[group] == items, "inconsistent occupancy shortcut list")
+        groups[group] = items
+    if not legacy:
+        for key, row in bindings.items():
+            items = shortcuts(row[3])
+            require(key not in groups or groups[key] == items, "binding/occupancy mismatch")
+            groups[key] = items
+        for (keymap, action), items in groups.items():
+            for item in items:
+                if item["kind"] != "keyboard":
+                    continue
+                for probe, row in probes.items():
+                    if item["first"] == row[2]:
+                        require((keymap, probe, action, item["first"], item["second"] or "null") in seen,
+                                "missing occupancy for a recorded shortcut")
+    return {"schema": int(meta["schema"]), "metadata": meta, "commands": commands, "keymaps": maps,
+            "bindings": bindings, "plugins": plugins, "occupancies": occupancy, "rowCount": len(rows),
+            "legacyInspectionOnly": legacy}

--- a/scripts/shortcut-audit/evidence.py
+++ b/scripts/shortcut-audit/evidence.py
@@ -115,6 +115,9 @@ def parse_export(source, allow_legacy=False):
         expected_counts = [len(maps), len(commands)]
     else:
         require({"profileId", "runId", "processId", "projectRoots"} <= set(meta), "missing run identity")
+        require(all(isinstance(meta.get(key), str) and len(meta[key]) == 64
+                    and all(char in "0123456789abcdef" for char in meta[key])
+                    for key in ["harnessJarSha256", "harnessManifestSha256"]), "missing/invalid harness identity")
         require(all(meta[key] not in {"", "null"} for key in ["profileId", "runId", "processId"]), "empty run identity")
         require(int(meta["processId"]) > 0, "process ID")
         roots = json.loads(meta["projectRoots"])

--- a/scripts/shortcut-audit/evidence.py
+++ b/scripts/shortcut-audit/evidence.py
@@ -31,7 +31,7 @@ def unescape(cell):
     return "".join(output)
 
 
-def shortcuts(value):
+def shortcuts(value, allow_duplicates=False):
     items = json.loads(value)
     require(isinstance(items, list), "shortcuts must be a JSON array")
     for item in items:
@@ -46,7 +46,7 @@ def shortcuts(value):
         else:
             require(set(item) == {"kind", "display"} and item["kind"] == "other"
                     and isinstance(item["display"], str) and bool(item["display"]), "non-keyboard shortcut fields")
-    require(len({json.dumps(item, sort_keys=True) for item in items}) == len(items), "duplicate shortcut")
+    require(allow_duplicates or len({json.dumps(item, sort_keys=True) for item in items}) == len(items), "duplicate shortcut")
     return items
 
 

--- a/scripts/shortcut-audit/fixtures/CopySelectionShortcuts.kt
+++ b/scripts/shortcut-audit/fixtures/CopySelectionShortcuts.kt
@@ -1,0 +1,69 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.actionSystem.KeyboardShortcut
+import com.intellij.openapi.keymap.Keymap
+import com.intellij.openapi.keymap.KeymapManager
+import com.intellij.openapi.util.SystemInfo
+import javax.swing.KeyStroke
+
+/** Shared source of truth for the plugin's assignable commands and defaults. */
+internal object CopySelectionShortcuts {
+    val commands: Map<String, String> = linkedMapOf(
+        "CopySelectionContext.Copy" to "C",
+        "CopySelectionContext.ShowHistory" to "H",
+        "CopySelectionContext.AddToCollection" to "A",
+        "CopySelectionContext.ShowCollection" to "O",
+        "CopySelectionContext.CopyAllCollection" to "F",
+        "CopySelectionContext.CopyRelativePath" to "R",
+        "CopySelectionContext.CopyAbsolutePath" to "P",
+        "CopySelectionContext.CopyWithCodeContent" to "B",
+        "CopySelectionContext.CopyGitPermalink" to "L",
+    )
+
+    val macKeymapIds: Set<String> = linkedSetOf(
+        "Mac OS X",
+        "Mac OS X 10.5+",
+        "macOS System Shortcuts",
+        "Visual Studio OSX",
+        "ReSharper OSX",
+        "VSCode OSX",
+        "Visual Assist OSX",
+        "Sublime Text (Mac OS X)",
+    )
+
+    fun defaultShortcuts(mac: Boolean): Map<String, KeyboardShortcut> {
+        val prefix = KeyStroke.getKeyStroke(if (mac) MAC_PREFIX else DEFAULT_PREFIX)
+        return commands.mapValues { (_, secondKey) ->
+            KeyboardShortcut(prefix, KeyStroke.getKeyStroke(secondKey))
+        }
+    }
+
+    fun defaultShortcuts(
+        keymap: Keymap?,
+        macHost: Boolean = SystemInfo.isMac,
+    ): Map<String, KeyboardShortcut> = defaultShortcuts(usesMacKeymap(keymap, macHost))
+
+    fun activeDefaultShortcuts(
+        keymapManager: KeymapManager = KeymapManager.getInstance(),
+        macHost: Boolean = SystemInfo.isMac,
+    ): Map<String, KeyboardShortcut> = defaultShortcuts(keymapManager.activeKeymap, macHost)
+
+    fun usesMacKeymap(
+        keymap: Keymap?,
+        macHost: Boolean = SystemInfo.isMac,
+    ): Boolean {
+        val visited = mutableSetOf<Keymap>()
+        var current = keymap
+        while (current != null && visited.add(current)) {
+            when (current.name) {
+                in macKeymapIds -> return true
+                KeymapManager.DEFAULT_IDEA_KEYMAP -> return false
+            }
+            current = current.parent
+        }
+        return macHost
+    }
+
+    private const val DEFAULT_PREFIX = "control alt shift G"
+    private const val MAC_PREFIX = "meta alt shift G"
+}

--- a/scripts/shortcut-audit/lineage.py
+++ b/scripts/shortcut-audit/lineage.py
@@ -7,24 +7,56 @@ applying an obsolete policy to a different product revision.
 
 import hashlib
 import json
+import os
 import re
+import stat
 from pathlib import Path
 
 from evidence import require
 
 SUPPORTED_SOURCE_SHA256 = "08bc83b6d6252f2f8ae7eebf90b9e5b46956911efb92d6a8921c0d39fd09c2a5"
+MAX_SOURCE_BYTES = 16 * 1024
+
+
+def read_policy_snapshot(source):
+    # The absolute lookup path is a label, not a post-read resolution claim.
+    # Parent aliases are allowed; the final entry must not be a symlink. The
+    # opened descriptor's device/inode identifies the bytes actually inspected.
+    source = Path(source).absolute()
+    entry = source.lstat()
+    require(stat.S_ISREG(entry.st_mode), "policy source must be a regular file, not a symlink or special file")
+    require(0 < entry.st_size <= MAX_SOURCE_BYTES, "policy source exceeds size limit or is empty")
+    require(hasattr(os, "O_NOFOLLOW") and hasattr(os, "O_NONBLOCK"),
+            "policy snapshot requires no-follow and nonblocking file-open support")
+    descriptor = os.open(source, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    try:
+        opened = os.fstat(descriptor)
+        require(stat.S_ISREG(opened.st_mode) and (opened.st_dev, opened.st_ino) == (entry.st_dev, entry.st_ino),
+                "policy source identity changed before opening")
+        require(0 < opened.st_size <= MAX_SOURCE_BYTES, "opened policy source exceeds size limit or is empty")
+        data = os.read(descriptor, MAX_SOURCE_BYTES + 1)
+        require(0 < len(data) <= MAX_SOURCE_BYTES and len(data) == opened.st_size,
+                "policy source snapshot exceeds size limit or changed size")
+        after = os.fstat(descriptor)
+        require((opened.st_size, opened.st_mtime_ns, opened.st_ctime_ns) ==
+                (after.st_size, after.st_mtime_ns, after.st_ctime_ns), "policy source changed during read")
+        return data, {"lookupPath": str(source), "device": opened.st_dev, "inode": opened.st_ino,
+                      "sizeBytes": len(data), "mtimeNs": opened.st_mtime_ns,
+                      "symlinkPolicy": "reject-final-entry; parent aliases allowed; descriptor identity recorded"}
+    finally:
+        os.close(descriptor)
 
 
 def load_policy(source):
-    source = Path(source)
-    digest = hashlib.sha256(source.read_bytes()).hexdigest()
+    data, identity = read_policy_snapshot(source)
+    digest = hashlib.sha256(data).hexdigest()
     require(digest == SUPPORTED_SOURCE_SHA256,
             "unsupported product defaults source; review the modifier rule before updating its pin")
-    text = source.read_text(encoding="utf-8")
+    text = data.decode("utf-8")
     # The verified source contains parentheses in one ID; use the closing line.
     block = text.split("val macKeymapIds: Set<String> = linkedSetOf(\n", 1)[1].split("\n    )", 1)[0]
     return {"id": "CopySelectionShortcuts.usesMacKeymap/source-pinned-v1",
-            "sourcePath": str(source.resolve()), "sourceSha256": digest,
+            "sourcePath": identity["lookupPath"], "sourceIdentity": identity, "sourceSha256": digest,
             "macKeymapIds": re.findall(r'"([^"\n]+)"', block),
             "defaultKeymapId": "$default", "macModifier": "meta", "otherModifier": "control",
             "rule": "Walk self then parents; first exact Mac ID selects Meta, first $default selects Ctrl; otherwise use recorded host OS."}

--- a/scripts/shortcut-audit/lineage.py
+++ b/scripts/shortcut-audit/lineage.py
@@ -1,0 +1,50 @@
+"""Explicit, source-pinned mirror of the product's keymap modifier selection.
+
+Updating this pin requires reviewing the Kotlin rule and its Python mirror.
+It deliberately rejects even unrelated source changes rather than silently
+applying an obsolete policy to a different product revision.
+"""
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+from evidence import require
+
+SUPPORTED_SOURCE_SHA256 = "08bc83b6d6252f2f8ae7eebf90b9e5b46956911efb92d6a8921c0d39fd09c2a5"
+
+
+def load_policy(source):
+    source = Path(source)
+    digest = hashlib.sha256(source.read_bytes()).hexdigest()
+    require(digest == SUPPORTED_SOURCE_SHA256,
+            "unsupported product defaults source; review the modifier rule before updating its pin")
+    text = source.read_text(encoding="utf-8")
+    # The verified source contains parentheses in one ID; use the closing line.
+    block = text.split("val macKeymapIds: Set<String> = linkedSetOf(\n", 1)[1].split("\n    )", 1)[0]
+    return {"id": "CopySelectionShortcuts.usesMacKeymap/source-pinned-v1",
+            "sourcePath": str(source.resolve()), "sourceSha256": digest,
+            "macKeymapIds": re.findall(r'"([^"\n]+)"', block),
+            "defaultKeymapId": "$default", "macModifier": "meta", "otherModifier": "control",
+            "rule": "Walk self then parents; first exact Mac ID selects Meta, first $default selects Ctrl; otherwise use recorded host OS."}
+
+
+def select_modifier(chain, os_name, policy):
+    for ancestor in chain:
+        if ancestor in policy["macKeymapIds"]:
+            return {"modifier": "meta", "decisiveAncestor": ancestor, "reason": "exact-mac-ancestor"}
+        if ancestor == policy["defaultKeymapId"]:
+            return {"modifier": "control", "decisiveAncestor": ancestor, "reason": "default-ancestor"}
+    # These are the supported captured host families. Unknown hosts cannot
+    # silently become a non-Mac fallback when the lineage gives no answer.
+    require(os_name == "Mac OS X" or os_name == "Linux" or os_name.startswith("Windows"),
+            "unknown host OS for product modifier fallback")
+    return {"modifier": "meta" if os_name == "Mac OS X" else "control",
+            "decisiveAncestor": None, "reason": "recorded-host-fallback", "hostOs": os_name}
+
+
+def decisions(inventory, policy):
+    return {name: {"chain": json.loads(row[3]), **select_modifier(
+        json.loads(row[3]), inventory["audit"]["metadata"]["os"][0], policy)}
+        for name, row in inventory["audit"]["keymaps"].items()}

--- a/scripts/shortcut-audit/plugin.xml
+++ b/scripts/shortcut-audit/plugin.xml
@@ -1,0 +1,16 @@
+<idea-plugin>
+    <id>com.github.hon454.copy-selection-context.audit</id>
+    <name>Copy Selection Context Audit Harness</name>
+    <version>1</version>
+    <vendor>Local audit</vendor>
+    <idea-version since-build="243"/>
+    <depends>com.intellij.modules.platform</depends>
+    <depends>com.github.hon454.copy-selection-context</depends>
+    <extensions defaultExtensionNs="com.intellij">
+        <appStarter id="csc-keymap-audit" implementation="audit.KeymapAuditStarter"/>
+    </extensions>
+    <actions>
+        <action id="CopySelectionContext.Audit.Export" class="audit.ExportKeymapAuditAction"
+                text="Export CSC Keymap Audit" description="Export effective keymap data to the explicit test evidence directory"/>
+    </actions>
+</idea-plugin>

--- a/scripts/shortcut-audit/strokes.py
+++ b/scripts/shortcut-audit/strokes.py
@@ -1,0 +1,160 @@
+"""Validate complete companion inventories and compare possible chord prefixes.
+
+This is runtime data inspection, never a physical keyboard/OS/IME pass verdict.
+The original schema-2 export and its six probes remain independently readable.
+"""
+
+import hashlib
+import json
+import string
+from pathlib import Path
+
+from evidence import COMMAND_IDS, PROBES, parse_export, require, shortcuts, unescape
+
+DEFAULT_KEYS = list(string.ascii_uppercase) + ["F" + str(number) for number in range(1, 25)]
+
+
+def sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def identities(value):
+    items = json.loads(value)
+    require(isinstance(items, list) and all(isinstance(item, str) and item for item in items)
+            and len(set(items)) == len(items), "inventory source action IDs")
+    return set(items)
+
+
+def parse_inventory(audit_path):
+    audit_path = Path(audit_path)
+    data = parse_export(audit_path)
+    require(data["schema"] == 2 and data["metadata"].get("strokeInventory") == "complete-v1",
+            "export has no complete stroke inventory; collect a new run")
+    source = audit_path.with_name(audit_path.name + ".strokes.tsv")
+    require(source.is_file() and not source.is_symlink() and source.stat().st_size <= 100 * 1024 * 1024,
+            "missing/invalid/oversized stroke inventory")
+    rows = [[unescape(cell) for cell in line.split("\t")]
+            for line in source.read_text(encoding="utf-8").splitlines()]
+    require(bool(rows) and sum(row[0] == "END" for row in rows) == 1 and rows[-1][0] == "END",
+            "inventory missing/duplicate/non-final END")
+    meta, registered, maps, origins, actions = {}, {}, {}, {}, {}
+    sizes = {"META": 3, "REGISTERED": 2, "MAP": 5, "SOURCE": 4, "ACTION": 7}
+    for row in rows[:-1]:
+        kind = row[0]
+        require(kind in sizes and len(row) == sizes[kind], "inventory row/column count")
+        require(bool(row[1]), "empty inventory identity")
+        target = {"META": meta, "REGISTERED": registered, "MAP": maps,
+                  "SOURCE": origins, "ACTION": actions}[kind]
+        key = tuple(row[1:3]) if kind in {"SOURCE", "ACTION"} else row[1]
+        require(key not in target, "duplicate inventory " + kind)
+        target[key] = row
+    require(set(meta) == {"schema", "auditFile", "auditSha256"} and meta["schema"][2] == "1",
+            "inventory metadata/schema")
+    require(meta["auditFile"][2] == audit_path.name and meta["auditSha256"][2] == sha256(audit_path),
+            "inventory belongs to a different audit export")
+    require(len(registered) == int(data["metadata"]["registeredActionCount"])
+            and COMMAND_IDS <= set(registered), "inventory registered action completeness")
+    require(set(maps) == set(data["keymaps"]), "inventory keymap completeness")
+    chains = {name: json.loads(row[3]) for name, row in data["keymaps"].items()}
+    require(set(origins) == {(name, ancestor) for name, chain in chains.items() for ancestor in chain},
+            "inventory ancestor source completeness")
+    expected = set()
+    watched = set(json.loads(data["metadata"]["watchedActions"]))
+    for name, chain in chains.items():
+        ids = set(registered) | COMMAND_IDS | watched
+        for ancestor in chain:
+            ids |= identities(origins[(name, ancestor)][3])
+        expected |= {(name, action) for action in ids}
+    require(set(actions) == expected, "inventory missing/extra effective action rows")
+    counts = {name: [0, 0, 0] for name in maps}
+    values = {}
+    for (name, action), row in actions.items():
+        require(row[4] in {"true", "false"} and row[6] in {"true", "false", "unknown"}
+                and bool(row[5]), "inventory ownership fields")
+        require(action not in registered or row[4] == "true", "registered inventory action missing at capture")
+        # Some platform actions return identical entries (for example IC 243's
+        # CommentByBlockComment on macOS). Keep the full API list and its counts.
+        items = shortcuts(row[3], allow_duplicates=True)
+        values[(name, action)] = items
+        counts[name][0] += 1
+        counts[name][1] += len(items)
+        counts[name][2] += sum(item["kind"] == "keyboard" for item in items)
+    for name, row in maps.items():
+        require([int(value) for value in row[2:]] == counts[name], "inventory per-keymap counts")
+    require(rows[-1][1::2] == ["keymaps", "registered", "sources", "actions", "shortcuts", "rows"]
+            and len(rows[-1]) == 13, "inventory END fields")
+    require([int(value) for value in rows[-1][2::2]] == [len(maps), len(registered), len(origins),
+            len(actions), sum(value[1] for value in counts.values()), len(rows)], "inventory END counts")
+    # Cross-check the complete inventory with the independent original six-probe
+    # representation, including dormant owners and every recorded second stroke.
+    for key, row in data["bindings"].items():
+        require(values[key] == shortcuts(row[3]), "inventory/schema-2 binding mismatch")
+    probes = {probe: normalize_stroke(probe.rsplit(" ", 1)[0] + " pressed " + probe.rsplit(" ", 1)[1])
+              for probe in PROBES}
+    expected_occupancy = set()
+    for (name, action), items in values.items():
+        for item in items:
+            if item["kind"] != "keyboard":
+                continue
+            for probe, stroke in probes.items():
+                if normalize_stroke(item["first"]) == stroke:
+                    expected_occupancy.add((name, probe, action, item["first"], item["second"] or "null"))
+    observed = {tuple(row[1:6]) for row in data["occupancies"]}
+    require(expected_occupancy == observed, "inventory/schema-2 occupancy completeness mismatch")
+    for row in data["occupancies"]:
+        key = (row[1], row[3])
+        require(shortcuts(row[6]) == values[key] and row[7:10] == actions[key][4:7],
+                "inventory/schema-2 occupancy owner/list mismatch")
+    return {"auditPath": str(audit_path.resolve()), "inventoryPath": str(source.resolve()),
+            "auditSha256": sha256(audit_path), "inventorySha256": sha256(source),
+            "audit": data, "actions": actions, "values": values}
+
+
+def normalize_stroke(stroke):
+    # Swing can print modifier tokens in a different order; pressed/released and
+    # typed remain distinct. Candidate keys are deliberately ASCII letters/F1-24.
+    return tuple(sorted("ctrl" if token == "control" else token for token in stroke.split()))
+
+
+def compare_prefixes(exports, keys=None):
+    keys = DEFAULT_KEYS if keys is None else keys
+    require(bool(keys) and len(set(keys)) == len(keys) and set(keys) <= set(DEFAULT_KEYS),
+            "candidate keys must be unique A-Z or F1-F24")
+    inventories = [parse_inventory(path) for path in exports]
+    require(bool(inventories) and len({item["auditSha256"] for item in inventories}) == len(inventories),
+            "missing or duplicate audit inputs")
+    reports = []
+    for key in keys:
+        probes = {modifier + " alt shift " + key:
+                  normalize_stroke(modifier + " alt shift pressed " + key) for modifier in ["control", "meta"]}
+        external, product = [], []
+        for index, inventory in enumerate(inventories):
+            for (name, action), items in inventory["values"].items():
+                row = inventory["actions"][(name, action)]
+                seen = set()
+                for item in items:
+                    if item["kind"] != "keyboard":
+                        continue
+                    identity = (item["first"], item["second"])
+                    if identity in seen:
+                        continue
+                    seen.add(identity)
+                    for probe, stroke in probes.items():
+                        if normalize_stroke(item["first"]) != stroke:
+                            continue
+                        match = {"input": index, "keymap": name, "probe": probe, "action": action,
+                                 "first": item["first"], "second": item["second"],
+                                 "registered": row[4] == "true", "owner": row[5], "bundled": row[6],
+                                 "allShortcuts": items, "occurrencesInApiList": items.count(item)}
+                        (product if action in COMMAND_IDS else external).append(match)
+        reports.append({"key": key, "probes": list(probes), "externalOccupancyCount": len(external),
+                        "occupiedKeymaps": len({(row["input"], row["keymap"]) for row in external}),
+                        "externalActionIds": sorted({row["action"] for row in external}),
+                        "externalOccupancy": external, "productOccupancy": product,
+                        "verdict": "OCCUPIED" if external else "NO_OCCUPANCY_IN_RECORDED_KEYMAPS"})
+    return {"schema": 1, "inputs": [{key: item[key] for key in
+            ["auditPath", "inventoryPath", "auditSha256", "inventorySha256"]} | {
+                "metadata": item["audit"]["metadata"], "keymaps": list(item["audit"]["keymaps"].values()),
+                "plugins": list(item["audit"]["plugins"].values())} for item in inventories],
+            "candidates": reports,
+            "note": "Only exact nine product IDs are excluded. Single strokes, other chords, dormant mappings and both Ctrl/Meta variants count. Zero is limited to these recorded IDEs/keymaps/plugins; no OS, IME, physical-key, candidate-product or unobserved-family verdict."}

--- a/scripts/shortcut-audit/strokes.py
+++ b/scripts/shortcut-audit/strokes.py
@@ -11,7 +11,9 @@ from pathlib import Path
 
 from evidence import COMMAND_IDS, PROBES, parse_export, require, shortcuts, unescape
 
-DEFAULT_KEYS = list(string.ascii_uppercase) + ["F" + str(number) for number in range(1, 25)]
+PUNCTUATION_KEYS = ["SEMICOLON", "COMMA", "PERIOD", "SLASH", "BACK_SLASH",
+                    "OPEN_BRACKET", "CLOSE_BRACKET", "MINUS", "EQUALS", "BACK_QUOTE", "QUOTE"]
+DEFAULT_KEYS = list(string.ascii_uppercase) + ["F" + str(number) for number in range(1, 25)] + PUNCTUATION_KEYS
 
 
 def sha256(path):
@@ -112,17 +114,22 @@ def parse_inventory(audit_path):
 
 def normalize_stroke(stroke):
     # Swing can print modifier tokens in a different order; pressed/released and
-    # typed remain distinct. Candidate keys are deliberately ASCII letters/F1-24.
+    # typed remain distinct. Candidates use explicit Swing KeyEvent key names;
+    # punctuation names describe key codes, not produced characters or IME text.
     return tuple(sorted("ctrl" if token == "control" else token for token in stroke.split()))
 
 
-def compare_prefixes(exports, keys=None):
+def compare_prefixes(exports, keys=None, defaults_source=None):
+    from lineage import decisions, load_policy
+
     keys = DEFAULT_KEYS if keys is None else keys
     require(bool(keys) and len(set(keys)) == len(keys) and set(keys) <= set(DEFAULT_KEYS),
-            "candidate keys must be unique A-Z or F1-F24")
+            "candidate keys must be unique A-Z, F1-F24 or supported Swing punctuation names")
     inventories = [parse_inventory(path) for path in exports]
     require(bool(inventories) and len({item["auditSha256"] for item in inventories}) == len(inventories),
             "missing or duplicate audit inputs")
+    policy = load_policy(defaults_source) if defaults_source is not None else None
+    selections = [decisions(item, policy) for item in inventories] if policy else None
     reports = []
     for key in keys:
         probes = {modifier + " alt shift " + key:
@@ -146,15 +153,31 @@ def compare_prefixes(exports, keys=None):
                                  "first": item["first"], "second": item["second"],
                                  "registered": row[4] == "true", "owner": row[5], "bundled": row[6],
                                  "allShortcuts": items, "occurrencesInApiList": items.count(item)}
+                        if selections is not None:
+                            match["selectedByProductRule"] = probe.split()[0] == selections[index][name]["modifier"]
                         (product if action in COMMAND_IDS else external).append(match)
         reports.append({"key": key, "probes": list(probes), "externalOccupancyCount": len(external),
                         "occupiedKeymaps": len({(row["input"], row["keymap"]) for row in external}),
                         "externalActionIds": sorted({row["action"] for row in external}),
                         "externalOccupancy": external, "productOccupancy": product,
                         "verdict": "OCCUPIED" if external else "NO_OCCUPANCY_IN_RECORDED_KEYMAPS"})
-    return {"schema": 1, "inputs": [{key: item[key] for key in
+        if selections is not None:
+            selected = [row for row in external if row["selectedByProductRule"]]
+            opposite = [row for row in external if not row["selectedByProductRule"]]
+            reports[-1]["productRuleComparison"] = {
+                "externalOccupancyCount": len(selected), "externalOccupancy": selected,
+                "oppositeModifierOccupancyCount": len(opposite), "oppositeModifierOccupancy": opposite,
+                "verdict": "OCCUPIED" if selected else "NO_OCCUPANCY_FOR_PRODUCT_RULE_IN_RECORDED_KEYMAPS"}
+    result = {"schema": 1, "inputs": [{key: item[key] for key in
             ["auditPath", "inventoryPath", "auditSha256", "inventorySha256"]} | {
                 "metadata": item["audit"]["metadata"], "keymaps": list(item["audit"]["keymaps"].values()),
                 "plugins": list(item["audit"]["plugins"].values())} for item in inventories],
             "candidates": reports,
             "note": "Only exact nine product IDs are excluded. Single strokes, other chords, dormant mappings and both Ctrl/Meta variants count. Zero is limited to these recorded IDEs/keymaps/plugins; no OS, IME, physical-key, candidate-product or unobserved-family verdict."}
+    if policy is not None:
+        result["productModifierPolicy"] = policy
+        for item, selection in zip(result["inputs"], selections):
+            item["productModifierDecisions"] = selection
+    result["comparisonSourceSha256"] = {path.name: sha256(path) for path in
+                                       [Path(__file__), Path(__file__).with_name("lineage.py")]}
+    return result

--- a/scripts/shortcut-audit/strokes.py
+++ b/scripts/shortcut-audit/strokes.py
@@ -69,11 +69,24 @@ def parse_inventory(audit_path):
         expected |= {(name, action) for action in ids}
     require(set(actions) == expected, "inventory missing/extra effective action rows")
     counts = {name: [0, 0, 0] for name in maps}
-    values = {}
+    values, owners = {}, {}
     for (name, action), row in actions.items():
         require(row[4] in {"true", "false"} and row[6] in {"true", "false", "unknown"}
                 and bool(row[5]), "inventory ownership fields")
-        require(action not in registered or row[4] == "true", "registered inventory action missing at capture")
+        require((action in registered) == (row[4] == "true"), "inventory registered snapshot mismatch")
+        owner = tuple(row[4:7])
+        require(action not in owners or owners[action] == owner, "inconsistent inventory action ownership")
+        owners[action] = owner
+        if row[4] == "false":
+            # The exporter obtains ownership from the resolved action/stub, so
+            # a missing action has neither an owner nor a bundled claim.
+            require(row[5:7] == ["unknown", "unknown"], "dormant inventory action claims ownership")
+        else:
+            # Unknown descriptors can be represented by the exporter, but they
+            # cannot certify a registered action's contribution in this audit.
+            require(row[5] != "unknown" and row[5] in data["plugins"],
+                    "registered inventory owner missing from plugin inventory")
+            require(row[6] == data["plugins"][row[5]][3], "inventory owner/plugin bundled mismatch")
         # Some platform actions return identical entries (for example IC 243's
         # CommentByBlockComment on macOS). Keep the full API list and its counts.
         items = shortcuts(row[3], allow_duplicates=True)

--- a/scripts/shortcut-audit/test_audit.py
+++ b/scripts/shortcut-audit/test_audit.py
@@ -5,18 +5,41 @@ import io
 import json
 from pathlib import Path
 import tempfile
+import subprocess
+import sys
+import uuid
+from unittest import mock
 import unittest
 import xml.etree.ElementTree as ET
 import zipfile
 
 import audit
+from evidence import PROBES, WATCHED_IDS
+
+
+def keyboard(first, second=None):
+    return {"kind": "keyboard", "first": first, "second": second}
+
+
+def encode_rows(rows):
+    escape = lambda value: str(value).replace("\\", "\\\\").replace("\t", "\\t").replace("\r", "\\r").replace("\n", "\\n")
+    return "\n".join("\t".join(escape(cell) for cell in row) for row in rows) + "\n"
+
+
+def recount(rows):
+    rows = [row for row in rows if row[0] != "END"]
+    rows.append(["END", "keymaps", sum(r[0] == "KEYMAP" for r in rows),
+                 "commands", sum(r[0] == "COMMAND" for r in rows),
+                 "bindings", sum(r[0] == "BINDING" for r in rows),
+                 "occupancies", sum(r[0] == "OCCUPANCY" for r in rows), "rows", len(rows) + 1])
+    return rows
 
 
 class AuditToolTest(unittest.TestCase):
     def setUp(self):
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
-        self.root = Path(self.temporary.name)
+        self.root = Path(self.temporary.name).resolve()
         self.archive = self.root / "product.zip"
         jar_bytes = io.BytesIO()
         with zipfile.ZipFile(jar_bytes, "w") as jar:
@@ -46,12 +69,85 @@ class AuditToolTest(unittest.TestCase):
         self.assertEqual(bindings[audit.PREFIX + "Copy"], "meta alt C")
         self.assertEqual(bindings[audit.PREFIX + "ShowHistory"], "meta alt H")
 
-    def test_upgrade_clone_preserves_original_and_mouse_payload(self):
-        source = self.prepare("custom")
-        before = audit.config_snapshot(source)
-        target = self.root / "candidate"
+    def export_rows(self, profile=None, context=None, pid=12345, extra=None):
+        metadata = audit.load_profile(profile) if profile else {"parent": "$default", "case": "pristine"}
+        parent, case = metadata["parent"], metadata["case"]
+        active = parent if case == "pristine" else "CSC Audit " + case
+        meta = {"schema": "2", "timeUtc": "2026-09-09T00:00:01+00:00", "ide": "Test IDE",
+                "build": "IC-243.21565.193", "activeKeymap": active, "headless": "false",
+                "registeredActionCount": "500", "profileId": metadata.get("profileId", str(uuid.uuid4())),
+                "runId": context["runId"] if context else str(uuid.uuid4()), "processId": str(pid),
+                "watchedActions": json.dumps(sorted(WATCHED_IDS)),
+                "projectRoots": json.dumps([context["project"]] if context else [])}
+        meta.update({"idea." + name + ".path": str((profile or self.root) / name)
+                     for name in ["config", "system", "plugins", "log"]})
+        rows = [["META", key, value] for key, value in meta.items()]
+        rows += [["META", "os", "Mac OS X", "15.5", "aarch64"],
+                 ["PLUGIN", audit.PRODUCT_ID, "1.6.0", "false", "test/plugin"]]
+        probes = {name: name.replace("control", "ctrl").rsplit(" ", 1)[0] + " pressed " + name.rsplit(" ", 1)[1]
+                  for name in PROBES}
+        rows += [["PROBE", name, value] for name, value in sorted(probes.items())]
+        rows += [["COMMAND", action, "test.Action"] for action in sorted(audit.COMMAND_IDS)]
+        schemes = [parent] if parent == active else [parent, active]
+        for scheme in schemes:
+            rows.append(["KEYMAP", scheme, str(scheme != parent).lower(), json.dumps([parent] if scheme == parent else [scheme, parent])])
+            values = {action: [] for action in audit.COMMAND_IDS | WATCHED_IDS}
+            values[audit.PREFIX + "Copy"] = [keyboard("meta alt pressed C")]
+            values[audit.PREFIX + "ShowHistory"] = [keyboard("meta alt pressed H")]
+            values["IntroduceConstant"] = [keyboard("meta alt pressed C")]
+            if scheme == active:
+                if case == "custom":
+                    values[audit.PREFIX + "Copy"] = [keyboard("shift meta pressed F11"),
+                        {"kind": "mouse", "button": 2, "modifiers": 128, "clickCount": 1}]
+                    values[audit.PREFIX + "ShowHistory"] = [keyboard("shift meta pressed F12")]
+                elif case == "unassigned":
+                    values[audit.PREFIX + "Copy"] = values[audit.PREFIX + "ShowHistory"] = []
+                elif case == "unrelated-only":
+                    values["EditorToggleUseSoftWraps"] = [keyboard("ctrl alt shift pressed F9")]
+                elif case == "removed-ide":
+                    values["IntroduceConstant"] = []
+            rows += [["BINDING", scheme, action, json.dumps(items)] for action, items in sorted(values.items())]
+            values.update(extra or {})
+            for action, items in sorted(values.items()):
+                for item in items:
+                    for name, stroke in probes.items():
+                        if item["kind"] == "keyboard" and item["first"] == stroke:
+                            rows.append(["OCCUPANCY", scheme, name, action, stroke, item["second"] or "null",
+                                         json.dumps(items), "true", audit.PRODUCT_ID if action in audit.COMMAND_IDS else "com.intellij", "false"])
+        return recount(rows)
+
+    def gui_fixture(self, source):
+        """Synthetic evidence for validator tests only; never real GUI acceptance."""
+        metadata = audit.load_profile(source)
+        run_id = str(uuid.uuid4())
+        directory = source / ("gui-run-" + run_id)
+        directory.mkdir()
+        context = audit.run_context(source, metadata, run_id, "gui", "243.21565.193", str(self.root / "project"))
+        start = {**context, "pid": 12345, "startedUtc": "2026-09-09T00:00:00+00:00"}
+        audit.write_json(directory / "gui-command.json", context)
+        audit.write_json(directory / "process-start.json", start)
+        audit.write_json(directory / "process-result.json", {**start, "finishedUtc": "2026-09-09T00:00:02+00:00",
+            "exitCode": 0, "interrupted": False, "configSnapshot": audit.config_snapshot(source)})
+        export = directory / "keymaps.tsv"
+        export.write_text(encode_rows(self.export_rows(source, context)))
+        (directory / "observation.png").write_bytes(b"\x89PNG\r\n\x1a\nSIMULATED TEST IMAGE")
+        (directory / "observation.txt").write_text("SIMULATED accessibility evidence; validator test only")
+        return argparse.Namespace(profile=str(source), run_directory=str(directory), export=str(export),
+            observed_keymap=metadata["parent"] if metadata["case"] == "pristine" else "CSC Audit " + metadata["case"],
+            performer="synthetic unit test", notes="Not a real GUI observation", confirm_observed=True,
+            gui_evidence=[str(directory / "observation.png"), str(directory / "observation.txt")])
+
+    def clone(self, source, target):
         audit.clone_upgrade(argparse.Namespace(source=str(source), output=str(target), zip=str(self.archive),
             sha256=audit.digest(self.archive), commit="a" * 40))
+
+    def test_upgrade_clone_requires_coherent_observed_evidence_and_preserves_mouse(self):
+        source = self.prepare("custom")
+        args = self.gui_fixture(source)
+        audit.accept_baseline(args)
+        before = audit.config_snapshot(source)
+        target = self.root / "candidate"
+        self.clone(source, target)
         self.assertEqual(before, audit.config_snapshot(source))
         self.assertEqual(before, audit.config_snapshot(target))
         self.assertEqual((source / "config/keymaps/audit.xml").read_bytes(),
@@ -59,6 +155,114 @@ class AuditToolTest(unittest.TestCase):
         self.assertIn(b'mouse-shortcut keystroke="control button2"',
                       (target / "config/keymaps/audit.xml").read_bytes())
         self.assertNotEqual((source / "idea.properties").read_text(), (target / "idea.properties").read_text())
+
+    def test_all_six_seed_contracts_accept_consistent_synthetic_observations(self):
+        for case in audit.CASES:
+            with self.subTest(case=case):
+                root = self.prepare(case)
+                audit.accept_baseline(self.gui_fixture(root))
+                audit.validate_acceptance(root)
+
+    def test_unobserved_or_boolean_marker_does_not_allow_clone(self):
+        source = self.prepare()
+        target = self.root / "candidate"
+        with self.assertRaises(ValueError):
+            self.clone(source, target)
+        audit.write_json(source / "acceptance.json", {"schema": 1, "state": "gui-accepted"})
+        with self.assertRaises(ValueError):
+            self.clone(source, target)
+        self.assertFalse(target.exists())
+
+    def test_clone_rejects_same_nested_parent_and_symlink_paths_before_writes(self):
+        source = self.prepare()
+        alias = self.root / "alias"
+        alias.symlink_to(source, target_is_directory=True)
+        before = audit.config_snapshot(source)
+        for target in [source, source / "system/candidate", source.parent, alias / "system/candidate"]:
+            with self.subTest(target=target), self.assertRaisesRegex(ValueError, "disjoint canonical"):
+                self.clone(source, target)
+        self.assertEqual(before, audit.config_snapshot(source))
+        self.assertFalse((source / "system/candidate").exists())
+
+    def test_acceptance_rejects_missing_launch_bad_exit_and_identity_mismatches(self):
+        source = self.prepare()
+        args = self.gui_fixture(source)
+        directory = Path(args.run_directory)
+        path = directory / "process-result.json"
+        original = path.read_bytes()
+        mutations = {"pid": 999, "exitCode": 1, "interrupted": True, "runId": str(uuid.uuid4()),
+                     "profileId": str(uuid.uuid4()), "profileSha256": "0" * 64,
+                     "productSha256": "0" * 64, "finishedUtc": "2026-08-01T00:00:00+00:00"}
+        for key, value in mutations.items():
+            with self.subTest(key=key):
+                modified = json.loads(original)
+                modified[key] = value
+                path.write_text(json.dumps(modified))
+                with self.assertRaises(ValueError):
+                    audit.accept_baseline(args)
+                self.assertFalse((source / "acceptance.json").exists())
+        path.write_bytes(original)
+        (directory / "process-start.json").unlink()
+        with self.assertRaises(ValueError):
+            audit.accept_baseline(args)
+
+    def test_acceptance_rejects_unobserved_cross_run_and_symlink_gui_evidence(self):
+        source = self.prepare()
+        args = self.gui_fixture(source)
+        args.confirm_observed = False
+        with self.assertRaises(ValueError):
+            audit.accept_baseline(args)
+        args.confirm_observed = True
+        original = args.gui_evidence[0]
+        other = source / "other.png"
+        other.write_bytes(Path(original).read_bytes())
+        args.gui_evidence[0] = str(other)
+        with self.assertRaises(ValueError):
+            audit.accept_baseline(args)
+        args.gui_evidence[0] = original
+        Path(original).unlink()
+        Path(original).symlink_to(other)
+        with self.assertRaises(ValueError):
+            audit.accept_baseline(args)
+
+    def test_native_jpeg_evidence_is_supported_and_wrong_signature_is_rejected(self):
+        source = self.prepare()
+        args = self.gui_fixture(source)
+        image = Path(args.run_directory) / "native.jpeg"
+        image.write_bytes(b"SIMULATED wrong signature")
+        args.gui_evidence[0] = str(image)
+        with self.assertRaisesRegex(ValueError, "screenshot"):
+            audit.accept_baseline(args)
+        image.write_bytes(b"\xff\xd8\xff\xe0SIMULATED JPEG test fixture")
+        audit.accept_baseline(args)
+        audit.validate_acceptance(source)
+
+    def test_changed_config_raw_gui_or_product_invalidates_acceptance(self):
+        source = self.prepare()
+        args = self.gui_fixture(source)
+        audit.accept_baseline(args)
+        paths = [source / "config/options/keymap.xml", Path(args.export), Path(args.gui_evidence[1]),
+                 next((source / "plugins").rglob("*.jar"))]
+        for path in paths:
+            with self.subTest(path=path):
+                original = path.read_bytes()
+                path.write_bytes(original + b"changed")
+                with self.assertRaises(ValueError):
+                    audit.validate_acceptance(source)
+                path.write_bytes(original)
+        audit.validate_acceptance(source)
+
+    def test_seed_contract_rejects_lost_mouse_unassigned_and_deleted_ide_values(self):
+        for case, action in [("custom", audit.PREFIX + "Copy"), ("unassigned", audit.PREFIX + "Copy"),
+                             ("removed-ide", "IntroduceConstant"), ("unrelated-only", "EditorToggleUseSoftWraps")]:
+            with self.subTest(case=case):
+                source = self.prepare(case)
+                args = self.gui_fixture(source)
+                data = audit.parse_export(Path(args.export))
+                key = (args.observed_keymap, action)
+                data["bindings"][key][3] = json.dumps([keyboard("meta alt pressed C")])
+                with self.assertRaises(ValueError):
+                    audit.validate_seed_bindings(audit.load_profile(source), data)
 
     def test_unassigned_and_unrelated_cases_keep_distinct_intent(self):
         empty = self.prepare("unassigned")
@@ -68,29 +272,114 @@ class AuditToolTest(unittest.TestCase):
         unrelated = self.prepare("unrelated-only")
         self.assertNotIn(audit.PREFIX, (unrelated / "config/keymaps/audit.xml").read_text())
 
-    def test_incomplete_and_zero_action_runtime_exports_fail(self):
-        source = self.root / "incomplete.tsv"
-        source.write_text("KEYMAP\t$default\tfalse\t$default\nEND\tkeymaps\t1\n")
-        with self.assertRaisesRegex(ValueError, "Incomplete"):
-            audit.summarize(source, self.root / "result.json")
-        self.assertFalse((self.root / "result.json").exists())
+    def test_malformed_and_incomplete_exports_fail_without_summary(self):
+        complete = self.export_rows()
+        cases = {
+            "missing END": complete[:-1],
+            "duplicate END": complete + [complete[-1]],
+            "wrong counts": complete[:-1] + [["END", "keymaps", 99, "commands", 9, "bindings", 11, "occupancies", 3, "rows", len(complete)]],
+            "missing command": recount([r for r in complete if not (r[0] == "COMMAND" and r[1].endswith("Copy"))]),
+            "zero command": recount([r for r in complete if r[0] != "COMMAND"]),
+            "duplicate command": recount(complete + [next(r for r in complete if r[0] == "COMMAND")]),
+            "missing keymap": recount([r for r in complete if r[0] != "KEYMAP"]),
+            "duplicate keymap": recount(complete + [next(r for r in complete if r[0] == "KEYMAP")]),
+            "missing binding": recount([r for r in complete if not (r[0] == "BINDING" and r[2].endswith("Copy"))]),
+            "missing watch": recount([r for r in complete if not (r[0] == "BINDING" and r[2] == "IntroduceConstant")]),
+            "duplicate binding": recount(complete + [next(r for r in complete if r[0] == "BINDING")]),
+            "missing occupancy": recount([r for r in complete if r[0] != "OCCUPANCY"]),
+            "missing probe": recount([r for r in complete if not (r[0] == "PROBE" and r[1] == "meta alt C")]),
+            "missing metadata": recount([r for r in complete if not (r[0] == "META" and r[1] == "runId")]),
+            "unknown row": recount(complete + [["UNKNOWN", "test"]]),
+        }
+        for name, rows in cases.items():
+            with self.subTest(name=name):
+                source, target = self.root / "bad.tsv", self.root / "result.json"
+                source.write_text(encode_rows(rows))
+                with self.assertRaises(ValueError):
+                    audit.summarize(source, target)
+                self.assertFalse(target.exists())
 
     def test_external_single_and_other_chord_occupancies_are_kept(self):
         source = self.root / "complete.tsv"
-        rows = ["COMMAND\t" + audit.PREFIX + name for name in audit.COMMANDS]
-        rows += ["KEYMAP\t$default\tfalse\t$default",
-                 "OCCUPANCY\t$default\tcontrol alt shift G\tExternal.single\tG\tnull",
-                 "OCCUPANCY\t$default\tcontrol alt shift G\tExternal.chord\tG\tQ",
-                 "OCCUPANCY\t$default\tcontrol alt shift G\tCopySelectionContext.Copy\tG\tC",
-                 "OCCUPANCY\t$default\tcontrol alt C\tIntroduceConstant\tC\tnull",
-                 "END\tkeymaps\t1\tcommands\t9"]
-        source.write_text("\n".join(rows) + "\n")
+        source.write_text(encode_rows(self.export_rows(extra={
+            "External.single": [keyboard("ctrl alt shift pressed G")],
+            "External.chord": [keyboard("ctrl alt shift pressed G", "pressed Q")]})))
         target = self.root / "summary.json"
         audit.summarize(source, target)
         result = json.loads(target.read_text())
-        self.assertEqual([row[3] for row in result["externalPrefixOccupancy"]],
-                         ["External.single", "External.chord"])
-        self.assertEqual(len(result["oldCHOccupancy"]), 1)
+        self.assertEqual({row[3] for row in result["externalPrefixOccupancy"]},
+                         {"External.single", "External.chord"})
+        self.assertEqual(len(result["oldCHOccupancy"]), 3)
+        self.assertFalse(result["legacyInspectionOnly"])
+
+    def test_legacy_requires_opt_in_and_still_checks_completeness(self):
+        rows = self.export_rows()
+        rows = [r for r in rows if r[0] not in {"PROBE", "END"}]
+        for row in rows:
+            if row[:2] == ["META", "schema"]:
+                row[2] = "1"
+        rows.append(["END", "keymaps", 1, "commands", 9])
+        source = self.root / "legacy.tsv"
+        source.write_text(encode_rows(rows))
+        with self.assertRaisesRegex(ValueError, "legacy export"):
+            audit.parse_export(source)
+        self.assertTrue(audit.parse_export(source, allow_legacy=True)["legacyInspectionOnly"])
+        rows[-1][-1] = 8
+        source.write_text(encode_rows(rows))
+        with self.assertRaises(ValueError):
+            audit.parse_export(source, allow_legacy=True)
+
+    def test_config_symlinks_are_rejected(self):
+        source = self.prepare()
+        (source / "config/linked").symlink_to(self.archive)
+        with self.assertRaisesRegex(ValueError, "symlink"):
+            audit.config_snapshot(source)
+
+    def test_process_timeout_records_pid_and_cleans_up(self):
+        source = self.prepare()
+        run = source / "process-test"
+        run.mkdir()
+        with self.assertRaises(subprocess.TimeoutExpired):
+            audit.run_process([sys.executable, "-c", "import time; time.sleep(30)"],
+                              source, run, {"runId": "test"}, timeout=0.1)
+        start = json.loads((run / "process-start.json").read_text())
+        result = json.loads((run / "process-result.json").read_text())
+        self.assertEqual(start["pid"], result["pid"])
+        self.assertTrue(result["interrupted"])
+        self.assertIsInstance(result["exitCode"], int)
+        with self.assertRaises(ProcessLookupError):
+            audit.os.kill(result["pid"], 0)
+
+    def test_abnormal_exit_is_reported_with_original_exit_code(self):
+        source = self.prepare()
+        run = source / "exit-test"
+        run.mkdir()
+        with self.assertRaisesRegex(RuntimeError, "IDE exited 7"):
+            audit.run_process([sys.executable, "-c", "raise SystemExit(7)"], source, run, {})
+        result = json.loads((run / "process-result.json").read_text())
+        self.assertEqual(result["exitCode"], 7)
+        self.assertTrue(result["interrupted"])
+
+    def test_keyboard_interrupt_records_cleanup_result(self):
+        source = self.prepare()
+        run = source / "interrupt-test"
+        run.mkdir()
+        wait = subprocess.Popen.wait
+        first = True
+        def interrupt_once(process, *args, **kwargs):
+            nonlocal first
+            if first:
+                first = False
+                raise KeyboardInterrupt()
+            return wait(process, *args, **kwargs)
+        with mock.patch.object(subprocess.Popen, "wait", interrupt_once):
+            with self.assertRaises(KeyboardInterrupt):
+                audit.run_process([sys.executable, "-c", "import time; time.sleep(30)"], source, run, {})
+        result = json.loads((run / "process-result.json").read_text())
+        self.assertTrue(result["interrupted"])
+        self.assertIsInstance(result["exitCode"], int)
+        with self.assertRaises(ProcessLookupError):
+            audit.os.kill(result["pid"], 0)
 
     def test_archive_path_traversal_is_rejected(self):
         bad = self.root / "bad.zip"

--- a/scripts/shortcut-audit/test_audit.py
+++ b/scripts/shortcut-audit/test_audit.py
@@ -74,6 +74,32 @@ class AuditToolTest(unittest.TestCase):
             self.prepare()
         self.assertEqual(before, audit.config_snapshot(root))
 
+    def test_headless_java_uses_metadata_or_explicit_inspected_bundled_runtime(self):
+        home = self.root / "IDE/Contents"
+        java = home / "jbr/Contents/Home/bin/java"
+        java.parent.mkdir(parents=True)
+        java.write_text("synthetic executable path fixture")
+        java.chmod(0o700)
+        info = home / "Resources/product-info.json"
+        self.assertEqual(audit.headless_java(home, info, {"javaExecutablePath": "../jbr/Contents/Home/bin/java"}),
+                         (java, "product-info"))
+        self.assertEqual(audit.headless_java(home, info, {}, str(java)), (java, "explicit-bundled-runtime"))
+
+    def test_headless_java_rejects_missing_external_relative_or_conflicting_runtime(self):
+        home = self.root / "IDE/Contents"
+        home.mkdir(parents=True)
+        external = self.root / "java"
+        external.write_text("synthetic executable path fixture")
+        external.chmod(0o700)
+        link = home / "java"
+        link.symlink_to(external)
+        cases = [({}, None), ({}, "jbr/bin/java"), ({}, str(external)), ({}, str(link)),
+                 ({}, str(home / "missing")), ({"javaExecutablePath": "../../java"}, None),
+                 ({"javaExecutablePath": "java"}, str(external))]
+        for launch, explicit in cases:
+            with self.subTest(launch=launch, explicit=explicit), self.assertRaises(ValueError):
+                audit.headless_java(home, home / "Resources/product-info.json", launch, explicit)
+
     def test_explicit_old_uses_observed_effective_mac_values(self):
         root = self.prepare("explicit-old")
         keymap = ET.parse(root / "config/keymaps/audit.xml").getroot()

--- a/scripts/shortcut-audit/test_audit.py
+++ b/scripts/shortcut-audit/test_audit.py
@@ -336,6 +336,39 @@ class AuditToolTest(unittest.TestCase):
                     project=str(self.root / "project")))
             launch.assert_not_called()
 
+    def test_gui_all_os_keymaps_is_explicit_and_recorded_in_launch_provenance(self):
+        app = self.root / "Synthetic.app"
+        resources = app / "Contents/Resources"
+        resources.mkdir(parents=True)
+        (resources / "original.vmoptions").write_text("-Xmx512m\n")
+        (resources / "product-info.json").write_text(json.dumps({
+            "envVarBaseName": "SYNTHETIC", "buildNumber": "test-only",
+            "launch": [{"os": "macOS", "arch": "aarch64", "launcherPath": "fake-launcher",
+                        "vmOptionsFilePath": "original.vmoptions"}],
+        }))
+        for enabled in [False, True]:
+            with self.subTest(all_os_keymaps=enabled):
+                root = self.root / str(enabled)
+                audit.prepare(argparse.Namespace(output=str(root), zip=str(self.archive),
+                    sha256=audit.digest(self.archive), case=None, parent="Mac OS X 10.5+",
+                    native_mac=True, removed_action="IntroduceConstant", old_copy=None, old_history=None))
+                self.install_harness(root)
+                before = audit.config_snapshot(root)
+                with mock.patch.object(audit, "run_process") as launch:
+                    audit.launch_gui(argparse.Namespace(app=str(app), profile=str(root),
+                        project=str(self.root / "project"), all_os_keymaps=enabled))
+                launch.assert_called_once()
+                command, _, directory, context, environment = launch.call_args.args
+                recorded = json.loads((directory / "gui-command.json").read_text())
+                options = (directory / "gui.vmoptions").read_text()
+                self.assertTrue(options.startswith("-Xmx512m\n"))
+                self.assertEqual(options.count("-Dkeymap.current.os.only=false\n"), int(enabled))
+                self.assertIs(recorded["keymapOsFilterOverride"], False if enabled else None)
+                self.assertEqual(recorded["keymapOsFilterOverride"], context["keymapOsFilterOverride"])
+                self.assertEqual(environment["SYNTHETIC_VM_OPTIONS"], str(directory / "gui.vmoptions"))
+                self.assertEqual(command[0], str(resources / "fake-launcher"))
+                self.assertEqual(before, audit.config_snapshot(root))
+
     def test_harness_change_invalidates_accepted_baseline_and_export_must_match_run(self):
         source = self.prepare()
         args = self.gui_fixture(source)

--- a/scripts/shortcut-audit/test_audit.py
+++ b/scripts/shortcut-audit/test_audit.py
@@ -1,0 +1,105 @@
+"""Safety and evidence integrity tests; no IDE process or platform state."""
+
+import argparse
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+import zipfile
+
+import audit
+
+
+class AuditToolTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.archive = self.root / "product.zip"
+        jar_bytes = io.BytesIO()
+        with zipfile.ZipFile(jar_bytes, "w") as jar:
+            jar.writestr("META-INF/plugin.xml", f"<idea-plugin><id>{audit.PRODUCT_ID}</id><version>1.6.0</version></idea-plugin>")
+        with zipfile.ZipFile(self.archive, "w") as archive:
+            archive.writestr("copy-selection-context/lib/product.jar", jar_bytes.getvalue())
+
+    def prepare(self, case="pristine"):
+        root = self.root / case
+        audit.prepare(argparse.Namespace(output=str(root), zip=str(self.archive),
+            sha256=audit.digest(self.archive), case=case, parent="Mac OS X 10.5+",
+            native_mac=True, removed_action="IntroduceConstant", old_copy="meta alt C", old_history="meta alt H"))
+        return root
+
+    def test_existing_profile_is_never_overwritten(self):
+        root = self.prepare()
+        before = audit.config_snapshot(root)
+        with self.assertRaises(FileExistsError):
+            self.prepare()
+        self.assertEqual(before, audit.config_snapshot(root))
+
+    def test_explicit_old_uses_observed_effective_mac_values(self):
+        root = self.prepare("explicit-old")
+        keymap = ET.parse(root / "config/keymaps/audit.xml").getroot()
+        bindings = {item.attrib["id"]: item.find("keyboard-shortcut").attrib["first-keystroke"]
+                    for item in keymap.findall("action")}
+        self.assertEqual(bindings[audit.PREFIX + "Copy"], "meta alt C")
+        self.assertEqual(bindings[audit.PREFIX + "ShowHistory"], "meta alt H")
+
+    def test_upgrade_clone_preserves_original_and_mouse_payload(self):
+        source = self.prepare("custom")
+        before = audit.config_snapshot(source)
+        target = self.root / "candidate"
+        audit.clone_upgrade(argparse.Namespace(source=str(source), output=str(target), zip=str(self.archive),
+            sha256=audit.digest(self.archive), commit="a" * 40))
+        self.assertEqual(before, audit.config_snapshot(source))
+        self.assertEqual(before, audit.config_snapshot(target))
+        self.assertEqual((source / "config/keymaps/audit.xml").read_bytes(),
+                         (target / "config/keymaps/audit.xml").read_bytes())
+        self.assertIn(b'mouse-shortcut keystroke="control button2"',
+                      (target / "config/keymaps/audit.xml").read_bytes())
+        self.assertNotEqual((source / "idea.properties").read_text(), (target / "idea.properties").read_text())
+
+    def test_unassigned_and_unrelated_cases_keep_distinct_intent(self):
+        empty = self.prepare("unassigned")
+        entries = ET.parse(empty / "config/keymaps/audit.xml").getroot().findall("action")
+        self.assertEqual(len(entries), 2)
+        self.assertTrue(all(len(entry) == 0 for entry in entries))
+        unrelated = self.prepare("unrelated-only")
+        self.assertNotIn(audit.PREFIX, (unrelated / "config/keymaps/audit.xml").read_text())
+
+    def test_incomplete_and_zero_action_runtime_exports_fail(self):
+        source = self.root / "incomplete.tsv"
+        source.write_text("KEYMAP\t$default\tfalse\t$default\nEND\tkeymaps\t1\n")
+        with self.assertRaisesRegex(ValueError, "Incomplete"):
+            audit.summarize(source, self.root / "result.json")
+        self.assertFalse((self.root / "result.json").exists())
+
+    def test_external_single_and_other_chord_occupancies_are_kept(self):
+        source = self.root / "complete.tsv"
+        rows = ["COMMAND\t" + audit.PREFIX + name for name in audit.COMMANDS]
+        rows += ["KEYMAP\t$default\tfalse\t$default",
+                 "OCCUPANCY\t$default\tcontrol alt shift G\tExternal.single\tG\tnull",
+                 "OCCUPANCY\t$default\tcontrol alt shift G\tExternal.chord\tG\tQ",
+                 "OCCUPANCY\t$default\tcontrol alt shift G\tCopySelectionContext.Copy\tG\tC",
+                 "OCCUPANCY\t$default\tcontrol alt C\tIntroduceConstant\tC\tnull",
+                 "END\tkeymaps\t1\tcommands\t9"]
+        source.write_text("\n".join(rows) + "\n")
+        target = self.root / "summary.json"
+        audit.summarize(source, target)
+        result = json.loads(target.read_text())
+        self.assertEqual([row[3] for row in result["externalPrefixOccupancy"]],
+                         ["External.single", "External.chord"])
+        self.assertEqual(len(result["oldCHOccupancy"]), 1)
+
+    def test_archive_path_traversal_is_rejected(self):
+        bad = self.root / "bad.zip"
+        with zipfile.ZipFile(bad, "w") as archive:
+            archive.writestr("../outside", "unexpected")
+        with self.assertRaisesRegex(ValueError, "Unsafe"):
+            audit.unpack_product(bad, self.root / "plugins")
+        self.assertFalse((self.root / "outside").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/shortcut-audit/test_audit.py
+++ b/scripts/shortcut-audit/test_audit.py
@@ -54,6 +54,19 @@ class AuditToolTest(unittest.TestCase):
             native_mac=True, removed_action="IntroduceConstant", old_copy="meta alt C", old_history="meta alt H"))
         return root
 
+    def install_harness(self, profile):
+        """Synthetic JAR for validation only; never loaded in an IDE."""
+        directory = profile / "plugins/csc-keymap-audit"
+        jar = directory / audit.HARNESS_JAR
+        jar.parent.mkdir(parents=True)
+        with zipfile.ZipFile(jar, "x") as archive:
+            archive.writestr("META-INF/plugin.xml", (audit.HERE / "plugin.xml").read_bytes())
+            archive.writestr("audit/Synthetic.class", b"SIMULATED validator test; not executable")
+        audit.write_json(directory / "manifest.json", {"schema": 1, "pluginId": audit.HARNESS_ID,
+            "jarSha256": audit.digest(jar), "sources": audit.exporter_sources(),
+            "sourceRevision": None, "sourceTreeDirty": None})
+        return directory
+
     def test_existing_profile_is_never_overwritten(self):
         root = self.prepare()
         before = audit.config_snapshot(root)
@@ -77,13 +90,17 @@ class AuditToolTest(unittest.TestCase):
                 "build": "IC-243.21565.193", "activeKeymap": active, "headless": "false",
                 "registeredActionCount": "500", "profileId": metadata.get("profileId", str(uuid.uuid4())),
                 "runId": context["runId"] if context else str(uuid.uuid4()), "processId": str(pid),
+                "harnessJarSha256": context["harness"]["jarSha256"] if context else "1" * 64,
+                "harnessManifestSha256": context["harness"]["manifestSha256"] if context else "2" * 64,
                 "watchedActions": json.dumps(sorted(WATCHED_IDS)),
                 "projectRoots": json.dumps([context["project"]] if context else [])}
         meta.update({"idea." + name + ".path": str((profile or self.root) / name)
                      for name in ["config", "system", "plugins", "log"]})
         rows = [["META", key, value] for key, value in meta.items()]
         rows += [["META", "os", "Mac OS X", "15.5", "aarch64"],
-                 ["PLUGIN", audit.PRODUCT_ID, "1.6.0", "false", "test/plugin"]]
+                 ["PLUGIN", audit.PRODUCT_ID, "1.6.0", "false", "test/plugin"],
+                 ["PLUGIN", audit.HARNESS_ID, "1", "false",
+                  context["harness"]["directory"] if context else "test/harness"]]
         probes = {name: name.replace("control", "ctrl").rsplit(" ", 1)[0] + " pressed " + name.rsplit(" ", 1)[1]
                   for name in PROBES}
         rows += [["PROBE", name, value] for name, value in sorted(probes.items())]
@@ -119,6 +136,7 @@ class AuditToolTest(unittest.TestCase):
     def gui_fixture(self, source):
         """Synthetic evidence for validator tests only; never real GUI acceptance."""
         metadata = audit.load_profile(source)
+        self.install_harness(source)
         run_id = str(uuid.uuid4())
         directory = source / ("gui-run-" + run_id)
         directory.mkdir()
@@ -235,6 +253,83 @@ class AuditToolTest(unittest.TestCase):
             audit.accept_baseline(args)
         image.write_bytes(b"\xff\xd8\xff\xe0SIMULATED JPEG test fixture")
         audit.accept_baseline(args)
+        audit.validate_acceptance(source)
+
+    def test_harness_rejects_missing_stale_changed_wrong_plugin_and_extra_files(self):
+        source = self.prepare()
+        directory = self.install_harness(source)
+        audit.validate_harness(directory)
+        manifest = directory / "manifest.json"
+        original_manifest = manifest.read_bytes()
+        manifest.unlink()
+        with self.assertRaises(ValueError):
+            audit.validate_harness(directory)
+        manifest.write_bytes(original_manifest)
+        for key, value in [("pluginId", "wrong.plugin"), ("sources", {"old.java": "1" * 64}),
+                           ("jarSha256", "2" * 64)]:
+            with self.subTest(key=key):
+                data = json.loads(original_manifest)
+                data[key] = value
+                manifest.write_text(json.dumps(data))
+                with self.assertRaises(ValueError):
+                    audit.validate_harness(directory)
+        manifest.write_bytes(original_manifest)
+        jar = directory / audit.HARNESS_JAR
+        original_jar = jar.read_bytes()
+        jar.write_bytes(original_jar + b"changed")
+        with self.assertRaisesRegex(ValueError, "JAR changed"):
+            audit.validate_harness(directory)
+        jar.write_bytes(original_jar)
+        (directory / "extra.jar").write_bytes(b"extra")
+        with self.assertRaisesRegex(ValueError, "unexpected harness files"):
+            audit.validate_harness(directory)
+
+    def test_wrong_descriptor_rejected_even_when_jar_digest_matches_manifest(self):
+        source = self.prepare()
+        directory = self.install_harness(source)
+        jar = directory / audit.HARNESS_JAR
+        with zipfile.ZipFile(jar, "w") as archive:
+            archive.writestr("META-INF/plugin.xml", "<idea-plugin><id>wrong.plugin</id></idea-plugin>")
+        manifest = directory / "manifest.json"
+        data = json.loads(manifest.read_text())
+        data["jarSha256"] = audit.digest(jar)
+        manifest.write_text(json.dumps(data))
+        with self.assertRaisesRegex(ValueError, "wrong harness plugin ID"):
+            audit.validate_harness(directory)
+
+    def test_stale_harness_stops_audit_and_gui_before_launch_or_copy(self):
+        source = self.prepare()
+        directory = self.install_harness(source)
+        (directory / "manifest.json").unlink()
+        with mock.patch.object(audit, "run_process") as launch:
+            with self.assertRaises(ValueError):
+                audit.audit(argparse.Namespace(profile=str(source), ide_home=str(self.root / "no-ide"),
+                    harness=str(directory), timeout=10))
+            with self.assertRaises(ValueError):
+                audit.launch_gui(argparse.Namespace(profile=str(source), app=str(self.root / "no-ide"),
+                    project=str(self.root / "project")))
+            launch.assert_not_called()
+
+    def test_harness_change_invalidates_accepted_baseline_and_export_must_match_run(self):
+        source = self.prepare()
+        args = self.gui_fixture(source)
+        raw = Path(args.export)
+        original = raw.read_text()
+        rows = [[audit.parse_export(raw)["metadata"]["harnessJarSha256"], "0" * 64],
+                [audit.parse_export(raw)["metadata"]["harnessManifestSha256"], "0" * 64]]
+        for before, after in rows:
+            raw.write_text(original.replace(before, after))
+            with self.assertRaisesRegex(ValueError, "export harness identity"):
+                audit.accept_baseline(args)
+        raw.write_text(original)
+        audit.accept_baseline(args)
+        directory = source / "plugins/csc-keymap-audit"
+        for path in [directory / audit.HARNESS_JAR, directory / "manifest.json"]:
+            before = path.read_bytes()
+            path.write_bytes(before + b" ")
+            with self.assertRaises(ValueError):
+                audit.validate_acceptance(source)
+            path.write_bytes(before)
         audit.validate_acceptance(source)
 
     def test_changed_config_raw_gui_or_product_invalidates_acceptance(self):

--- a/scripts/shortcut-audit/test_strokes.py
+++ b/scripts/shortcut-audit/test_strokes.py
@@ -1,12 +1,15 @@
 """Synthetic complete-inventory integrity and prefix-comparison tests; no real IDE verdict."""
 
 import json
+import os
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from evidence import COMMAND_IDS, PREFIX, parse_export
 from strokes import DEFAULT_KEYS, PUNCTUATION_KEYS, compare_prefixes, parse_inventory, sha256
-from lineage import load_policy, select_modifier
+from lineage import MAX_SOURCE_BYTES, load_policy, select_modifier
 import test_audit
 from test_audit import encode_rows, keyboard
 
@@ -14,6 +17,78 @@ POLICY_SOURCE = Path(__file__).with_name("fixtures") / "CopySelectionShortcuts.k
 
 
 class ProductModifierPolicyTest(unittest.TestCase):
+    def test_hash_and_policy_use_one_bounded_descriptor_read_without_path_rereads(self):
+        injected = POLICY_SOURCE.read_text().replace('"Mac OS X",', '"Injected Mac Family",')
+        with mock.patch("lineage.os.read", wraps=os.read) as read, \
+                mock.patch.object(Path, "read_bytes", side_effect=AssertionError("second path read")), \
+                mock.patch.object(Path, "read_text", return_value=injected) as read_text, \
+                mock.patch.object(Path, "resolve", side_effect=AssertionError("post-read resolve")):
+            policy = load_policy(POLICY_SOURCE)
+        read.assert_called_once()
+        self.assertEqual(read.call_args.args[1], MAX_SOURCE_BYTES + 1)
+        read_text.assert_not_called()
+        self.assertIn("Mac OS X", policy["macKeymapIds"])
+        self.assertNotIn("Injected Mac Family", policy["macKeymapIds"])
+        self.assertEqual(policy["sourceIdentity"]["inode"], POLICY_SOURCE.stat().st_ino)
+
+    def test_policy_rejects_empty_and_oversized_sources_before_read(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source.kt"
+            for data in [b"", b"x" * (MAX_SOURCE_BYTES + 1)]:
+                source.write_bytes(data)
+                with self.subTest(size=len(data)), mock.patch("lineage.os.read") as read:
+                    with self.assertRaisesRegex(ValueError, "size limit or is empty"):
+                        load_policy(source)
+                    read.assert_not_called()
+
+    def test_policy_rejects_final_symlink_directory_and_fifo_before_open(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source.kt"
+            source.write_bytes(POLICY_SOURCE.read_bytes())
+            link = root / "link.kt"
+            link.symlink_to(source)
+            fifo = root / "fifo.kt"
+            os.mkfifo(fifo)
+            for path in [link, root, fifo]:
+                with self.subTest(path=path), mock.patch("lineage.os.open") as open_file:
+                    with self.assertRaisesRegex(ValueError, "regular file"):
+                        load_policy(path)
+                    open_file.assert_not_called()
+
+    def test_policy_rejects_post_stat_oversize_and_mutation_during_read(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source.kt"
+            source.write_bytes(POLICY_SOURCE.read_bytes())
+            with mock.patch("lineage.os.read", return_value=b"x" * (MAX_SOURCE_BYTES + 1)):
+                with self.assertRaisesRegex(ValueError, "snapshot exceeds size limit"):
+                    load_policy(source)
+            original_read = os.read
+
+            def mutate_after_read(descriptor, limit):
+                data = original_read(descriptor, limit)
+                with source.open("ab") as output:
+                    output.write(b"\n")
+                return data
+
+            with mock.patch("lineage.os.read", side_effect=mutate_after_read):
+                with self.assertRaisesRegex(ValueError, "changed during read"):
+                    load_policy(source)
+
+    def test_parent_alias_records_lookup_path_and_actual_opened_identity(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            actual = root / "actual"
+            actual.mkdir()
+            source = actual / "source.kt"
+            source.write_bytes(POLICY_SOURCE.read_bytes())
+            alias = root / "alias"
+            alias.symlink_to(actual, target_is_directory=True)
+            policy = load_policy(alias / "source.kt")
+            self.assertEqual(policy["sourcePath"], str(alias / "source.kt"))
+            self.assertEqual(policy["sourceIdentity"]["inode"], source.stat().st_ino)
+            self.assertEqual(policy["sourceIdentity"]["device"], source.stat().st_dev)
+
     def test_exact_ancestor_rule_and_default_stop_precede_host_fallback(self):
         policy = load_policy(POLICY_SOURCE)
         examples = [

--- a/scripts/shortcut-audit/test_strokes.py
+++ b/scripts/shortcut-audit/test_strokes.py
@@ -72,6 +72,8 @@ class StrokeInventoryTest(unittest.TestCase):
             "MouseOnly": [{"kind": "mouse", "button": 2, "modifiers": 128, "clickCount": 1}],
         }
         audit_rows = fixture.export_rows(extra=extras)
+        audit_rows.append(["PLUGIN", "com.intellij", "test", "false", "test/platform"])
+        audit_rows = test_audit.recount(audit_rows)
         # Candidate Q on an exact product ID must be listed separately; a merely
         # prefix-matching external ID above must still block Q.
         for row in audit_rows:
@@ -102,6 +104,40 @@ class StrokeInventoryTest(unittest.TestCase):
 
     def write(self, rows):
         self.path.write_text(encode_rows(rows))
+
+    def test_registered_snapshot_must_match_in_both_directions(self):
+        for action, claimed in [("DormantChord", "true"), ("ExternalSingle", "false")]:
+            rows = [row.copy() for row in self.rows]
+            next(row for row in rows if row[:3] == ["ACTION", "$default", action])[4] = claimed
+            self.write(rows)
+            with self.subTest(action=action), self.assertRaisesRegex(ValueError, "registered snapshot mismatch"):
+                parse_inventory(self.audit_path)
+
+    def test_non_probe_owner_must_exist_in_original_plugin_inventory(self):
+        rows = [row.copy() for row in self.rows]
+        row = next(row for row in rows if row[:3] == ["ACTION", "$default", "ExternalSingle"])
+        row[5:7] = ["invented.plugin", "true"]
+        self.write(rows)
+        with self.assertRaisesRegex(ValueError, "owner missing from plugin inventory"):
+            compare_prefixes([self.audit_path], ["J"])
+
+    def test_registered_owner_requires_known_matching_bundled_value(self):
+        for owner, bundled in [("com.intellij", "true"), ("com.intellij", "unknown"),
+                               ("unknown", "unknown"), ("unknown", "false")]:
+            rows = [row.copy() for row in self.rows]
+            next(row for row in rows if row[:3] == ["ACTION", "$default", "ExternalSingle"])[5:7] = [owner, bundled]
+            self.write(rows)
+            with self.subTest(owner=owner, bundled=bundled), self.assertRaises(ValueError):
+                parse_inventory(self.audit_path)
+
+    def test_dormant_action_requires_both_unknown_fields(self):
+        for owner, bundled in [("com.intellij", "false"), ("com.intellij", "unknown"),
+                               ("unknown", "true"), ("unknown", "false")]:
+            rows = [row.copy() for row in self.rows]
+            next(row for row in rows if row[:3] == ["ACTION", "$default", "DormantChord"])[5:7] = [owner, bundled]
+            self.write(rows)
+            with self.subTest(owner=owner, bundled=bundled), self.assertRaisesRegex(ValueError, "dormant.*claims ownership"):
+                parse_inventory(self.audit_path)
 
     def test_changed_product_source_is_rejected_before_policy_claim(self):
         changed = self.root / "CopySelectionShortcuts.kt"
@@ -169,7 +205,7 @@ class StrokeInventoryTest(unittest.TestCase):
         self.assertEqual(single["occurrencesInApiList"], 2)
         self.assertEqual(len(single["allShortcuts"]), 2)
 
-    def test_inherited_dormant_mapping_is_required_in_child_even_without_local_id(self):
+    def add_child_inventory(self):
         rows = [row.copy() for row in self.audit_rows]
         rows += [["KEYMAP", "Child", "true", json.dumps(["Child", "$default"])]]
         for row in self.audit_rows:
@@ -188,6 +224,19 @@ class StrokeInventoryTest(unittest.TestCase):
                 copied[1] = "Child"
                 inventory.append(copied)
         self.write(recount_inventory(inventory))
+        return inventory
+
+    def test_same_action_owner_tuple_must_match_across_keymaps(self):
+        inventory = self.add_child_inventory()
+        # Both owners exist with the same bundled flag, so per-row plugin
+        # validation alone cannot reject this non-probe attribution change.
+        next(row for row in inventory if row[:3] == ["ACTION", "Child", "ExternalSingle"])[5] = "com.github.hon454.copy-selection-context"
+        self.write(recount_inventory(inventory))
+        with self.assertRaisesRegex(ValueError, "inconsistent inventory action ownership"):
+            parse_inventory(self.audit_path)
+
+    def test_inherited_dormant_mapping_is_required_in_child_even_without_local_id(self):
+        inventory = self.add_child_inventory()
         candidate = compare_prefixes([self.audit_path], ["F13"])["candidates"][0]
         self.assertEqual(candidate["occupiedKeymaps"], 2)
         self.write(recount_inventory([row for row in inventory if row[:3] != ["ACTION", "Child", "DormantChord"]]))
@@ -249,7 +298,7 @@ class StrokeInventoryTest(unittest.TestCase):
 
     def test_ownership_disagreement_with_original_probe_fails(self):
         rows = [row.copy() for row in self.rows]
-        next(row for row in rows if row[:3] == ["ACTION", "$default", "ExternalG"])[5] = "wrong.owner"
+        next(row for row in rows if row[:3] == ["ACTION", "$default", "ExternalG"])[5] = "com.github.hon454.copy-selection-context"
         self.write(rows)
         with self.assertRaisesRegex(ValueError, "owner/list mismatch"):
             parse_inventory(self.audit_path)

--- a/scripts/shortcut-audit/test_strokes.py
+++ b/scripts/shortcut-audit/test_strokes.py
@@ -2,11 +2,41 @@
 
 import json
 import unittest
+from pathlib import Path
 
 from evidence import COMMAND_IDS, PREFIX, parse_export
-from strokes import DEFAULT_KEYS, compare_prefixes, parse_inventory, sha256
+from strokes import DEFAULT_KEYS, PUNCTUATION_KEYS, compare_prefixes, parse_inventory, sha256
+from lineage import load_policy, select_modifier
 import test_audit
 from test_audit import encode_rows, keyboard
+
+POLICY_SOURCE = Path(__file__).with_name("fixtures") / "CopySelectionShortcuts.kt"
+
+
+class ProductModifierPolicyTest(unittest.TestCase):
+    def test_exact_ancestor_rule_and_default_stop_precede_host_fallback(self):
+        policy = load_policy(POLICY_SOURCE)
+        examples = [
+            (["Eclipse (Mac OS X)", "Mac OS X 10.5+", "$default"], "Linux", "meta", "Mac OS X 10.5+"),
+            (["Visual Studio 2022", "Visual Studio", "$default"], "Mac OS X", "control", "$default"),
+            (["My Mac OS X child", "$default", "Mac OS X"], "Mac OS X", "control", "$default"),
+            (["Custom", "ReSharper OSX", "$default"], "Windows 11", "meta", "ReSharper OSX"),
+            (["Custom", "Sublime Text (Mac OS X)", "$default"], "Linux", "meta", "Sublime Text (Mac OS X)"),
+        ]
+        for chain, host, modifier, ancestor in examples:
+            with self.subTest(chain=chain):
+                result = select_modifier(chain, host, policy)
+                self.assertEqual(result["modifier"], modifier)
+                self.assertEqual(result["decisiveAncestor"], ancestor)
+
+    def test_unknown_lineage_uses_recorded_host_and_unknown_host_fails(self):
+        policy = load_policy(POLICY_SOURCE)
+        for host, modifier in [("Mac OS X", "meta"), ("Windows 11", "control"), ("Linux", "control")]:
+            result = select_modifier(["Unlisted OSX"], host, policy)
+            self.assertEqual(result["modifier"], modifier)
+            self.assertEqual(result["reason"], "recorded-host-fallback")
+        with self.assertRaisesRegex(ValueError, "unknown host"):
+            select_modifier(["Unlisted"], "unknown", policy)
 
 
 def recount_inventory(rows):
@@ -73,6 +103,29 @@ class StrokeInventoryTest(unittest.TestCase):
     def write(self, rows):
         self.path.write_text(encode_rows(rows))
 
+    def test_changed_product_source_is_rejected_before_policy_claim(self):
+        changed = self.root / "CopySelectionShortcuts.kt"
+        changed.write_text(POLICY_SOURCE.read_text().replace("return false", "return true"))
+        with self.assertRaisesRegex(ValueError, "unsupported product defaults source"):
+            compare_prefixes([self.audit_path], ["J"], changed)
+
+    def test_product_rule_comparison_preserves_opposite_modifier_and_full_raw_view(self):
+        result = compare_prefixes([self.audit_path], ["J", "F13", "Q"], POLICY_SOURCE)
+        candidates = {row["key"]: row for row in result["candidates"]}
+        self.assertEqual(result["productModifierPolicy"]["sourceSha256"], sha256(POLICY_SOURCE))
+        decision = result["inputs"][0]["productModifierDecisions"]["$default"]
+        self.assertEqual(decision["modifier"], "control")  # Exported host is Mac; $default still wins.
+        self.assertEqual(candidates["J"]["productRuleComparison"]["externalOccupancyCount"], 2)
+        f13 = candidates["F13"]
+        self.assertEqual(f13["externalOccupancyCount"], 1)
+        self.assertEqual(f13["verdict"], "OCCUPIED")
+        self.assertEqual(f13["productRuleComparison"]["externalOccupancyCount"], 0)
+        self.assertEqual(f13["productRuleComparison"]["oppositeModifierOccupancy"], f13["externalOccupancy"])
+        self.assertFalse(f13["externalOccupancy"][0]["selectedByProductRule"])
+        self.assertEqual(candidates["Q"]["productRuleComparison"]["externalOccupancyCount"], 1)
+        self.assertTrue(candidates["Q"]["productOccupancy"][0]["selectedByProductRule"])
+        self.assertEqual(set(result["comparisonSourceSha256"]), {"strokes.py", "lineage.py"})
+
     def test_complete_inventory_keeps_single_chord_dormant_and_exact_product_exclusion(self):
         result = compare_prefixes([self.audit_path], ["J", "F13", "Q", "Z"])
         candidates = {row["key"]: row for row in result["candidates"]}
@@ -87,8 +140,23 @@ class StrokeInventoryTest(unittest.TestCase):
     def test_default_candidates_cover_all_letters_and_f1_through_f24(self):
         result = compare_prefixes([self.audit_path])
         self.assertEqual([row["key"] for row in result["candidates"]], DEFAULT_KEYS)
-        self.assertEqual(len(DEFAULT_KEYS), 50)
+        self.assertEqual(len(DEFAULT_KEYS), 61)
         self.assertEqual(len(result["candidates"][0]["probes"]), 2)
+
+    def test_punctuation_matches_key_codes_and_any_second_stroke_without_typed_aliases(self):
+        rows = [row.copy() for row in self.rows]
+        next(row for row in rows if row[:3] == ["ACTION", "$default", "ExternalSingle"])[3] = json.dumps([
+            keyboard("shift ctrl alt pressed SEMICOLON"), keyboard("shift meta alt pressed OPEN_BRACKET", "pressed A"),
+            keyboard("ctrl alt shift typed ,")])
+        self.write(recount_inventory(rows))
+        result = compare_prefixes([self.audit_path], PUNCTUATION_KEYS)
+        candidates = {row["key"]: row for row in result["candidates"]}
+        self.assertEqual(candidates["SEMICOLON"]["externalOccupancyCount"], 1)
+        self.assertEqual(candidates["OPEN_BRACKET"]["externalOccupancy"][0]["second"], "pressed A")
+        self.assertEqual(candidates["COMMA"]["externalOccupancyCount"], 0)
+        for literal in [";", ",", ".", "/", "[", "]"]:
+            with self.subTest(literal=literal), self.assertRaises(ValueError):
+                compare_prefixes([self.audit_path], [literal])
 
     def test_platform_duplicate_shortcuts_are_preserved_without_double_counting_occupancy(self):
         rows = [row.copy() for row in self.rows]

--- a/scripts/shortcut-audit/test_strokes.py
+++ b/scripts/shortcut-audit/test_strokes.py
@@ -1,0 +1,198 @@
+"""Synthetic complete-inventory integrity and prefix-comparison tests; no real IDE verdict."""
+
+import json
+import unittest
+
+from evidence import COMMAND_IDS, PREFIX, parse_export
+from strokes import DEFAULT_KEYS, compare_prefixes, parse_inventory, sha256
+import test_audit
+from test_audit import encode_rows, keyboard
+
+
+def recount_inventory(rows):
+    rows = [row for row in rows if row[0] not in {"END", "MAP"}]
+    maps = sorted({row[1] for row in rows if row[0] == "SOURCE"})
+    for name in maps:
+        actions = [row for row in rows if row[0] == "ACTION" and row[1] == name]
+        items = [item for row in actions for item in json.loads(row[3])]
+        rows.append(["MAP", name, len(actions), len(items), sum(item["kind"] == "keyboard" for item in items)])
+    rows.append(["END", "keymaps", len(maps), "registered", sum(row[0] == "REGISTERED" for row in rows),
+                 "sources", sum(row[0] == "SOURCE" for row in rows),
+                 "actions", sum(row[0] == "ACTION" for row in rows),
+                 "shortcuts", sum(len(json.loads(row[3])) for row in rows if row[0] == "ACTION"),
+                 "rows", len(rows) + 1])
+    return rows
+
+
+class StrokeInventoryTest(unittest.TestCase):
+    def setUp(self):
+        fixture = test_audit.AuditToolTest()
+        fixture.setUp()
+        self.addCleanup(fixture.doCleanups)
+        self.root = fixture.root
+        self.audit_path = self.root / "keymaps.tsv"
+        self.path = self.root / "keymaps.tsv.strokes.tsv"
+        extras = {
+            "ExternalSingle": [keyboard("shift ctrl alt pressed J")],
+            "ExternalChord": [keyboard("alt shift ctrl pressed J", "pressed X")],
+            "DormantChord": [keyboard("shift meta alt pressed F13", "pressed B")],
+            PREFIX + "NotOneOfNine": [keyboard("shift ctrl alt pressed Q")],
+            "ExternalG": [keyboard("ctrl alt shift pressed G", "pressed Z")],
+            "ReleasedOnly": [keyboard("shift ctrl alt released Z")],
+            "MouseOnly": [{"kind": "mouse", "button": 2, "modifiers": 128, "clickCount": 1}],
+        }
+        audit_rows = fixture.export_rows(extra=extras)
+        # Candidate Q on an exact product ID must be listed separately; a merely
+        # prefix-matching external ID above must still block Q.
+        for row in audit_rows:
+            if row[:3] == ["BINDING", "$default", PREFIX + "AddToCollection"]:
+                row[3] = json.dumps([keyboard("shift ctrl alt pressed Q")])
+        registered = COMMAND_IDS | {"IntroduceConstant", "EditorToggleUseSoftWraps"} | (set(extras) - {"DormantChord"})
+        for row in audit_rows:
+            if row[:2] == ["META", "registeredActionCount"]:
+                row[2] = str(len(registered))
+        audit_rows.insert(0, ["META", "strokeInventory", "complete-v1"])
+        audit_rows[-1][-1] += 1
+        self.audit_path.write_text(encode_rows(audit_rows))
+        self.audit_rows = audit_rows
+        data = parse_export(self.audit_path)
+        values = {key[1]: json.loads(row[3]) for key, row in data["bindings"].items()}
+        values.update(extras)
+        rows = [["META", "schema", "1"], ["META", "auditFile", self.audit_path.name],
+                ["META", "auditSha256", sha256(self.audit_path)]]
+        rows += [["REGISTERED", action] for action in sorted(registered)]
+        rows += [["SOURCE", "$default", "$default", json.dumps(["DormantChord"])]]
+        for action, items in sorted(values.items()):
+            rows.append(["ACTION", "$default", action, json.dumps(items), str(action in registered).lower(),
+                         "unknown" if action == "DormantChord" else
+                         "com.github.hon454.copy-selection-context" if action in COMMAND_IDS else "com.intellij",
+                         "unknown" if action == "DormantChord" else "false"])
+        self.rows = recount_inventory(rows)
+        self.write(self.rows)
+
+    def write(self, rows):
+        self.path.write_text(encode_rows(rows))
+
+    def test_complete_inventory_keeps_single_chord_dormant_and_exact_product_exclusion(self):
+        result = compare_prefixes([self.audit_path], ["J", "F13", "Q", "Z"])
+        candidates = {row["key"]: row for row in result["candidates"]}
+        self.assertEqual(candidates["J"]["externalOccupancyCount"], 2)
+        self.assertEqual({row["second"] for row in candidates["J"]["externalOccupancy"]}, {None, "pressed X"})
+        self.assertFalse(candidates["F13"]["externalOccupancy"][0]["registered"])
+        self.assertEqual(candidates["Q"]["externalActionIds"], [PREFIX + "NotOneOfNine"])
+        self.assertEqual(candidates["Q"]["productOccupancy"][0]["action"], PREFIX + "AddToCollection")
+        self.assertEqual(candidates["Z"]["verdict"], "NO_OCCUPANCY_IN_RECORDED_KEYMAPS")
+        self.assertEqual(result["inputs"][0]["inventorySha256"], sha256(self.path))
+
+    def test_default_candidates_cover_all_letters_and_f1_through_f24(self):
+        result = compare_prefixes([self.audit_path])
+        self.assertEqual([row["key"] for row in result["candidates"]], DEFAULT_KEYS)
+        self.assertEqual(len(DEFAULT_KEYS), 50)
+        self.assertEqual(len(result["candidates"][0]["probes"]), 2)
+
+    def test_platform_duplicate_shortcuts_are_preserved_without_double_counting_occupancy(self):
+        rows = [row.copy() for row in self.rows]
+        row = next(row for row in rows if row[:3] == ["ACTION", "$default", "ExternalSingle"])
+        row[3] = json.dumps(json.loads(row[3]) * 2)
+        self.write(recount_inventory(rows))
+        candidate = compare_prefixes([self.audit_path], ["J"])["candidates"][0]
+        self.assertEqual(candidate["externalOccupancyCount"], 2)
+        single = next(row for row in candidate["externalOccupancy"] if row["action"] == "ExternalSingle")
+        self.assertEqual(single["occurrencesInApiList"], 2)
+        self.assertEqual(len(single["allShortcuts"]), 2)
+
+    def test_inherited_dormant_mapping_is_required_in_child_even_without_local_id(self):
+        rows = [row.copy() for row in self.audit_rows]
+        rows += [["KEYMAP", "Child", "true", json.dumps(["Child", "$default"])]]
+        for row in self.audit_rows:
+            if row[0] in {"BINDING", "OCCUPANCY"}:
+                copied = row.copy()
+                copied[1] = "Child"
+                rows.append(copied)
+        self.audit_path.write_text(encode_rows(test_audit.recount(rows)))
+        inventory = [row.copy() for row in self.rows]
+        next(row for row in inventory if row[:2] == ["META", "auditSha256"])[2] = sha256(self.audit_path)
+        inventory += [["SOURCE", "Child", "Child", "[]"],
+                      ["SOURCE", "Child", "$default", json.dumps(["DormantChord"])]]
+        for row in self.rows:
+            if row[0] == "ACTION":
+                copied = row.copy()
+                copied[1] = "Child"
+                inventory.append(copied)
+        self.write(recount_inventory(inventory))
+        candidate = compare_prefixes([self.audit_path], ["F13"])["candidates"][0]
+        self.assertEqual(candidate["occupiedKeymaps"], 2)
+        self.write(recount_inventory([row for row in inventory if row[:3] != ["ACTION", "Child", "DormantChord"]]))
+        with self.assertRaisesRegex(ValueError, "missing/extra effective action"):
+            parse_inventory(self.audit_path)
+
+    def test_export_without_inventory_opt_in_is_rejected_even_with_companion(self):
+        rows = [row for row in self.audit_rows if row[:2] != ["META", "strokeInventory"]]
+        self.audit_path.write_text(encode_rows(test_audit.recount(rows)))
+        with self.assertRaisesRegex(ValueError, "no complete stroke inventory"):
+            parse_inventory(self.audit_path)
+
+    def test_old_six_probe_export_cannot_claim_new_candidate_coverage(self):
+        self.path.unlink()
+        with self.assertRaisesRegex(ValueError, "missing/invalid"):
+            parse_inventory(self.audit_path)
+
+    def test_missing_action_fails_even_after_map_and_end_counts_are_repaired(self):
+        for action in ["ExternalChord", "DormantChord", PREFIX + "Copy"]:
+            self.write(recount_inventory([row for row in self.rows if row[:3] != ["ACTION", "$default", action]]))
+            with self.subTest(action=action), self.assertRaisesRegex(ValueError, "missing/extra effective action"):
+                parse_inventory(self.audit_path)
+
+    def test_missing_registered_and_ancestor_source_rows_fail(self):
+        for kind in ["REGISTERED", "SOURCE"]:
+            changed = list(self.rows)
+            changed.pop(next(index for index, row in enumerate(changed) if row[0] == kind))
+            self.write(recount_inventory(changed))
+            with self.subTest(kind=kind), self.assertRaises(ValueError):
+                parse_inventory(self.audit_path)
+
+    def test_hash_mismatch_and_cross_export_pairing_fail(self):
+        for key, value in [("auditFile", "other.tsv"), ("auditSha256", "0" * 64)]:
+            rows = [row.copy() for row in self.rows]
+            next(row for row in rows if row[:2] == ["META", key])[2] = value
+            self.write(rows)
+            with self.subTest(key=key), self.assertRaisesRegex(ValueError, "different audit export"):
+                parse_inventory(self.audit_path)
+
+    def test_corrupt_counts_duplicate_rows_unknown_rows_and_missing_end_fail(self):
+        variants = [self.rows[:-1], self.rows + [self.rows[-1]],
+                    recount_inventory(self.rows[:-1] + [self.rows[3]]),
+                    self.rows[:-1] + [["UNEXPECTED", "x"], self.rows[-1]]]
+        bad_count = [row.copy() for row in self.rows]
+        next(row for row in bad_count if row[0] == "MAP")[2] = 999
+        variants.append(bad_count)
+        for rows in variants:
+            self.write(rows)
+            with self.subTest(rows=len(rows)), self.assertRaises(ValueError):
+                parse_inventory(self.audit_path)
+
+    def test_changed_original_binding_and_missing_original_probe_occupancy_fail(self):
+        for action in [PREFIX + "Copy", "ExternalG"]:
+            rows = [row.copy() for row in self.rows]
+            next(row for row in rows if row[:3] == ["ACTION", "$default", action])[3] = "[]"
+            self.write(recount_inventory(rows))
+            with self.subTest(action=action), self.assertRaisesRegex(ValueError, "inventory/schema-2"):
+                parse_inventory(self.audit_path)
+
+    def test_ownership_disagreement_with_original_probe_fails(self):
+        rows = [row.copy() for row in self.rows]
+        next(row for row in rows if row[:3] == ["ACTION", "$default", "ExternalG"])[5] = "wrong.owner"
+        self.write(rows)
+        with self.assertRaisesRegex(ValueError, "owner/list mismatch"):
+            parse_inventory(self.audit_path)
+
+    def test_duplicate_or_missing_input_and_invalid_candidate_keys_fail(self):
+        for paths, keys in [([], ["J"]), ([self.audit_path, self.audit_path], ["J"]),
+                            ([self.audit_path], []), ([self.audit_path], ["J", "J"]),
+                            ([self.audit_path], ["F25"]), ([self.audit_path], ["j"])]:
+            with self.subTest(paths=paths, keys=keys), self.assertRaises(ValueError):
+                compare_prefixes(paths, keys)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reference cards and descriptor declarations cannot establish effective shortcut inheritance or first-stroke conflicts. This PR adds a separate diagnostic plugin, isolated profile tooling and the macOS execution matrix for #132. No diagnostic code enters the product source set or ZIP, and no product bindings change. Related to #132; this preparation PR does not close the issue.

The schema-2 exporter reads the nine product actions, initialized keymap parent chains, effective keyboard/mouse lists, original G/C/H probes and owner-plugin inventory. Strict parsing and harness manifests bind evidence to source/artifact and run identity. GUI acceptance requires observed v1.6.0 baseline bindings, clean exit, screenshots/accessibility text and unchanged profile contents; frozen originals and disjoint clone paths prevent accidental baseline mutation.

An optional complete-inventory companion now supports replacement-prefix research. It preserves the original six probes and records every registered/ancestor action and effective shortcut list, including dormant mappings, empty lists and platform duplicates. The comparator verifies the original export hash, action-set completeness, counts and original probe/binding consistency before comparing A-Z, F1-F24 and eleven punctuation key codes with Ctrl/Meta+Alt+Shift. Single strokes and chords with any second key count as occupied; only the exact nine product IDs are excluded. A zero result is limited to the supplied runtime inventories and does not certify physical keyboards, OS interception or IME behavior.

An optional `--defaults-source` comparison mirrors the source-pinned product ancestor rule: exact Mac ancestors select Meta, `$default` selects Ctrl, and unresolved lineages use the recorded host OS. Every decision and source hash is retained, both-modifier results remain intact, and opposite-modifier occupancies are reported separately. Any changed product source is rejected until the mirror is reviewed again. Tests cover ancestor precedence, host fallback, changed-source rejection and retained opposite-modifier records.

Every companion action now validates registration snapshot membership in both directions, stable ownership across keymaps, a known registered owner in the original plugin inventory and matching bundled metadata. Missing actions require unknown ownership, while registered unknown descriptors fail complete-evidence acceptance. Mutation tests cover non-probe ownership and registration claims as well as the original probe cross-check.

Policy hashing and parsing now share one bounded file-descriptor snapshot (16 KiB maximum). Regular-file, no-follow, identity and size/timestamp checks reject invalid or changing sources; provenance records the opened identity without rereading or resolving the path afterward. Tests cover split-read injection, oversize input, symlinks/special files, concurrent growth and the explicit parent-alias policy.

Validation: 55 Python integrity/safety/comparison tests pass, including missing ancestor/action rows despite repaired counts, cross-export mismatches, dormant inherited chords, exact product exclusions and duplicate API shortcut handling. The separate Java harness compiles with JDK21 against minimum IC243 APIs (diagnostic deprecation warnings only). Detailed procedures and the remaining keyboard/settings/introduction/upgrade matrix are in `docs/development/shortcut-audit-runbook.md`.

Headless launch also accepts an explicitly inspected bundled Java executable when product metadata omits its path (as in Android Studio). It rejects external/symlink-escaped executables and overriding a declared path, records selection and binary hash, and resolves runtime paths before installing the harness.

An explicit GUI-only `--all-os-keymaps` option appends `-Dkeymap.current.os.only=false` to the isolated run's private VM options and records the override in launch provenance. This lets a normal native GUI initialize bundled OS families otherwise filtered on macOS. The ordinary and override captures remain separate, actual loaded keymaps must still be validated, and neither licensing nor physical OS/IME requirements are relaxed. Mocked launch-envelope tests cover both default and opt-in behavior without modifying profile config.

Manual validation: collect fresh isolated runtime exports with `--stroke-inventory`, invoke the GUI export after project/plugin initialization, quit the owned IDE, compare multiple `--export` inputs, and inspect all external first-stroke owners. Preserve older evidence with its pinned exporter revision rather than replacing its harness. Final integrated-candidate validation and replacement-prefix selection remain separate work.
