### PR TITLE
feat(shortcuts): add one-time shortcut introduction

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -123,6 +123,7 @@ The implementation uses the flat package `com.github.hon454.copyselectioncontext
 | `CopySelectionConfigurable.kt` | Tools settings UI, multiline template editor, preview, validation, and local analytics controls |
 | `CopySelectionContextAction.kt` | Settings-driven primary action |
 | `CopySelectionShortcuts.kt` | Shared nine-command G-prefix defaults and active-keymap lineage selection |
+| `CopySelectionShortcutIntroduction.kt` | Application-scoped non-roaming once-only introduction that reads the shared prefix and effective Copy binding without changing keymaps |
 | `CopySelectionGutterIconRenderer.kt` | Gutter icon and safe tooltip preview |
 | `CopySelectionHighlighter.kt` | Editor-scoped multi-range gutter marker lifecycle |
 | `CopySelectionNotifier.kt` | Settings-aware success, guarded clipboard-failure and localized permalink-failure balloons |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,6 +131,7 @@ changelog {
 }
 
 val platformStateTestClasses = listOf(
+    "com.github.hon454.copyselectioncontext.CopySelectionShortcutIntroductionFixtureTest",
     "com.github.hon454.copyselectioncontext.CopySelectionShortcutFixtureTest",
     "com.github.hon454.copyselectioncontext.ContextCollectionSourceFixtureTest",
     "com.github.hon454.copyselectioncontext.ClipboardFailureFixtureTest",

--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcutIntroduction.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcutIntroduction.kt
@@ -1,0 +1,199 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.Shortcut
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.RoamingType
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.keymap.Keymap
+import com.intellij.openapi.keymap.KeymapManager
+import com.intellij.openapi.keymap.KeymapUtil
+import com.intellij.openapi.options.SearchableConfigurable
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+@Service(Service.Level.APP)
+@State(
+    name = "CopySelectionShortcutIntroduction",
+    storages = [Storage(value = "copySelectionShortcuts.xml", roamingType = RoamingType.DISABLED)],
+)
+class CopySelectionShortcutIntroduction : PersistentStateComponent<CopySelectionShortcutIntroduction.State> {
+    data class State(var introduced: Boolean = false)
+
+    private var myState = State()
+
+    @Synchronized
+    override fun getState(): State = myState.copy()
+
+    @Synchronized
+    override fun loadState(state: State) {
+        myState = state.copy()
+    }
+
+    @Synchronized
+    internal fun claimIfFirst(): Boolean {
+        if (myState.introduced) return false
+        myState.introduced = true
+        return true
+    }
+
+    @Synchronized
+    private fun hasBeenIntroduced(): Boolean = myState.introduced
+
+    internal fun show(project: Project): Boolean = show(project, PlatformShortcutIntroductionRuntime)
+
+    internal fun show(project: Project, runtime: ShortcutIntroductionRuntime): Boolean {
+        ApplicationManager.getApplication().assertIsDispatchThread()
+        if (project.isDisposed || runtime.unitTestMode || runtime.headlessEnvironment) return false
+
+        val keymap = runtime.activeKeymap ?: return false
+        if (hasBeenIntroduced()) return false
+        val presentation = presentation(keymap)
+        val notification = runtime.createNotification(
+            CopySelectionBundle.message("shortcuts.intro.title"),
+            CopySelectionBundle.message(
+                "shortcuts.intro.content",
+                presentation.defaultPrefix,
+                presentation.currentCopy,
+            ),
+        )
+        addProjectAction(
+            notification,
+            project,
+            CopySelectionBundle.message("shortcuts.intro.action.settings"),
+            runtime::openPluginSettings,
+        )
+        addProjectAction(
+            notification,
+            project,
+            CopySelectionBundle.message("shortcuts.intro.action.keymap"),
+            runtime::openKeymapSettings,
+        )
+        addProjectAction(
+            notification,
+            project,
+            CopySelectionBundle.message("shortcuts.intro.action.dismiss"),
+        ) {}
+
+        // Notification construction can initialize services. Recheck at the visible boundary
+        // so a closing project never consumes the application-wide introduction claim.
+        if (project.isDisposed || !claimIfFirst()) return false
+        runtime.publish(notification, project)
+        return true
+    }
+
+    internal fun presentation(
+        keymap: Keymap,
+        renderShortcut: (Shortcut) -> String = { KeymapUtil.getShortcutText(it) },
+    ): ShortcutIntroductionPresentation {
+        val defaultCopy = CopySelectionShortcuts.defaultShortcuts(keymap).getValue(COPY_ACTION_ID)
+        val currentCopy = keymap.getShortcuts(COPY_ACTION_ID)
+            .joinToString(SHORTCUT_SEPARATOR, transform = renderShortcut)
+            .ifEmpty { CopySelectionBundle.message("shortcuts.intro.unassigned") }
+        return ShortcutIntroductionPresentation(
+            defaultPrefix = CopyPreview.notification(KeymapUtil.getKeystrokeText(defaultCopy.firstKeyStroke)),
+            currentCopy = CopyPreview.notification(currentCopy),
+        )
+    }
+
+    private fun addProjectAction(
+        notification: Notification,
+        project: Project,
+        text: String,
+        action: (Project) -> Unit,
+    ) {
+        notification.addAction(NotificationAction.create(text) { _, currentNotification ->
+            if (!project.isDisposed) {
+                action(project)
+                currentNotification.expire()
+            }
+        })
+    }
+
+    companion object {
+        internal const val COPY_ACTION_ID = "CopySelectionContext.Copy"
+        internal const val NOTIFICATION_GROUP_ID = "CopySelectionContext"
+        internal const val PLUGIN_SETTINGS_ID = "CopySelectionContext.Settings"
+        internal const val KEYMAP_SETTINGS_ID = "preferences.keymap"
+        private const val SHORTCUT_SEPARATOR = " / "
+
+        internal fun getInstance(): CopySelectionShortcutIntroduction =
+            ApplicationManager.getApplication().getService(CopySelectionShortcutIntroduction::class.java)
+    }
+}
+
+internal data class ShortcutIntroductionPresentation(
+    val defaultPrefix: String,
+    val currentCopy: String,
+)
+
+internal interface ShortcutIntroductionRuntime {
+    val unitTestMode: Boolean
+    val headlessEnvironment: Boolean
+    val activeKeymap: Keymap?
+
+    fun createNotification(title: String, content: String): Notification
+
+    fun publish(notification: Notification, project: Project)
+
+    fun openPluginSettings(project: Project)
+
+    fun openKeymapSettings(project: Project)
+}
+
+private object PlatformShortcutIntroductionRuntime : ShortcutIntroductionRuntime {
+    override val unitTestMode: Boolean
+        get() = ApplicationManager.getApplication().isUnitTestMode
+
+    override val headlessEnvironment: Boolean
+        get() = ApplicationManager.getApplication().isHeadlessEnvironment
+
+    override val activeKeymap: Keymap?
+        get() = KeymapManager.getInstance().activeKeymap
+
+    override fun createNotification(title: String, content: String): Notification =
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup(CopySelectionShortcutIntroduction.NOTIFICATION_GROUP_ID)
+            .createNotification(title, content, NotificationType.INFORMATION)
+
+    override fun publish(notification: Notification, project: Project) {
+        notification.notify(project)
+    }
+
+    override fun openPluginSettings(project: Project) {
+        openSettings(project, CopySelectionShortcutIntroduction.PLUGIN_SETTINGS_ID)
+    }
+
+    override fun openKeymapSettings(project: Project) {
+        openSettings(project, CopySelectionShortcutIntroduction.KEYMAP_SETTINGS_ID)
+    }
+
+    private fun openSettings(project: Project, configurableId: String) {
+        if (project.isDisposed) return
+        ShowSettingsUtil.getInstance().showSettingsDialog(
+            project,
+            { configurable -> (configurable as? SearchableConfigurable)?.id == configurableId },
+            {},
+        )
+    }
+}
+
+class CopySelectionShortcutStartupActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        val application = ApplicationManager.getApplication()
+        if (project.isDisposed || application.isUnitTestMode || application.isHeadlessEnvironment) return
+
+        application.invokeLater {
+            if (!project.isDisposed && !application.isUnitTestMode && !application.isHeadlessEnvironment) {
+                CopySelectionShortcutIntroduction.getInstance().show(project)
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -47,6 +47,8 @@ Source and issue tracker: <a href="https://github.com/hon454/copy-selection-cont
                     factoryClass="com.github.hon454.copyselectioncontext.ContextCollectionToolWindowFactory"
                     icon="/icons/copyContext.svg" canCloseContents="false"/>
 
+        <postStartupActivity implementation="com.github.hon454.copyselectioncontext.CopySelectionShortcutStartupActivity"/>
+
         <!-- Notification Group -->
         <notificationGroup id="CopySelectionContext" displayType="BALLOON"/>
         

--- a/src/main/resources/messages/CopySelectionBundle.properties
+++ b/src/main/resources/messages/CopySelectionBundle.properties
@@ -146,3 +146,11 @@ permalink.progress=Checking Git permalink target
 permalink.confirm.title=Copy a permalink to HEAD?
 permalink.confirm.message=The current editor content differs from HEAD. The link will use the captured HEAD commit and your current line numbers; those lines may contain different code in HEAD. Line numbers will not be mapped automatically. Copy this permalink?
 permalink.confirm.copy=Copy Permalink
+
+# One-time shortcut introduction
+shortcuts.intro.title=Copy Selection Context shortcuts
+shortcuts.intro.content=Plugin defaults use a shared two-stroke prefix: <b>{0}</b>. Press and release the full prefix, then press the second key without modifiers. Your current Copy Selection Context shortcut in the active keymap is <b>{1}</b>. Custom assignments and unassigned choices are preserved. View all nine shortcuts or restore plugin defaults in Settings. This introduction appears once on this installation.
+shortcuts.intro.unassigned=Unassigned
+shortcuts.intro.action.settings=View all shortcuts
+shortcuts.intro.action.keymap=Open Keymap settings
+shortcuts.intro.action.dismiss=Dismiss

--- a/src/main/resources/messages/CopySelectionBundle_ja.properties
+++ b/src/main/resources/messages/CopySelectionBundle_ja.properties
@@ -146,3 +146,11 @@ permalink.progress=Git固定リンクの対象を確認中
 permalink.confirm.title=HEADへの固定リンクをコピーしますか？
 permalink.confirm.message=現在のエディター内容はHEADと異なります。リンクには取得したHEADコミットと現在の行番号を使用するため、HEADの該当行には別のコードがある可能性があります。行番号の自動対応付けは行いません。この固定リンクをコピーしますか？
 permalink.confirm.copy=固定リンクをコピー
+
+# 初回のショートカット案内
+shortcuts.intro.title=Copy Selection Contextのショートカット
+shortcuts.intro.content=プラグインのデフォルトショートカットは、共通の2ストロークプレフィックス <b>{0}</b> を使用します。プレフィックスのキーをすべて離してから、修飾キーなしで2番目のキーを押してください。現在のキーマップでのCopy Selection Contextのショートカットは <b>{1}</b> です。カスタム割り当てと未割り当ての選択はそのまま維持されます。設定で9個すべてのショートカットを確認するか、プラグインのデフォルトに復元できます。この案内はこのインストールで一度だけ表示されます。
+shortcuts.intro.unassigned=未割り当て
+shortcuts.intro.action.settings=すべてのショートカットを表示
+shortcuts.intro.action.keymap=Keymap設定を開く
+shortcuts.intro.action.dismiss=閉じる

--- a/src/main/resources/messages/CopySelectionBundle_ko.properties
+++ b/src/main/resources/messages/CopySelectionBundle_ko.properties
@@ -146,3 +146,11 @@ permalink.progress=Git permalink 대상 확인 중
 permalink.confirm.title=HEAD 기준 permalink를 복사할까요?
 permalink.confirm.message=현재 편집기 내용이 HEAD와 다릅니다. 링크에는 캡처한 HEAD commit과 현재 행 번호를 사용하므로 HEAD의 해당 행에는 다른 코드가 있을 수 있습니다. 행 번호를 자동으로 맞추지는 않습니다. 이 permalink를 복사할까요?
 permalink.confirm.copy=Permalink 복사
+
+# 최초 단축키 안내
+shortcuts.intro.title=Copy Selection Context 단축키 안내
+shortcuts.intro.content=플러그인 기본 단축키는 공통 2단계 접두 조합 <b>{0}</b>을 사용합니다. 접두 조합의 키를 모두 놓은 뒤 보조 키 없이 두 번째 키를 누르세요. 현재 활성 키맵의 Copy Selection Context 단축키는 <b>{1}</b>입니다. 사용자 지정 배정과 미지정 선택은 그대로 유지됩니다. 설정에서 9개 단축키를 모두 보거나 플러그인 기본값으로 복원할 수 있습니다. 이 안내는 이 설치에서 한 번만 표시됩니다.
+shortcuts.intro.unassigned=미지정
+shortcuts.intro.action.settings=전체 단축키 보기
+shortcuts.intro.action.keymap=Keymap 설정 열기
+shortcuts.intro.action.dismiss=닫기

--- a/src/main/resources/messages/CopySelectionBundle_zh_CN.properties
+++ b/src/main/resources/messages/CopySelectionBundle_zh_CN.properties
@@ -146,3 +146,11 @@ permalink.progress=正在检查 Git 永久链接目标
 permalink.confirm.title=复制指向 HEAD 的永久链接？
 permalink.confirm.message=当前编辑器内容与 HEAD 不同。链接将使用捕获的 HEAD 提交和当前行号，因此 HEAD 中这些行的代码可能不同。不会自动映射行号。是否复制此永久链接？
 permalink.confirm.copy=复制永久链接
+
+# 首次快捷键介绍
+shortcuts.intro.title=Copy Selection Context 快捷键
+shortcuts.intro.content=插件默认快捷键使用共享的两段式前缀：<b>{0}</b>。按下并松开整个前缀组合，然后在不按修饰键的情况下按第二个键。当前活动键位映射中的 Copy Selection Context 快捷键为 <b>{1}</b>。自定义分配和未分配选择都会保留。可在设置中查看全部 9 个快捷键或恢复插件默认值。本介绍在此次安装中只显示一次。
+shortcuts.intro.unassigned=未分配
+shortcuts.intro.action.settings=查看全部快捷键
+shortcuts.intro.action.keymap=打开 Keymap 设置
+shortcuts.intro.action.dismiss=关闭

--- a/src/main/resources/messages/CopySelectionBundle_zh_TW.properties
+++ b/src/main/resources/messages/CopySelectionBundle_zh_TW.properties
@@ -146,3 +146,11 @@ permalink.progress=正在檢查 Git 永久連結目標
 permalink.confirm.title=複製指向 HEAD 的永久連結？
 permalink.confirm.message=目前編輯器內容與 HEAD 不同。連結將使用擷取的 HEAD 提交和目前行號，因此 HEAD 中這些行的程式碼可能不同。不會自動對應行號。是否複製此永久連結？
 permalink.confirm.copy=複製永久連結
+
+# 首次快速鍵介紹
+shortcuts.intro.title=Copy Selection Context 快速鍵
+shortcuts.intro.content=外掛預設快速鍵使用共用的兩段式前綴：<b>{0}</b>。按下並放開完整的前綴組合，接著在不按修飾鍵的情況下按第二個鍵。目前作用中鍵位配置的 Copy Selection Context 快速鍵是 <b>{1}</b>。自訂指派與未指派選擇都會保留。可在設定中查看全部 9 個快速鍵或還原外掛預設值。此介紹在這次安裝中只會顯示一次。
+shortcuts.intro.unassigned=未指派
+shortcuts.intro.action.settings=查看全部快速鍵
+shortcuts.intro.action.keymap=開啟 Keymap 設定
+shortcuts.intro.action.dismiss=關閉

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBundleTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionBundleTest.kt
@@ -250,6 +250,38 @@ class CopySelectionBundleTest {
         assertTrue(base.getProperty("review.prompt.content").contains("honest", ignoreCase = true))
     }
 
+    @Test
+    fun `shortcut introduction is localized and preserves dynamic prefix and assignment`() {
+        val keys = setOf(
+            "shortcuts.intro.title",
+            "shortcuts.intro.content",
+            "shortcuts.intro.unassigned",
+            "shortcuts.intro.action.settings",
+            "shortcuts.intro.action.keymap",
+            "shortcuts.intro.action.dismiss",
+        )
+
+        ALL_BUNDLES.forEach { (localeName, resourcePath) ->
+            val bundle = loadBundle(resourcePath)
+            keys.forEach { key ->
+                assertTrue(bundle.getProperty(key).isNotBlank(), "$localeName message '$key' should be non-blank")
+            }
+            val content = bundle.getProperty("shortcuts.intro.content")
+            assertEquals(setOf(0, 1), messageArgumentIndexes(content), localeName)
+            val formatted = MessageFormat.format(content, "PREFIX_VALUE", "CURRENT_VALUE")
+            assertTrue(formatted.contains("PREFIX_VALUE"), localeName)
+            assertTrue(formatted.contains("CURRENT_VALUE"), localeName)
+        }
+
+        val english = loadBundle("messages/CopySelectionBundle.properties")
+            .getProperty("shortcuts.intro.content")
+        assertTrue(english.contains("defaults", ignoreCase = true))
+        assertTrue(english.contains("current", ignoreCase = true))
+        assertTrue(english.contains("once", ignoreCase = true))
+        assertTrue(!english.contains("changed", ignoreCase = true))
+        assertTrue(!english.contains("updated", ignoreCase = true))
+    }
+
     private fun loadBundleKeys(resourcePath: String): Set<String> {
         return loadBundle(resourcePath).stringPropertyNames()
     }

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcutIntroductionFixtureTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcutIntroductionFixtureTest.kt
@@ -1,0 +1,231 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.KeyboardShortcut
+import com.intellij.openapi.actionSystem.Shortcut
+import com.intellij.openapi.keymap.Keymap
+import com.intellij.openapi.keymap.KeymapManager
+import com.intellij.openapi.keymap.ex.KeymapManagerEx
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.swing.KeyStroke
+
+class CopySelectionShortcutIntroductionFixtureTest : BasePlatformTestCase() {
+    private lateinit var introduction: CopySelectionShortcutIntroduction
+    private lateinit var originalIntroductionState: CopySelectionShortcutIntroduction.State
+
+    override fun setUp() {
+        super.setUp()
+        introduction = CopySelectionShortcutIntroduction.getInstance()
+        originalIntroductionState = introduction.state
+        introduction.loadState(CopySelectionShortcutIntroduction.State())
+    }
+
+    override fun tearDown() {
+        try {
+            introduction.loadState(originalIntroductionState)
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testProductionEntryDoesNotClaimOrNotifyInTestEnvironment() {
+        assertFalse(introduction.show(project))
+        assertFalse(introduction.state.introduced)
+    }
+
+    fun testIneligibleRuntimeAndDisposedProjectNeverConsumeTheClaim() {
+        val activeKeymap = KeymapManager.getInstance().activeKeymap
+        val cases = listOf(
+            liveProject() to RecordingRuntime(activeKeymap, unitTestMode = true),
+            liveProject() to RecordingRuntime(activeKeymap, headlessEnvironment = true),
+            liveProject() to RecordingRuntime(activeKeymap = null),
+            disposedProject() to RecordingRuntime(activeKeymap),
+        )
+
+        cases.forEach { (owner, runtime) ->
+            val service = CopySelectionShortcutIntroduction()
+            assertFalse(service.show(owner, runtime))
+            assertFalse(service.state.introduced)
+            assertEmpty(runtime.notifications)
+            assertEmpty(runtime.publishedProjects)
+        }
+    }
+
+    fun testApplicationClaimPublishesOnceAcrossProjectsAndIgnoresCopyNotificationPreference() {
+        val settings = CopySelectionSettings.getInstance()
+        val originalSettings = settings.state.copy()
+        val runtime = RecordingRuntime(KeymapManager.getInstance().activeKeymap)
+        val secondProject = liveProject()
+        try {
+            settings.loadState(originalSettings.copy(enableNotification = false))
+
+            assertTrue(introduction.show(project, runtime))
+            assertFalse(introduction.show(secondProject, runtime))
+
+            assertTrue(introduction.state.introduced)
+            assertEquals(listOf(project), runtime.publishedProjects)
+            assertEquals(1, runtime.notifications.size)
+            assertEquals(NotificationType.INFORMATION, runtime.notifications.single().type)
+            assertEquals(
+                CopySelectionShortcutIntroduction.NOTIFICATION_GROUP_ID,
+                runtime.notifications.single().groupId,
+            )
+            assertFalse(settings.state.enableNotification)
+        } finally {
+            settings.loadState(originalSettings)
+        }
+    }
+
+    fun testProjectDisposedDuringNotificationConstructionDoesNotConsumeTheClaim() {
+        val disposed = AtomicBoolean(false)
+        val owner = project(disposed)
+        val runtime = RecordingRuntime(KeymapManager.getInstance().activeKeymap).apply {
+            afterCreate = { disposed.set(true) }
+        }
+
+        assertFalse(introduction.show(owner, runtime))
+
+        assertFalse(introduction.state.introduced)
+        assertEquals(1, runtime.notifications.size)
+        assertEmpty(runtime.publishedProjects)
+    }
+
+    fun testAllNotificationActionsRecheckProjectLifetimeAndExpireOnlyWhileLive() {
+        val settings = fireAction(actionIndex = 0, disposeBeforeAction = false)
+        assertEquals(1, settings.runtime.pluginSettingsOpenCount)
+        assertEquals(0, settings.runtime.keymapSettingsOpenCount)
+        assertTrue(settings.notification.isExpired)
+
+        val keymap = fireAction(actionIndex = 1, disposeBeforeAction = false)
+        assertEquals(0, keymap.runtime.pluginSettingsOpenCount)
+        assertEquals(1, keymap.runtime.keymapSettingsOpenCount)
+        assertTrue(keymap.notification.isExpired)
+
+        val dismiss = fireAction(actionIndex = 2, disposeBeforeAction = false)
+        assertEquals(0, dismiss.runtime.pluginSettingsOpenCount)
+        assertEquals(0, dismiss.runtime.keymapSettingsOpenCount)
+        assertTrue(dismiss.notification.isExpired)
+
+        (0..2).forEach { actionIndex ->
+            val disposed = fireAction(actionIndex, disposeBeforeAction = true)
+            assertEquals(0, disposed.runtime.pluginSettingsOpenCount)
+            assertEquals(0, disposed.runtime.keymapSettingsOpenCount)
+            assertFalse(disposed.notification.isExpired)
+        }
+    }
+
+    fun testActiveCustomAndUnassignedCopyPresentationNeverMutatesTheKeymap() {
+        val manager = KeymapManagerEx.getInstanceEx()
+        val originalKeymap = manager.activeKeymap
+        val customKeymap = originalKeymap.deriveKeymap("Shortcut introduction fixture ${System.nanoTime()}")
+        manager.schemeManager.addScheme(customKeymap)
+        manager.setActiveKeymap(customKeymap)
+        try {
+            val custom = KeyboardShortcut(KeyStroke.getKeyStroke("control K"), null)
+            customKeymap.removeAllActionShortcuts(CopySelectionShortcutIntroduction.COPY_ACTION_ID)
+            customKeymap.addShortcut(CopySelectionShortcutIntroduction.COPY_ACTION_ID, custom)
+            val customSnapshot = shortcutSnapshot(customKeymap)
+            val customService = CopySelectionShortcutIntroduction()
+            val customRuntime = RecordingRuntime(manager.activeKeymap)
+            val customPresentation = customService.presentation(customKeymap)
+
+            assertTrue(customService.show(project, customRuntime))
+            assertTrue(customRuntime.notifications.single().content.contains(customPresentation.defaultPrefix))
+            assertTrue(customRuntime.notifications.single().content.contains(customPresentation.currentCopy))
+            assertEquals(customSnapshot, shortcutSnapshot(customKeymap))
+            assertSame(customKeymap, manager.activeKeymap)
+
+            customKeymap.removeAllActionShortcuts(CopySelectionShortcutIntroduction.COPY_ACTION_ID)
+            val unassignedSnapshot = shortcutSnapshot(customKeymap)
+            val unassignedService = CopySelectionShortcutIntroduction()
+            val unassignedRuntime = RecordingRuntime(manager.activeKeymap)
+            val unassignedPresentation = unassignedService.presentation(customKeymap)
+
+            assertTrue(unassignedService.show(project, unassignedRuntime))
+            assertEquals(
+                CopyPreview.notification(CopySelectionBundle.message("shortcuts.intro.unassigned")),
+                unassignedPresentation.currentCopy,
+            )
+            assertTrue(unassignedRuntime.notifications.single().content.contains(unassignedPresentation.currentCopy))
+            assertEquals(unassignedSnapshot, shortcutSnapshot(customKeymap))
+            assertSame(customKeymap, manager.activeKeymap)
+        } finally {
+            manager.setActiveKeymap(originalKeymap)
+            manager.schemeManager.removeScheme(customKeymap)
+        }
+        assertSame(originalKeymap, manager.activeKeymap)
+    }
+
+    private fun fireAction(actionIndex: Int, disposeBeforeAction: Boolean): ActionResult {
+        val disposed = AtomicBoolean(false)
+        val owner = project(disposed)
+        val runtime = RecordingRuntime(KeymapManager.getInstance().activeKeymap)
+        val service = CopySelectionShortcutIntroduction()
+        assertTrue(service.show(owner, runtime))
+        val notification = runtime.notifications.single()
+        disposed.set(disposeBeforeAction)
+
+        val action = notification.actions[actionIndex] as NotificationAction
+        action.actionPerformed(mockk<AnActionEvent>(relaxed = true), notification)
+
+        return ActionResult(runtime, notification)
+    }
+
+    private fun shortcutSnapshot(keymap: Keymap): Map<String, List<Shortcut>> =
+        CopySelectionShortcuts.commands.keys.associateWith { actionId -> keymap.getShortcuts(actionId).toList() }
+
+    private fun liveProject(): Project = project(AtomicBoolean(false))
+
+    private fun disposedProject(): Project = project(AtomicBoolean(true))
+
+    private fun project(disposed: AtomicBoolean): Project = mockk<Project>().also { project ->
+        every { project.isDisposed } answers { disposed.get() }
+    }
+
+    private data class ActionResult(
+        val runtime: RecordingRuntime,
+        val notification: Notification,
+    )
+
+    private class RecordingRuntime(
+        override val activeKeymap: Keymap?,
+        override val unitTestMode: Boolean = false,
+        override val headlessEnvironment: Boolean = false,
+    ) : ShortcutIntroductionRuntime {
+        val notifications = mutableListOf<Notification>()
+        val publishedProjects = mutableListOf<Project>()
+        var pluginSettingsOpenCount = 0
+        var keymapSettingsOpenCount = 0
+        var afterCreate: (() -> Unit)? = null
+
+        override fun createNotification(title: String, content: String): Notification =
+            Notification(
+                CopySelectionShortcutIntroduction.NOTIFICATION_GROUP_ID,
+                title,
+                content,
+                NotificationType.INFORMATION,
+            ).also { notification ->
+                notifications += notification
+                afterCreate?.invoke()
+            }
+
+        override fun publish(notification: Notification, project: Project) {
+            publishedProjects += project
+        }
+
+        override fun openPluginSettings(project: Project) {
+            pluginSettingsOpenCount++
+        }
+
+        override fun openKeymapSettings(project: Project) {
+            keymapSettingsOpenCount++
+        }
+    }
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcutIntroductionTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcutIntroductionTest.kt
@@ -1,0 +1,146 @@
+package com.github.hon454.copyselectioncontext
+
+import com.intellij.openapi.actionSystem.KeyboardShortcut
+import com.intellij.openapi.actionSystem.Shortcut
+import com.intellij.openapi.components.RoamingType
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.keymap.Keymap
+import com.intellij.openapi.keymap.KeymapManager
+import com.intellij.openapi.keymap.KeymapUtil
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import javax.swing.KeyStroke
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CopySelectionShortcutIntroductionTest {
+    @Test
+    fun `first claim wins once and persisted restart remains introduced`() {
+        val firstSession = CopySelectionShortcutIntroduction()
+
+        assertTrue(firstSession.claimIfFirst())
+        assertFalse(firstSession.claimIfFirst())
+
+        val restarted = CopySelectionShortcutIntroduction().apply { loadState(firstSession.state) }
+        assertFalse(restarted.claimIfFirst())
+        assertTrue(restarted.state.introduced)
+    }
+
+    @Test
+    fun `getState and loadState do not retain mutable aliases`() {
+        val service = CopySelectionShortcutIntroduction()
+        val loaded = CopySelectionShortcutIntroduction.State(introduced = true)
+
+        service.loadState(loaded)
+        loaded.introduced = false
+        val returned = service.state
+        returned.introduced = false
+
+        assertTrue(service.state.introduced)
+    }
+
+    @Test
+    fun `concurrent callers produce exactly one claim winner`() {
+        val service = CopySelectionShortcutIntroduction()
+        val start = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(8)
+        try {
+            val results = (1..64).map {
+                executor.submit<Boolean> {
+                    start.await()
+                    service.claimIfFirst()
+                }
+            }
+
+            start.countDown()
+
+            assertEquals(1, results.count { it.get(5, TimeUnit.SECONDS) })
+            assertTrue(service.state.introduced)
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `state is application scoped local and contains only the introduction flag`() {
+        val service = requireNotNull(CopySelectionShortcutIntroduction::class.java.getAnnotation(Service::class.java))
+        val state = requireNotNull(CopySelectionShortcutIntroduction::class.java.getAnnotation(State::class.java))
+
+        assertEquals(listOf(Service.Level.APP), service.value.toList())
+        assertEquals("CopySelectionShortcutIntroduction", state.name)
+        assertEquals(1, state.storages.size)
+        assertEquals("copySelectionShortcuts.xml", state.storages.single().value)
+        assertEquals(RoamingType.DISABLED, state.storages.single().roamingType)
+        assertEquals(
+            setOf("introduced"),
+            CopySelectionShortcutIntroduction.State::class.java.declaredFields
+                .map { it.name }
+                .filterNot { it.startsWith("\$") }
+                .toSet(),
+        )
+    }
+
+    @Test
+    fun `presentation uses the shared prefix and actual active copy assignment`() {
+        val custom = KeyboardShortcut(KeyStroke.getKeyStroke("control K"), null)
+        val keymap = keymap(arrayOf(custom))
+
+        val presentation = CopySelectionShortcutIntroduction().presentation(keymap)
+        val sharedDefault = CopySelectionShortcuts.defaultShortcuts(keymap)
+            .getValue(CopySelectionShortcutIntroduction.COPY_ACTION_ID)
+
+        assertEquals(
+            CopyPreview.notification(KeymapUtil.getKeystrokeText(sharedDefault.firstKeyStroke)),
+            presentation.defaultPrefix,
+        )
+        assertEquals(CopyPreview.notification(KeymapUtil.getShortcutText(custom)), presentation.currentCopy)
+        assertNotEquals(CopyPreview.notification(KeymapUtil.getShortcutText(sharedDefault)), presentation.currentCopy)
+    }
+
+    @Test
+    fun `unassigned copy remains explicitly unassigned instead of falling back to defaults`() {
+        val keymap = keymap(emptyArray())
+
+        val presentation = CopySelectionShortcutIntroduction().presentation(keymap)
+
+        assertEquals(
+            CopyPreview.notification(CopySelectionBundle.message("shortcuts.intro.unassigned")),
+            presentation.currentCopy,
+        )
+    }
+
+    @Test
+    fun `long hostile shortcut text is bounded flattened and markup escaped`() {
+        val shortcut = KeyboardShortcut(KeyStroke.getKeyStroke("control K"), null)
+        val keymap = keymap(Array<Shortcut>(12) { shortcut })
+        val hostile = "<shortcut>&\"'\n" + "x".repeat(240) + "\uD83E\uDDEA"
+
+        val presentation = CopySelectionShortcutIntroduction().presentation(keymap) { hostile }
+
+        assertTrue(presentation.currentCopy.length <= CopyPreview.NOTIFICATION_MAX_LENGTH)
+        assertTrue(presentation.currentCopy.contains("&lt;shortcut&gt;"))
+        assertTrue(presentation.currentCopy.contains("&amp;"))
+        assertFalse(presentation.currentCopy.contains("<shortcut>"))
+        assertFalse(presentation.currentCopy.any { it == '\n' || it == '\r' })
+        assertTrue(presentation.currentCopy.endsWith("…"))
+    }
+
+    @Test
+    fun `settings destinations use exact configurable ids`() {
+        assertEquals("CopySelectionContext.Settings", CopySelectionShortcutIntroduction.PLUGIN_SETTINGS_ID)
+        assertEquals("preferences.keymap", CopySelectionShortcutIntroduction.KEYMAP_SETTINGS_ID)
+    }
+
+    private fun keymap(shortcuts: Array<Shortcut>): Keymap = mockk<Keymap>().also { keymap ->
+        every { keymap.name } returns KeymapManager.DEFAULT_IDEA_KEYMAP
+        every { keymap.parent } returns null
+        every { keymap.getShortcuts(CopySelectionShortcutIntroduction.COPY_ACTION_ID) } returns shortcuts
+    }
+}

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/PluginDescriptorLocalizationTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/PluginDescriptorLocalizationTest.kt
@@ -95,6 +95,25 @@ class PluginDescriptorLocalizationTest {
     }
 
     @Test
+    fun `shortcut introduction is registered as one project startup activity`() {
+        val activities = descriptor.getElementsByTagName("postStartupActivity")
+        val matching = (0 until activities.length)
+            .map { activities.item(it) as org.w3c.dom.Element }
+            .filter {
+                it.getAttribute("implementation") ==
+                    "com.github.hon454.copyselectioncontext.CopySelectionShortcutStartupActivity"
+            }
+
+        assertEquals(1, matching.size)
+
+        val groups = descriptor.getElementsByTagName("notificationGroup")
+        val introductionGroup = (0 until groups.length)
+            .map { groups.item(it) as org.w3c.dom.Element }
+            .single { it.getAttribute("id") == CopySelectionShortcutIntroduction.NOTIFICATION_GROUP_ID }
+        assertEquals("BALLOON", introductionGroup.getAttribute("displayType"))
+    }
+
+    @Test
     fun `descriptor and shared command table declare the same g prefix defaults`() {
         val actions = descriptor.getElementsByTagName("action")
         val registered = (0 until actions.length)


### PR DESCRIPTION
New and existing installations receive a one-time introduction to the shared two-stroke shortcuts without changing their active keymap. The notification shows the current effective Copy assignment, including custom or unassigned shortcuts, and opens the plugin settings or IDE Keymap settings.

An application-level service stores a defensive, atomic delivery claim in non-roaming `copySelectionShortcuts.xml`. Startup checks the EDT, project lifetime, application mode and active keymap before claiming delivery; notification actions recheck project lifetime. The normal notification group remains in control of visibility. Six introduction strings are provided in all five locales.

Related to #130.

## Validation

- Base: `1909df4ec318fda5ebab33400ceca1e912fb7549`; HEAD: `0e1c10ef3608a8ba9689d526cc5e5c843b3f0196`.
- macOS arm64, JDK 21, Gradle 9.7.1; isolated worktree sandbox, `--no-daemon --max-workers=2`.
- Targeted introduction/bundle/descriptor unit tests: 31 passed; introduction platform fixture: 6 passed.
- `allTests`: 450 unit and 101 platform tests passed, with no failures, errors or skips. The introduction fixture runs only in `platformTest`.
- `detekt verifyPluginProjectConfiguration verifyPluginStructure buildPlugin koverXmlReport koverHtmlReport`: passed. Detekt reported no findings.
- Test ZIP SHA-256: `0353ab4dc06fa3061b7b558eef6650e978711ca7a2c85436c6c80ae6b4907730`.
- Descriptor XML, bundle key parity and `git diff --check`: passed.

## Remaining integration and manual validation

This draft consumes the shared default API and does not hardcode a replacement prefix. Rebase, final automated checks, the three IDE Plugin Verifier targets and independent final review follow the replacement #128 defaults and #129 settings integration on main. The current tests do not certify the new candidate prefix.

On the final integrated ZIP, #132 will check first startup, another project, restart and dismissal; default/custom/unassigned presentation; Settings and Keymap navigation; notification preference and group suppression; and unchanged user keymaps in real macOS IDE sessions. These GUI checks have not been run for this PR. Windows/Linux GUI checks are user-excluded; three-OS automated CI remains required.

No version bump, release tag, deployment, Marketplace publication or account/credential change is included.
