### PR TITLE
fix(shortcuts): move shared defaults to the z prefix

### DIFF
--- a/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcuts.kt
+++ b/src/main/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcuts.kt
@@ -64,6 +64,6 @@ internal object CopySelectionShortcuts {
         return macHost
     }
 
-    private const val DEFAULT_PREFIX = "control alt shift G"
-    private const val MAC_PREFIX = "meta alt shift G"
+    private const val DEFAULT_PREFIX = "control alt shift Z"
+    private const val MAC_PREFIX = "meta alt shift Z"
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -79,123 +79,123 @@ Source and issue tracker: <a href="https://github.com/hon454/copy-selection-cont
             <action id="CopySelectionContext.Copy"
                     class="com.github.hon454.copyselectioncontext.CopySelectionContextAction"
                     icon="/icons/copyContext.svg">
-                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="C"/>
-                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
-                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
-                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
-                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
-                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
-                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift Z" second-keystroke="C"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift Z" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift Z" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift Z" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift Z" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift Z" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift Z" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift Z" second-keystroke="C" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift Z" second-keystroke="C" replace-all="true"/>
             </action>
 
             <separator/>
 
             <action id="CopySelectionContext.ShowHistory"
                     class="com.github.hon454.copyselectioncontext.ShowCopyHistoryAction">
-                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="H"/>
-                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
-                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
-                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
-                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
-                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
-                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift Z" second-keystroke="H"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift Z" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift Z" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift Z" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift Z" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift Z" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift Z" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift Z" second-keystroke="H" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift Z" second-keystroke="H" replace-all="true"/>
             </action>
 
             <action id="CopySelectionContext.ShowCollection"
                     class="com.github.hon454.copyselectioncontext.ShowContextCollectionAction">
-                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="O"/>
-                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
-                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
-                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
-                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
-                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
-                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift Z" second-keystroke="O"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift Z" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift Z" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift Z" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift Z" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift Z" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift Z" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift Z" second-keystroke="O" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift Z" second-keystroke="O" replace-all="true"/>
             </action>
             <action id="CopySelectionContext.CopyAllCollection"
                     class="com.github.hon454.copyselectioncontext.CopyAllContextCollectionAction">
-                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="F"/>
-                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
-                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
-                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
-                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
-                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
-                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift Z" second-keystroke="F"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift Z" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift Z" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift Z" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift Z" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift Z" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift Z" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift Z" second-keystroke="F" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift Z" second-keystroke="F" replace-all="true"/>
             </action>
             <action id="CopySelectionContext.AddToCollection"
                     class="com.github.hon454.copyselectioncontext.AddToContextCollectionAction">
-                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="A"/>
-                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
-                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
-                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
-                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
-                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
-                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift Z" second-keystroke="A"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift Z" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift Z" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift Z" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift Z" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift Z" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift Z" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift Z" second-keystroke="A" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift Z" second-keystroke="A" replace-all="true"/>
             </action>
 
             <!-- Explicit copy actions -->
             <action id="CopySelectionContext.CopyRelativePath"
                     class="com.github.hon454.copyselectioncontext.CopyRelativePathAction"
                     icon="/icons/copyRelative.svg">
-                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="R"/>
-                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
-                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
-                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
-                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
-                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
-                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift Z" second-keystroke="R"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift Z" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift Z" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift Z" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift Z" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift Z" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift Z" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift Z" second-keystroke="R" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift Z" second-keystroke="R" replace-all="true"/>
             </action>
 
             <action id="CopySelectionContext.CopyAbsolutePath"
                     class="com.github.hon454.copyselectioncontext.CopyAbsolutePathAction"
                     icon="/icons/copyAbsolute.svg">
-                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="P"/>
-                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
-                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
-                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
-                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
-                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
-                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift Z" second-keystroke="P"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift Z" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift Z" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift Z" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift Z" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift Z" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift Z" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift Z" second-keystroke="P" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift Z" second-keystroke="P" replace-all="true"/>
             </action>
 
             <action id="CopySelectionContext.CopyWithCodeContent"
                     class="com.github.hon454.copyselectioncontext.CopyWithCodeContentAction"
                     icon="/icons/copyWithCode.svg">
-                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="B"/>
-                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
-                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
-                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
-                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
-                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
-                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift Z" second-keystroke="B"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift Z" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift Z" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift Z" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift Z" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift Z" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift Z" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift Z" second-keystroke="B" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift Z" second-keystroke="B" replace-all="true"/>
             </action>
 
             <action id="CopySelectionContext.CopyGitPermalink"
                     class="com.github.hon454.copyselectioncontext.CopyGitPermalinkAction">
-                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift G" second-keystroke="L"/>
-                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
-                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
-                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
-                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
-                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
-                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
-                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift G" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="$default" first-keystroke="control alt shift Z" second-keystroke="L"/>
+                <keyboard-shortcut keymap="Mac OS X" first-keystroke="meta alt shift Z" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift Z" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="macOS System Shortcuts" first-keystroke="meta alt shift Z" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Studio OSX" first-keystroke="meta alt shift Z" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="ReSharper OSX" first-keystroke="meta alt shift Z" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="VSCode OSX" first-keystroke="meta alt shift Z" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="Visual Assist OSX" first-keystroke="meta alt shift Z" second-keystroke="L" replace-all="true"/>
+                <keyboard-shortcut keymap="Sublime Text (Mac OS X)" first-keystroke="meta alt shift Z" second-keystroke="L" replace-all="true"/>
             </action>
 
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcutFixtureTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/CopySelectionShortcutFixtureTest.kt
@@ -154,6 +154,51 @@ class CopySelectionShortcutFixtureTest : BasePlatformTestCase() {
         assertEquals(listOf(unrelatedKeyboard), after.getShortcuts(UNRELATED_ACTION).toList())
     }
 
+    fun testPersistedGPrefixDistinguishesInheritedAndExplicitAssignments() {
+        val oldDefaults = CopySelectionShortcuts.commands.mapValues { (_, secondKey) ->
+            twoStroke("control alt shift G", secondKey)
+        }
+        val oldParent = keymap(G_PREFIX_PARENT_NAME).apply {
+            oldDefaults.forEach { (actionId, shortcut) -> addShortcut(actionId, shortcut) }
+            canModify = false
+        }
+        val unrelatedKeyboard = keyboard("control Q")
+        val staged = oldParent.deriveKeymap("Persisted G-prefix user keymap").apply {
+            addShortcut(UNRELATED_ACTION, unrelatedKeyboard)
+        }
+        val persisted = staged.writeScheme().apply {
+            replaceAction(COPY, oldDefaults.getValue(COPY))
+        }
+
+        val before = loadPersisted(persisted, oldParent)
+        val beforeCommands = shortcutSnapshot(before, CopySelectionShortcuts.commands.keys)
+        assertEquals(oldDefaults.mapValues { (_, shortcut) -> listOf(shortcut) }, beforeCommands)
+
+        val newDefaults = CopySelectionShortcuts.defaultShortcuts(mac = false)
+        val newParent = keymap(G_PREFIX_PARENT_NAME).apply {
+            newDefaults.forEach { (actionId, shortcut) ->
+                addShortcut(actionId, shortcut)
+            }
+            canModify = false
+        }
+        val after = loadPersisted(persisted, newParent)
+        val expectedAfter = CopySelectionShortcuts.commands.keys.associateWith { actionId ->
+            listOf(
+                if (actionId == COPY) {
+                    oldDefaults.getValue(actionId)
+                } else {
+                    newDefaults.getValue(actionId)
+                },
+            )
+        }
+
+        assertEquals(expectedAfter, shortcutSnapshot(after, CopySelectionShortcuts.commands.keys))
+        assertEquals(listOf(unrelatedKeyboard), after.getShortcuts(UNRELATED_ACTION).toList())
+        CopySelectionShortcuts.commands.keys.filterNot { it == COPY }.forEach { actionId ->
+            assertFalse(after.getShortcuts(actionId).contains(oldDefaults.getValue(actionId)))
+        }
+    }
+
     private fun loadPersisted(element: Element, parent: Keymap): Keymap = PersistedKeymap(parent, element)
 
     private fun shortcutSnapshot(keymap: Keymap, actionIds: Collection<String>): Map<String, List<Shortcut>> =
@@ -163,10 +208,10 @@ class CopySelectionShortcutFixtureTest : BasePlatformTestCase() {
         getChildren("action").firstOrNull { it.getAttributeValue("id") == actionId }?.let(::removeContent)
         addContent(Element("action").setAttribute("id", actionId).apply {
             shortcuts.forEach { shortcut ->
-                addContent(
-                    Element("keyboard-shortcut")
-                        .setAttribute("first-keystroke", shortcut.firstKeyStroke.toString()),
-                )
+                addContent(Element("keyboard-shortcut").apply {
+                    setAttribute("first-keystroke", shortcut.firstKeyStroke.toString())
+                    shortcut.secondKeyStroke?.let { setAttribute("second-keystroke", it.toString()) }
+                })
             }
         })
     }
@@ -191,8 +236,14 @@ class CopySelectionShortcutFixtureTest : BasePlatformTestCase() {
 
     private fun keyboard(stroke: String) = KeyboardShortcut(KeyStroke.getKeyStroke(stroke), null)
 
+    private fun twoStroke(first: String, second: String) = KeyboardShortcut(
+        KeyStroke.getKeyStroke(first),
+        KeyStroke.getKeyStroke(second),
+    )
+
     companion object {
         private const val PARENT_NAME = "Synthetic plugin defaults"
+        private const val G_PREFIX_PARENT_NAME = "Synthetic G-prefix plugin defaults"
         private const val COPY = "CopySelectionContext.Copy"
         private const val HISTORY = "CopySelectionContext.ShowHistory"
         private const val ADD_TO_COLLECTION = "CopySelectionContext.AddToCollection"

--- a/src/test/kotlin/com/github/hon454/copyselectioncontext/PluginDescriptorLocalizationTest.kt
+++ b/src/test/kotlin/com/github/hon454/copyselectioncontext/PluginDescriptorLocalizationTest.kt
@@ -95,7 +95,7 @@ class PluginDescriptorLocalizationTest {
     }
 
     @Test
-    fun `descriptor and shared command table declare the same g prefix defaults`() {
+    fun `descriptor and shared command table declare the same two step defaults`() {
         val actions = descriptor.getElementsByTagName("action")
         val registered = (0 until actions.length)
             .map { actions.item(it) as org.w3c.dom.Element }
@@ -111,13 +111,13 @@ class PluginDescriptorLocalizationTest {
             assertEquals(CopySelectionShortcuts.macKeymapIds + "\$default", declared.keys, actionId)
 
             val default = declared.getValue("\$default")
-            assertEquals("control alt shift G", default.getAttribute("first-keystroke"), actionId)
+            assertEquals("control alt shift Z", default.getAttribute("first-keystroke"), actionId)
             assertEquals(secondKey, default.getAttribute("second-keystroke"), actionId)
             assertEquals("", default.getAttribute("replace-all"), actionId)
 
             CopySelectionShortcuts.macKeymapIds.forEach { keymapId ->
                 val mac = declared.getValue(keymapId)
-                assertEquals("meta alt shift G", mac.getAttribute("first-keystroke"), "$keymapId / $actionId")
+                assertEquals("meta alt shift Z", mac.getAttribute("first-keystroke"), "$keymapId / $actionId")
                 assertEquals(secondKey, mac.getAttribute("second-keystroke"), "$keymapId / $actionId")
                 assertEquals("true", mac.getAttribute("replace-all"), "$keymapId / $actionId")
             }
@@ -131,6 +131,11 @@ class PluginDescriptorLocalizationTest {
         assertFalse(shortcutXml.any { it.getAttribute("second-keystroke").isEmpty() })
         assertFalse(shortcutXml.any { it.getAttribute("first-keystroke") in setOf("control alt C", "meta alt C") })
         assertFalse(shortcutXml.any { it.getAttribute("first-keystroke") == "control alt H" })
+        assertFalse(
+            shortcutXml.any {
+                it.getAttribute("first-keystroke") in setOf("control alt shift G", "meta alt shift G")
+            },
+        )
     }
 
     private fun descriptorPresentationKeys(properties: Properties): Set<String> =


### PR DESCRIPTION
The original G prefix conflicts with bundled actions in current IDEA/Rider keymaps. This changes the shared first stroke to `Ctrl+Alt+Shift+Z`, or `Cmd+Option+Shift+Z` for native macOS keymap lineages. Release the first combination before pressing the unchanged second key: C/H/A/O/F/R/P/B/L.

Only the shared prefix constants, descriptor defaults and their regression tests change. Action IDs, keymap ancestry rules and copy behavior stay intact. Inherited G defaults move to Z; explicitly persisted G assignments remain custom bindings. Existing custom, unassigned, mouse and removed external bindings retain their coverage.

Refs #128. Keep this PR in draft while the remaining candidate input and Rider checks are unresolved. The final integrated settings, introduction, documentation and upgrade matrix is tracked separately in #129–#132.

Validation for `837c5aaaee5188d07f1e9d4414b70cf891d8e0c1`:

- 440 unit tests and 96 platform tests passed, including six descriptor tests and six shortcut fixture tests; no skipped tests or duplicate fixture execution.
- Detekt, plugin project/structure validation, build and fresh Kover XML/HTML reports passed.
- Fresh Plugin Verifier results are Compatible for IC 243.21565.193, IDEA 262.10315.125 and Rider 262.9437.287.
- The rebuilt ZIP remains SHA-256 `0672868b8243fa8720550e073171afadc16fdd9ff3902202ff7a10ff883a932a`.
- Independent source review found no blocking findings. The diagnostic tool also passed its independent review, 55 Python tests and its own CI; that CI does not replace this candidate PR's CI.
- The retained five-product inventory recorded no Z occupancy on the modifier selected by the product's lineage rule. Opposite-modifier entries are preserved. Six products are user-excluded from runtime measurement.
- Isolated IC and IDEA Safe Mode trials independently confirmed 108 Z bindings each and bounded app-targeted command/clipboard observations. IDEA also exercised H/O/F with all editor tabs closed.

Still unverified: Rider candidate input and three hidden OS keymap families; final permalink URL under trusted test projects; Korean input, held modifiers and global OS interception; remaining IC observations and without-harness repetitions. These are not passing results. The real macOS matrix remains required, while Windows/Linux physical tests are user-excluded and three-OS automated CI remains required for final integration.

Manual continuation:

1. Use the exact candidate ZIP in an isolated profile and verify the active keymap and actual input source.
2. Release the full Z prefix before each plain second key, verify the expected clipboard and add-only behavior, and test H/O/F with all editors closed.
3. Exercise Escape, an invalid second key and delayed input, then verify normal typing resumes.
4. Use only the approved synthetic Git fixture for permalink verification; retain blocked or unexecuted rows until the required trust and operator evidence are available.
